### PR TITLE
Add flag to mark versions as in development

### DIFF
--- a/app/config/projects.yml
+++ b/app/config/projects.yml
@@ -24,6 +24,7 @@ parameters:
                     name: 'master'
                     branchName: 'master'
                     slug: 'latest'
+                    wip: true
                 -
                     name: '2.6'
                     branchName: '2.6'
@@ -61,6 +62,7 @@ parameters:
                     name: 'master'
                     branchName: 'master'
                     slug: 'latest'
+                    wip: true
                 -
                     name: '2.7'
                     branchName: '2.7'
@@ -97,6 +99,7 @@ parameters:
                     name: 'master'
                     branchName: 'master'
                     slug: 'latest'
+                    wip: true
                 -
                     name: '1.2'
                     branchName: '1.2.x'

--- a/app/src/Doctrine/Website/Projects/ProjectVersion.php
+++ b/app/src/Doctrine/Website/Projects/ProjectVersion.php
@@ -21,6 +21,9 @@ class ProjectVersion
     /** @var bool */
     private $maintained = true;
 
+    /** @var bool */
+    private $wip = false;
+
     /** @var array */
     private $aliases;
 
@@ -31,6 +34,7 @@ class ProjectVersion
         $this->slug       = (string) ($version['slug'] ?? '');
         $this->current    = (bool) ($version['current'] ?? false);
         $this->maintained = (bool) ($version['maintained'] ?? true);
+        $this->wip        = (bool) ($version['wip'] ?? false);
         $this->aliases    = $version['aliases'] ?? [];
     }
 
@@ -57,6 +61,11 @@ class ProjectVersion
     public function isMaintained() : bool
     {
         return $this->maintained;
+    }
+
+    public function isWip() : bool
+    {
+        return $this->wip;
     }
 
     public function getAliases() : array

--- a/source/_includes/project.html
+++ b/source/_includes/project.html
@@ -47,6 +47,10 @@
                             {% if not version.maintained %}
                                 (unmaintained)
                             {% endif %}
+
+                            {% if version.wip %}
+                                (in development)
+                            {% endif %}
                         </td>
                         <td><a href="{{ site.url }}/projects/{{ project.docsSlug }}/en/{{ version.slug ?? 'latest' }}/index.html">Docs</a></td>
                         <td><a href="{{ site.url }}/api/{{ project.slug }}/{{ version.slug ?? 'latest' }}/index.html">API Docs</a></td>

--- a/tests/Doctrine/Website/Tests/Projects/ProjectVersionTest.php
+++ b/tests/Doctrine/Website/Tests/Projects/ProjectVersionTest.php
@@ -19,6 +19,7 @@ class ProjectVersionTest extends TestCase
             'branchName' => '1.0',
             'slug' => '1.0',
             'current' => true,
+            'wip' => true,
         ]);
     }
 
@@ -28,5 +29,6 @@ class ProjectVersionTest extends TestCase
         $this->assertEquals('1.0', $this->projectVersion->getBranchName());
         $this->assertEquals('1.0', $this->projectVersion->getSlug());
         $this->assertTrue($this->projectVersion->isCurrent());
+        $this->assertTrue($this->projectVersion->isWip());
     }
 }


### PR DESCRIPTION
Primarily for ORM 3.0, DBAL 3.0 and ODM 2.0.
(I'll rename _"master"_ to their respective versions once this is in + add DBAL develop.)

![preview](https://user-images.githubusercontent.com/144181/39061802-d4ae46d8-44c5-11e8-8311-3c92c5d11102.png)
