### PR TITLE
fix link formatting

### DIFF
--- a/source/_posts/2017-12-21-orm-2-6-0-and-next.md
+++ b/source/_posts/2017-12-21-orm-2-6-0-and-next.md
@@ -6,9 +6,7 @@ authorEmail: mike@simonson.be
 categories: []
 permalink: /2017/12/21/orm-2-6-0-and-next.html
 ---
-We are happy to announce the immediate availability of Doctrine ORM 2.6
-\`2.6.0
-\<[https://github.com/doctrine/doctrine2/releases/tag/v2.6.0](https://github.com/doctrine/doctrine2/releases/tag/v2.6.0)\>\`.
+We are happy to announce the immediate availability of Doctrine ORM [2.6.0](https://github.com/doctrine/doctrine2/releases/tag/v2.6.0).
 
 ORM 2.6.0
 =========


### PR DESCRIPTION
 [This](https://www.doctrine-project.org/2017/12/21/orm-2-6-0-and-next.html) looks weird:

> We are happy to announce the immediate availability of Doctrine ORM 2.6 `2.6.0 \<https://github.com/doctrine/doctrine2/releases/tag/v2.6.0>`.