### PR TITLE
Fix number of fixes/improvements and period since last release

### DIFF
--- a/source/_posts/2018-07-12-common-2-9-and-dbal-2-8-and-orm-2-6-2.md
+++ b/source/_posts/2018-07-12-common-2-9-and-dbal-2-8-and-orm-2-6-2.md
@@ -43,7 +43,7 @@ For complete release notes,
 ### DBAL 2.8.0
 
 DBAL 2.8.0 is a minor release of Doctrine DBAL that aggregates over
-20 fixes and improvements developed over the last 2 months.
+30 fixes and improvements developed over the last 3 months.
 
 The dependency on `doctrine/common` is removed. DBAL now
 depends on `doctrine/cache` and `doctrine/event-manager` instead.


### PR DESCRIPTION
According to the release notes and tags of DBAL 2.8.0 it's more than 30 fixes/improvements instead of 20 in 3 months instead of 2.