### PR TITLE
Move search result container out of sticky area

### DIFF
--- a/source/_layouts/layout.html
+++ b/source/_layouts/layout.html
@@ -162,15 +162,15 @@
                         <!-- SearchBox widget will appear here -->
                     </div>
                 </div>
-
-                <div class="search-results rounded">
-                    <div id="hits">
-                        <!-- Hits widget will appear here -->
-                    </div>
-
-                    <a href="https://www.algolia.com" target="_blank"><img src="{{ site.url }}/images/search-by-algolia.png" class="float-right" style="width: 150px;" /></a>
-                </div>
             </nav>
+
+            <div class="search-results rounded">
+                <div id="hits">
+                    <!-- Hits widget will appear here -->
+                </div>
+
+                <a href="https://www.algolia.com" target="_blank"><img src="{{ site.url }}/images/search-by-algolia.png" class="float-right" style="width: 150px;" /></a>
+            </div>
         {% endblock %}
 
         {% block container %}

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -17,13 +17,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .search-results {
-    position: absolute;
-    top: 50px;
-    left: 20px;
-    right: 20px;
+    margin-left: 20px;
+    margin-right: 20px;
     background-color: #fff;
     padding: 20px;
-    z-index: 1000;
+    z-index: 1030;
     margin-top: 20px;
     border: 1px solid #ccc;
     display: none;


### PR DESCRIPTION
This is a fix for #190.

This PR also handles the search results for mobiles, because the sticky option for the results are not usable for screens, that can't hold all results in the visible area and won't scroll further when reached the sites end.