### PR TITLE
Explicitly set search box color to black

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -61,6 +61,8 @@ h1, h2, h3, h4, h5, h6 {
 .navbar input {
     height: 40px;
     margin-top: 2px;
+    color: black;
+    background-color: white;
 }
 
 .navbar a:hover {


### PR DESCRIPTION
Without this, the input has white text on white background with dark GTK+ theme (Gnome).

![](https://user-images.githubusercontent.com/144181/44469061-f12c9900-a626-11e8-92a8-0ff97e8c610d.png)
