### PR TITLE
Cut of back-link for target=blank links

### DIFF
--- a/source/community.html
+++ b/source/community.html
@@ -16,7 +16,7 @@ permalink: /community/index.html
 
     <p class="lead">
         The Doctrine community is made up of thousands of developers all around
-        the world. The project has had over <a href="https://github.com/doctrine/doctrine2/graphs/contributors" target="_blank">500 contributors</a> and is maintained by a <a href="/team/">core team</a> of developers. If you want to get involved, find other
+        the world. The project has had over <a href="https://github.com/doctrine/doctrine2/graphs/contributors" target="_blank" rel="noopener noreferrer">500 contributors</a> and is maintained by a <a href="/team/">core team</a> of developers. If you want to get involved, find other
         Doctrine developers on GitHub, Gitter Chat and the Mailing List.
     </p>
 
@@ -31,7 +31,7 @@ permalink: /community/index.html
                 contribute to Doctrine <a href="/contribute/">here</a>.
             </p>
 
-            <a href="https://github.com/doctrine/" class="btn btn-primary" target="_blank">Go to GitHub</a>
+            <a href="https://github.com/doctrine/" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Go to GitHub</a>
         </div>
     </div>
 
@@ -43,7 +43,7 @@ permalink: /community/index.html
                 You must have a GitHub account in order to use Gitter.
             </p>
 
-            <a href="https://gitter.im/doctrine/home" class="btn btn-primary" target="_blank">Go to Gitter</a>
+            <a href="https://gitter.im/doctrine/home" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Go to Gitter</a>
         </div>
     </div>
 
@@ -55,7 +55,7 @@ permalink: /community/index.html
                 to communicate with other Doctrine developers.
             </p>
 
-            <a href="http://groups.google.com/group/doctrine-user" class="btn btn-primary" target="_blank">Go to Mailing List</a>
+            <a href="http://groups.google.com/group/doctrine-user" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Go to Mailing List</a>
         </div>
     </div>
 
@@ -73,7 +73,7 @@ permalink: /community/index.html
                 Communicate with other Symfony developers that use Doctrine in the #doctrine slack channel in the Symfony Devs slack instance.
             </p>
 
-            <a href="https://symfony-devs.slack.com/messages/C3FQPE6LE/" class="btn btn-primary" target="_blank">Go to Slack</a>
+            <a href="https://symfony-devs.slack.com/messages/C3FQPE6LE/" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Go to Slack</a>
         </div>
     </div>
 
@@ -84,7 +84,7 @@ permalink: /community/index.html
                 Communicate with other Laravel developers that use Doctrine in the Laravel Doctrine slack instance.
             </p>
 
-            <a href="http://slack.laraveldoctrine.org/" class="btn btn-primary" target="_blank">Go to Slack</a>
+            <a href="http://slack.laraveldoctrine.org/" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Go to Slack</a>
         </div>
     </div>
 {% endblock %}

--- a/source/index.html
+++ b/source/index.html
@@ -15,7 +15,7 @@
                 <a class="btn bg-doctrine-dark-blue text-white btn-lg" href="{{ site.url }}/projects.html" role="button">View Projects</a>
 
                 <div class="btn btn-lg tidelift-badge">
-                    <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank"><img src="{{ get_asset_url('/images/tidelift-icon.png', site.url) }}" class="tidelift-icon" /> <span>Get professional support for Doctrine</span></a>
+                    <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank" rel="noopener noreferrer"><img src="{{ get_asset_url('/images/tidelift-icon.png', site.url) }}" class="tidelift-icon" /> <span>Get professional support for Doctrine</span></a>
                 </div>
             </p>
         </div>
@@ -67,7 +67,7 @@
                         <tr>
                             {% for doctrineUser in batch %}
                                 {% if doctrineUser.url is defined %}
-                                    <td><a href="{{ doctrineUser.url }}" target="_blank" class="mr-4">{{ doctrineUser.name }}</a></td>
+                                    <td><a href="{{ doctrineUser.url }}" target="_blank" rel="noopener noreferrer" class="mr-4">{{ doctrineUser.name }}</a></td>
                                 {% else %}
                                     <td><span class="font-italic">{{ doctrineUser|raw }}</span></a></td>
                                 {% endif %}
@@ -106,9 +106,9 @@
             <div class="card">
                 <h5 class="card-header">Get professional support for Doctrine ORM</h5>
                 <div class="card-body">
-                    Available as part of the <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank">Tidelift Subscription</a>. It includes support for Doctrine ORM and many of the other open source packages you depend on. Here’s how it provides the professional assurances you need.
+                    Available as part of the <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank" rel="noopener noreferrer">Tidelift Subscription</a>. It includes support for Doctrine ORM and many of the other open source packages you depend on. Here’s how it provides the professional assurances you need.
 
-                    <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank"><img src="{{ get_asset_url('/images/tidelift-logo.png', site.url) }}" class="w-100" /></a>
+                    <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank" rel="noopener noreferrer"><img src="{{ get_asset_url('/images/tidelift-logo.png', site.url) }}" class="w-100" /></a>
 
                     <ul>
                         <li><strong>Security:</strong> Timely notifications and help addressing vulnerabilities</li>

--- a/source/projects.html
+++ b/source/projects.html
@@ -1,7 +1,7 @@
 <h1>Projects</h1>
 
 <p class="lead">
-    Doctrine is a collection of projects built for <a href="https://php.net" target="_blank">PHP</a>. Each project can be used standalone and installed with <a href="https://getcomposer.org/" target="_blank">Composer</a>.
+    Doctrine is a collection of projects built for <a href="https://php.net" target="_blank" rel="noopener noreferrer">PHP</a>. Each project can be used standalone and installed with <a href="https://getcomposer.org/" target="_blank" rel="noopener noreferrer">Composer</a>.
 </p>
 
 <ul class="nav nav-tabs" id="projects" role="tablist">
@@ -31,7 +31,7 @@
 
     <div class="tab-pane" id="inactive-projects" role="tabpanel" aria-labelledby="inactive-projects-tab">
         <p class="lead">
-            These were once active and maintained projects. If you are interested in helping to maintain any Doctrine project take a look at the open issues on <a href="https://github.com/doctrine/" target="_blank">GitHub</a> and submit pull requests.
+            These were once active and maintained projects. If you are interested in helping to maintain any Doctrine project take a look at the open issues on <a href="https://github.com/doctrine/" target="_blank" rel="noopener noreferrer">GitHub</a> and submit pull requests.
         </p>
 
         {% include "projects-short-list.html.twig" with {projects:inactiveProjects} %}

--- a/templates/contributors-list.html.twig
+++ b/templates/contributors-list.html.twig
@@ -12,15 +12,15 @@
             {% if contributor.teamMember %}
                 <ul class="list-inline">
                     {% if contributor.teamMember.twitter %}
-                        <li class="list-inline-item" target="_blank"><a href="https://twitter.com/{{ contributor.teamMember.twitter }}/" target="_blank"><i class="fab fa-twitter mr-2"></i></a></li>
+                        <li class="list-inline-item"><a href="https://twitter.com/{{ contributor.teamMember.twitter }}/" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter mr-2"></i></a></li>
                     {% endif %}
 
                     {% if contributor.teamMember.website %}
-                        <li class="list-inline-item" target="_blank"><a href="{{ contributor.teamMember.website }}" target="_blank"><i class="fas fa-link mr-2"></i></a></li>
+                        <li class="list-inline-item"><a href="{{ contributor.teamMember.website }}" target="_blank" rel="noopener noreferrer"><i class="fas fa-link mr-2"></i></a></li>
                     {% endif %}
 
                     {% if contributor.teamMember.github %}
-                        <li class="list-inline-item" target="_blank"><a href="https://github.com/{{ contributor.teamMember.github }}/" target="_blank"><i class="fab fa-github mr-2"></i></a></li>
+                        <li class="list-inline-item"><a href="https://github.com/{{ contributor.teamMember.github }}/" target="_blank" rel="noopener noreferrer"><i class="fab fa-github mr-2"></i></a></li>
                     {% endif %}
                 </ul>
             {% endif %}

--- a/templates/layouts/documentation.html.twig
+++ b/templates/layouts/documentation.html.twig
@@ -74,7 +74,7 @@
                 {% if project.archived == true %}
                     {% set alertMessage = 'This project is no longer maintained and has been archived.' %}
                 {% elseif project.active == false %}
-                    {% set alertMessage = 'This project is not being actively maintained. If you are interested in helping to maintain this project, take a look at the open issues on <a href="https://github.com/doctrine/{{ project.repositoryName }}/" target="_blank">GitHub</a> and submit pull requests.' %}
+                    {% set alertMessage = 'This project is not being actively maintained. If you are interested in helping to maintain this project, take a look at the open issues on <a href="https://github.com/doctrine/{{ project.repositoryName }}/" target="_blank" rel="noopener noreferrer">GitHub</a> and submit pull requests.' %}
                 {% elseif project.getVersion(page.docsVersion).maintained == false %}
                     {% set alertMessage = 'You are browsing documentation for a version that is no longer maintained.' %}
                 {% elseif project.getVersion(page.docsVersion).upcoming == true %}

--- a/templates/layouts/layout.html.twig
+++ b/templates/layouts/layout.html.twig
@@ -175,7 +175,7 @@
                                 <a class="dropdown-item" href="{{ path('contribute_maintainer') }}">Maintainer Workflow</a>
                                 <a class="dropdown-item" href="{{ path('contribute_website') }}">Contribute to Website</a>
                                 <a class="dropdown-item" href="{{ path('policies') }}">Policies</a>
-                                <a class="dropdown-item" href="https://github.com/doctrine" target="_blank">GitHub</a>
+                                <a class="dropdown-item" href="https://github.com/doctrine" target="_blank" rel="noopener noreferrer">GitHub</a>
                             </div>
                         </li>
                         <li class="nav-item{% if menuSlug == 'community' %} active{% endif %}">
@@ -196,9 +196,9 @@
 
                     <div class="layout-edit-button d-inline-block mr-2">
                         {% if page.docsSlug is defined and page.docsSlug and project is defined and projectVersion is defined %}
-                            <a href="https://github.com/doctrine/{{ project.docsRepositoryName }}/edit/{{ projectVersion.branchName }}{{ project.docsPath }}{{ page.docsSourcePath }}" class="btn btn-light" target="_blank">Edit</a>
+                            <a href="https://github.com/doctrine/{{ project.docsRepositoryName }}/edit/{{ projectVersion.branchName }}{{ project.docsPath }}{{ page.docsSourcePath }}" class="btn btn-light" target="_blank" rel="noopener noreferrer">Edit</a>
                         {% else %}
-                            <a href="https://github.com/doctrine/doctrine-website/edit/master/source{{ page.sourcePath }}" class="btn btn-light" target="_blank">Edit</a>
+                            <a href="https://github.com/doctrine/doctrine-website/edit/master/source{{ page.sourcePath }}" class="btn btn-light" target="_blank" rel="noopener noreferrer">Edit</a>
                         {% endif %}
                     </div>
 
@@ -223,7 +223,7 @@
                     <!-- Hits widget will appear here -->
                 </div>
 
-                <a href="https://www.algolia.com" target="_blank"><img src="{{ site.url }}/images/search-by-algolia.png" class="float-right" style="width: 150px;" /></a>
+                <a href="https://www.algolia.com" target="_blank" rel="noopener noreferrer"><img src="{{ site.url }}/images/search-by-algolia.png" class="float-right" style="width: 150px;" /></a>
             </div>
         {% endblock %}
 

--- a/templates/layouts/project.html.twig
+++ b/templates/layouts/project.html.twig
@@ -18,7 +18,7 @@
         } %}
     {% elseif project.active == false %}
         {% include "alert.html.twig" with {
-            alertMessage: 'This project is not being actively maintained. If you are interested in helping to maintain this project, take a look at the open issues on <a href="https://github.com/doctrine/' ~ project.repositoryName ~ ' /" target="_blank">GitHub</a> and submit pull requests.'
+            alertMessage: 'This project is not being actively maintained. If you are interested in helping to maintain this project, take a look at the open issues on <a href="https://github.com/doctrine/' ~ project.repositoryName ~ ' /" target="_blank" rel="noopener noreferrer">GitHub</a> and submit pull requests.'
         } %}
     {% endif %}
 
@@ -30,7 +30,7 @@
 
     <a href="{{ site.url }}/api/{{ project.slug }}/{{ project.currentVersion.slug ?? 'latest' }}/index.html" class="btn btn-primary mr-2">API Docs</a>
 
-    <a href="https://github.com/doctrine/{{ project.repositoryName }}/" class="btn btn-primary" target="_blank">GitHub</a>
+    <a href="https://github.com/doctrine/{{ project.repositoryName }}/" class="btn btn-primary" target="_blank" rel="noopener noreferrer">GitHub</a>
 
     <hr />
 

--- a/templates/maintainers-list.html.twig
+++ b/templates/maintainers-list.html.twig
@@ -16,15 +16,15 @@
             {% if contributor.teamMember %}
                 <ul class="list-inline">
                     {% if contributor.teamMember.twitter %}
-                        <li class="list-inline-item" target="_blank"><a href="https://twitter.com/{{ contributor.teamMember.twitter }}/" target="_blank"><i class="fab fa-twitter mr-2"></i></a></li>
+                        <li class="list-inline-item"><a href="https://twitter.com/{{ contributor.teamMember.twitter }}/" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter mr-2"></i></a></li>
                     {% endif %}
 
                     {% if contributor.teamMember.website %}
-                        <li class="list-inline-item" target="_blank"><a href="{{ contributor.teamMember.website }}" target="_blank"><i class="fas fa-link mr-2"></i></a></li>
+                        <li class="list-inline-item"><a href="{{ contributor.teamMember.website }}" target="_blank" rel="noopener noreferrer"><i class="fas fa-link mr-2"></i></a></li>
                     {% endif %}
 
                     {% if contributor.teamMember.github %}
-                        <li class="list-inline-item" target="_blank"><a href="https://github.com/{{ contributor.teamMember.github }}/" target="_blank"><i class="fab fa-github mr-2"></i></a></li>
+                        <li class="list-inline-item"><a href="https://github.com/{{ contributor.teamMember.github }}/" target="_blank" rel="noopener noreferrer"><i class="fab fa-github mr-2"></i></a></li>
                     {% endif %}
                 </ul>
             {% endif %}

--- a/templates/projects-list.html.twig
+++ b/templates/projects-list.html.twig
@@ -15,7 +15,7 @@
                     <a href="{{ site.url }}/api/{{ project.slug }}/{{ project.currentVersion.slug ?? 'latest' }}/index.html" class="mr-2 text-white">API</a>
 
                     <i class="fab fa-github"></i>
-                    <a href="https://github.com/doctrine/{{ project.repositoryName }}" class="mr-2 text-white" target="_blank">GitHub</a>
+                    <a href="https://github.com/doctrine/{{ project.repositoryName }}" class="mr-2 text-white" target="_blank" rel="noopener noreferrer">GitHub</a>
                 </div>
             </div>
         </div>

--- a/templates/projects-short-list.html.twig
+++ b/templates/projects-short-list.html.twig
@@ -3,7 +3,7 @@
         <li class="list-group-item">
             <h5 class="card-title">
                 {% if project.isIntegration %}
-                    <a href="{{ project.projectIntegrationType.url }}" target="_blank"><img src="{{ project.projectIntegrationType.icon }}" title="{{ project.projectIntegrationType.name }}" width="30" class="mr-2" /></a>
+                    <a href="{{ project.projectIntegrationType.url }}" target="_blank" rel="noopener noreferrer"><img src="{{ project.projectIntegrationType.icon }}" title="{{ project.projectIntegrationType.name }}" width="30" class="mr-2" /></a>
                 {% endif %}
 
                 <a href="{{ site.url }}/projects/{{ project.slug }}.html">{{ project.name }}</a>
@@ -22,7 +22,7 @@
 
                 <li class="list-inline-item">
                     <i class="fab fa-github"></i>
-                    <a href="https://github.com/doctrine/{{ project.repositoryName }}" class="mr-2" target="_blank">GitHub</a>
+                    <a href="https://github.com/doctrine/{{ project.repositoryName }}" class="mr-2" target="_blank" rel="noopener noreferrer">GitHub</a>
                 </li>
             </ul>
         </li>

--- a/templates/team/member.html.twig
+++ b/templates/team/member.html.twig
@@ -11,15 +11,15 @@
 
         <ul class="list-inline">
             {% if contributor.teamMember and contributor.teamMember.twitter %}
-                <li class="list-inline-item" target="_blank"><a href="https://twitter.com/{{ contributor.teamMember.twitter }}/" target="_blank"><i class="fab fa-twitter mr-2"></i></a></li>
+                <li class="list-inline-item"><a href="https://twitter.com/{{ contributor.teamMember.twitter }}/" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter mr-2"></i></a></li>
             {% endif %}
 
             {% if contributor.teamMember and contributor.teamMember.website %}
-                <li class="list-inline-item" target="_blank"><a href="{{ contributor.teamMember.website }}" target="_blank"><i class="fas fa-link mr-2"></i></a></li>
+                <li class="list-inline-item"><a href="{{ contributor.teamMember.website }}" target="_blank" rel="noopener noreferrer"><i class="fas fa-link mr-2"></i></a></li>
             {% endif %}
 
             {% if contributor.github %}
-                <li class="list-inline-item" target="_blank"><a href="https://github.com/{{ contributor.github }}/" target="_blank"><i class="fab fa-github mr-2"></i></a></li>
+                <li class="list-inline-item"><a href="https://github.com/{{ contributor.github }}/" target="_blank" rel="noopener noreferrer"><i class="fab fa-github mr-2"></i></a></li>
             {% endif %}
         </ul>
 


### PR DESCRIPTION
I've added to all `target="blank"` links `rel="noopener noreferrer"` to fix attempts to use tabnapping. You can read more about it here:

https://www.owasp.org/index.php/Reverse_Tabnabbing
https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Tabnabbing

This should also be addressed in future reviews where `target="blank"` links were added.