### PR TITLE
Don't hit github api in test env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ jobs:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
       script:
-        - ./bin/console build-docs --sync-git
-        - ./bin/console build-website
+        - ./bin/console build-docs --sync-git --env=test
+        - ./bin/console build-website --env=test
         - ./vendor/bin/phpunit --coverage-clover clover.xml
       after_script:
         - wget https://scrutinizer-ci.com/ocular.phar

--- a/config/config_test.yml
+++ b/config/config_test.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config.yml }
+
+services:
+    Doctrine\Website\Github\GithubProjectContributors:
+        alias: Doctrine\Website\Github\TestGithubProjectContributors

--- a/config/services.xml
+++ b/config/services.xml
@@ -53,6 +53,8 @@
 
         <service id="Doctrine\StaticWebsiteGenerator\Twig\TwigRenderer" alias="Doctrine\StaticWebsiteGenerator\Twig\StringTwigRenderer" />
 
+        <service id="Doctrine\Website\Github\GithubProjectContributors" alias="Doctrine\Website\Github\ProdGithubProjectContributors" />
+
         <service id="Doctrine\Website\Application" autowire="true" public="true" />
 
         <service id="Doctrine\Website\Projects\ProjectDataRepository" autowire="true" />

--- a/config/services.xml
+++ b/config/services.xml
@@ -74,12 +74,18 @@
         </service>
 
         <service id="Doctrine\RST\HTML\Kernel" autowire="true" />
+
+        <service id="Doctrine\Website\Github\GithubClientProvider">
+            <argument type="service">
+                <service class="Github\Client" />
+            </argument>
+            <argument>%doctrine.website.github.http_token%</argument>
+        </service>
+
         <service id="Github\Client">
-            <call method="authenticate">
-                <argument>%doctrine.website.github.http_token%</argument>
-                <argument></argument>
-                <argument>http_token</argument>
-            </call>
+            <factory service="Doctrine\Website\Github\GithubClientProvider"
+                method="getGithubClient"
+            />
             <call method="addCache">
                 <argument type="service">
                     <service class="Cache\Adapter\Doctrine\DoctrineCachePool" autowire="false">
@@ -88,6 +94,7 @@
                 </argument>
             </call>
         </service>
+
         <service id="Highlight\Highlighter" autowire="true" />
         <service id="Parsedown" class="Parsedown" autowire="true" />
         <service id="Symfony\Component\Console\Application" autowire="true" />

--- a/lib/Github/GithubClientProvider.php
+++ b/lib/Github/GithubClientProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Github;
+
+use Github\Client;
+use InvalidArgumentException;
+
+class GithubClientProvider
+{
+    /** @var Client */
+    private $githubClient;
+
+    /** @var string */
+    private $githubHttpToken;
+
+    /** @var bool */
+    private $authenticated = false;
+
+    public function __construct(Client $githubClient, string $githubHttpToken)
+    {
+        if ($githubHttpToken === '') {
+            throw new InvalidArgumentException('You must configure a Github http token.');
+        }
+
+        $this->githubClient    = $githubClient;
+        $this->githubHttpToken = $githubHttpToken;
+    }
+
+    public function getGithubClient() : Client
+    {
+        if ($this->authenticated === false) {
+            $this->githubClient->authenticate($this->githubHttpToken, '', 'http_token');
+
+            $this->authenticated = true;
+        }
+
+        return $this->githubClient;
+    }
+}

--- a/lib/Github/GithubProjectContributors.php
+++ b/lib/Github/GithubProjectContributors.php
@@ -4,46 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Github;
 
-use Doctrine\Common\Cache\FilesystemCache;
 use Doctrine\Website\Model\Project;
-use Github\Api\Repo;
-use Github\Client;
-use function sprintf;
 
-class GithubProjectContributors
+interface GithubProjectContributors
 {
-    /** @var FilesystemCache */
-    private $filesystemCache;
-
-    /** @var Client */
-    private $githubClient;
-
-    public function __construct(
-        FilesystemCache $filesystemCache,
-        Client $githubClient
-    ) {
-        $this->filesystemCache = $filesystemCache;
-        $this->githubClient    = $githubClient;
-    }
-
     /**
      * @return mixed[]
      */
-    public function getProjectContributors(Project $project) : array
-    {
-        $id = sprintf('doctrine-%s-contributors-data', $project->getSlug());
-
-        if ($this->filesystemCache->contains($id)) {
-            return $this->filesystemCache->fetch($id);
-        }
-
-        /** @var Repo $repo */
-        $repo = $this->githubClient->api('repo');
-
-        $contributors = $repo->statistics('doctrine', $project->getRepositoryName());
-
-        $this->filesystemCache->save($id, $contributors, 86400);
-
-        return $contributors;
-    }
+    public function getProjectContributors(Project $project) : array;
 }

--- a/lib/Github/ProdGithubProjectContributors.php
+++ b/lib/Github/ProdGithubProjectContributors.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Github;
+
+use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\Website\Model\Project;
+use Github\Api\Repo;
+use Github\Client;
+use function sprintf;
+
+class ProdGithubProjectContributors implements GithubProjectContributors
+{
+    /** @var FilesystemCache */
+    private $filesystemCache;
+
+    /** @var Client */
+    private $githubClient;
+
+    public function __construct(
+        FilesystemCache $filesystemCache,
+        Client $githubClient
+    ) {
+        $this->filesystemCache = $filesystemCache;
+        $this->githubClient    = $githubClient;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getProjectContributors(Project $project) : array
+    {
+        $id = sprintf('doctrine-%s-contributors-data', $project->getSlug());
+
+        if ($this->filesystemCache->contains($id)) {
+            return $this->filesystemCache->fetch($id);
+        }
+
+        /** @var Repo $repo */
+        $repo = $this->githubClient->api('repo');
+
+        $contributors = $repo->statistics('doctrine', $project->getRepositoryName());
+
+        $this->filesystemCache->save($id, $contributors, 86400);
+
+        return $contributors;
+    }
+}

--- a/lib/Github/TestGithubProjectContributors.php
+++ b/lib/Github/TestGithubProjectContributors.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Github;
+
+use Doctrine\Website\Model\Project;
+use Doctrine\Website\Model\TeamMember;
+use Doctrine\Website\Repositories\TeamMemberRepository;
+
+class TestGithubProjectContributors implements GithubProjectContributors
+{
+    /** @var TeamMemberRepository */
+    private $teamMemberRepository;
+
+    public function __construct(TeamMemberRepository $teamMemberRepository)
+    {
+        $this->teamMemberRepository = $teamMemberRepository;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getProjectContributors(Project $project) : array
+    {
+        $projectContributors = [];
+
+        /** @var TeamMember[] $teamMembers */
+        $teamMembers = $this->teamMemberRepository->findAll();
+
+        foreach ($teamMembers as $teamMember) {
+            $projectContributors[] = [
+                'weeks' => [
+                    ['a' => 1, 'd' => 1],
+                    ['a' => 1, 'd' => 1],
+                ],
+                'total' => 2,
+                'author' => [
+                    'login' =>  $teamMember->getGithub(),
+                    'avatar_url' => $teamMember->getAvatarUrl(),
+                ],
+            ];
+        }
+
+        $contributors = [
+            [
+                'login' => 'fabpot',
+                'avatar_url' => 'https://avatars3.githubusercontent.com/u/47313?v=4',
+            ],
+            [
+                'login' => 'Seldaek',
+                'avatar_url' => 'https://avatars1.githubusercontent.com/u/183678?v=4',
+            ],
+            [
+                'login' => 'kriswallsmith',
+                'avatar_url' => 'https://avatars2.githubusercontent.com/u/33886?v=4',
+            ],
+        ];
+
+        foreach ($contributors as $contributor) {
+            $projectContributors[] = [
+                'weeks' => [
+                    ['a' => 1, 'd' => 1],
+                    ['a' => 1, 'd' => 1],
+                ],
+                'total' => 2,
+                'author' => [
+                    'login' =>  $contributor['login'],
+                    'avatar_url' => $contributor['avatar_url'],
+                ],
+            ];
+        }
+
+        return $projectContributors;
+    }
+}

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -20,15 +20,15 @@ class FunctionalTest extends TestCase
     /** @var string */
     private $rootDir;
 
-    /** @var string */
+    /** @var string|null */
     private $buildDir;
 
     protected function setUp() : void
     {
         $this->rootDir  = __DIR__ . '/..';
-        $this->buildDir = $this->rootDir . '/build-dev';
+        $this->buildDir = $this->getBuildDir();
 
-        if (is_dir($this->buildDir)) {
+        if ($this->buildDir !== null) {
             return;
         }
 
@@ -289,5 +289,23 @@ class FunctionalTest extends TestCase
         self::assertCount(1, $crawler->filter('body'), sprintf('%s has a body', $path));
 
         return $crawler;
+    }
+
+    private function getBuildDir() : ?string
+    {
+        $foldersToCheck = [
+            'build-test',
+            'build-dev',
+        ];
+
+        foreach ($foldersToCheck as $foldersToCheck) {
+            $path = $this->rootDir . '/' . $foldersToCheck;
+
+            if (is_dir($path)) {
+                return $path;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Github/GithubClientProviderTest.php
+++ b/tests/Github/GithubClientProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Tests\Github;
+
+use Doctrine\Website\Github\GithubClientProvider;
+use Doctrine\Website\Tests\TestCase;
+use Github\Client;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class GithubClientProviderTest extends TestCase
+{
+    /** @var Client|MockObject */
+    private $githubClient;
+
+    /** @var string */
+    private $githubHttpToken;
+
+    /** @var GithubClientProvider */
+    private $githubClientProvider;
+
+    public function testGetGithubClient() : void
+    {
+        $this->githubClient->expects(self::exactly(1))
+            ->method('authenticate')
+            ->with($this->githubHttpToken, '', 'http_token');
+
+        $githubClient = $this->githubClientProvider->getGithubClient();
+
+        self::assertSame($this->githubClient, $githubClient);
+
+        $githubClient = $this->githubClientProvider->getGithubClient();
+
+        self::assertSame($this->githubClient, $githubClient);
+    }
+
+    protected function setUp() : void
+    {
+        $this->githubClient    = $this->createMock(Client::class);
+        $this->githubHttpToken = '1234';
+
+        $this->githubClientProvider = new GithubClientProvider($this->githubClient, $this->githubHttpToken);
+    }
+}

--- a/tests/Github/ProdGithubProjectContributorsTest.php
+++ b/tests/Github/ProdGithubProjectContributorsTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\Website\Tests\Github;
 
 use Doctrine\Common\Cache\FilesystemCache;
-use Doctrine\Website\Github\GithubProjectContributors;
+use Doctrine\Website\Github\ProdGithubProjectContributors;
 use Doctrine\Website\Model\Project;
 use Github\Api\Repo;
 use Github\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class GithubProjectContributorsTest extends TestCase
+class ProdGithubProjectContributorsTest extends TestCase
 {
     /** @var FilesystemCache|MockObject */
     private $filesystemCache;
@@ -20,7 +20,7 @@ class GithubProjectContributorsTest extends TestCase
     /** @var Client|MockObject */
     private $githubClient;
 
-    /** @var GithubProjectContributors */
+    /** @var ProdGithubProjectContributors */
     private $githubProjectContributors;
 
     protected function setUp() : void
@@ -28,7 +28,7 @@ class GithubProjectContributorsTest extends TestCase
         $this->filesystemCache = $this->createMock(FilesystemCache::class);
         $this->githubClient    = $this->createMock(Client::class);
 
-        $this->githubProjectContributors = new GithubProjectContributors(
+        $this->githubProjectContributors = new ProdGithubProjectContributors(
             $this->filesystemCache,
             $this->githubClient
         );


### PR DESCRIPTION
We are getting throttled by the github api when travis tests run so this change allows us to not need to hit the github api in the test env.