### PR TITLE
Default project version branchName and slug to name when it is not present

### DIFF
--- a/lib/Model/ProjectVersion.php
+++ b/lib/Model/ProjectVersion.php
@@ -53,8 +53,8 @@ class ProjectVersion
     public function __construct(array $version)
     {
         $this->name       = (string) ($version['name'] ?? '');
-        $this->branchName = (string) ($version['branchName'] ?? '');
-        $this->slug       = (string) ($version['slug'] ?? '');
+        $this->branchName = (string) ($version['branchName'] ?? $this->name);
+        $this->slug       = (string) ($version['slug'] ?? $this->name);
         $this->current    = (bool) ($version['current'] ?? false);
         $this->maintained = (bool) ($version['maintained'] ?? true);
         $this->upcoming   = (bool) ($version['upcoming'] ?? false);

--- a/tests/Projects/ProjectVersionTest.php
+++ b/tests/Projects/ProjectVersionTest.php
@@ -27,10 +27,45 @@ class ProjectVersionTest extends TestCase
     public function testGetName() : void
     {
         self::assertSame('1.0', $this->projectVersion->getName());
+    }
+
+    public function testGetBranchName() : void
+    {
         self::assertSame('1.0', $this->projectVersion->getBranchName());
+    }
+
+    public function testGetSlug() : void
+    {
         self::assertSame('1.0', $this->projectVersion->getSlug());
+    }
+
+    public function testIsCurrent() : void
+    {
         self::assertTrue($this->projectVersion->isCurrent());
+    }
+
+    public function testIsUpcoming() : void
+    {
         self::assertTrue($this->projectVersion->isUpcoming());
+    }
+
+    public function testGetAliases() : void
+    {
         self::assertSame(['alias', 'current', 'stable'], $this->projectVersion->getAliases());
+    }
+
+    public function testDefaults() : void
+    {
+        $projectVersion = new ProjectVersion(['name' => '1.0']);
+
+        self::assertSame('1.0', $projectVersion->getName());
+        self::assertSame('1.0', $projectVersion->getBranchName());
+        self::assertSame('1.0', $projectVersion->getSlug());
+        self::assertFalse($projectVersion->isCurrent());
+        self::assertFalse($projectVersion->isUpcoming());
+        self::assertTrue($projectVersion->hasDocs());
+        self::assertEmpty($projectVersion->getTags());
+        self::assertEmpty($projectVersion->getDocsLanguages());
+        self::assertEmpty($projectVersion->getAliases());
     }
 }


### PR DESCRIPTION
I am going through the projects and updating the .doctrine-project.json and wanted to set these defaults in code so I can reduce the amount of data that has to be manually configured in .doctrine-project.json