### PR TITLE
remove dead links

### DIFF
--- a/source/blog/2008-10-19-the-bleeding-edge-website-upgraded.md
+++ b/source/blog/2008-10-19-the-bleeding-edge-website-upgraded.md
@@ -10,13 +10,13 @@ awesomeness that is [symfony](http://www.symfony-project.com) 1.2. I
 upgraded the Doctrine website to 1.2 as well as Doctrine 1.1. I had
 several schema changes that I migrated to production with the new
 [Migrations
-features](http://www.doctrine-project.org/blog/new-to-migrations-in-1-1)
+features](https://www.doctrine-project.org/2008/10/18/new-to-migrations-in-1-1.html)
 that were mentioned previously on the blog. It made the upgrade of the
 website much easier. The primary motivation for diving in to this was a
 blog post made on
-[10/18/2008](http://www.symfony-project.org/blog/2008/10/18/spice-up-your-forms-with-some-nice-widgets-and-validators)
+[10/18/2008](https://symfony.com/blog/spice-up-your-forms-with-some-nice-widgets-and-validators)
 and
-[10/14/2008](http://www.symfony-project.org/blog/2008/10/14/new-in-symfony-1-2-make-your-choice)
+[10/14/2008](https://symfony.com/blog/new-in-symfony-1-2-make-your-choice)
 where Fabien talks about forms in symfony 1.2.
 
 Below is an overview of some of the changes made.

--- a/source/blog/2008-10-26-symfony-doctrine-schema-manager.md
+++ b/source/blog/2008-10-26-symfony-doctrine-schema-manager.md
@@ -15,9 +15,9 @@ Something I've always thought would be fun to build and has been one of
 the most requested items by users is a nice web based interface for
 managing your schema and generate your models from it. With the [new
 form
-framework](http://www.symfony-project.org/blog/2008/10/18/spice-up-your-forms-with-some-nice-widgets-and-validators)
+framework](https://symfony.com/blog/spice-up-your-forms-with-some-nice-widgets-and-validators)
 as of [symfony
-1.1](http://www.symfony-project.org/blog/2008/06/30/the-wait-is-over-symfony-1-1-released)
+1.1](https://symfony.com/blog/the-wait-is-over-symfony-1-1-released)
 , you can build rich forms with a nice OOP interface. This made it
 extremely easy to make the schema manager feature of the
 [sfDoctrineManagerPlugin](http://www.symfony-project.com/plugins/sfDoctrineManagerPlugin).

--- a/source/blog/2008-12-03-first-1-1-alpha-version-released.md
+++ b/source/blog/2008-12-03-first-1-1-alpha-version-released.md
@@ -12,11 +12,11 @@ cycles before releasing the stable version.
 
 This new version is sporting dozens of enhancements and even more bug
 fixes. Primarily the [new scalar hydration
-type](http://www.doctrine-project.org/blog/new-hydration-modes-for-doctrine-1-1)
+type](https://www.doctrine-project.org/2008/10/12/new-hydration-modes-for-doctrine-1-1.html)
 , [the migration diff
-tool](http://www.doctrine-project.org/blog/new-to-migrations-in-1-1) ,
+tool](https://www.doctrine-project.org/2008/10/18/new-to-migrations-in-1-1.html) ,
 and other [miscellaneous new
-features](http://www.doctrine-project.org/blog/doctrine-1-1-development-begins).
+features](https://www.doctrine-project.org/2008/10/02/doctrine-1-1-development-begins.html).
 
 You can download the package
 [here](http://www.doctrine-project.org/download) and read some

--- a/source/blog/2009-03-03-doctrine-1-1-documentation.md
+++ b/source/blog/2009-03-03-doctrine-1-1-documentation.md
@@ -7,7 +7,7 @@ permalink: /2009/03/03/doctrine-1-1-documentation.html
 ---
 Today I have begun updating the documentation to reflect the changes
 made in 1.1 and [The Guide to Doctrine for
-PHP](http://www.doctrine-project.org/documentation/manual/1_1/en) is now
+PHP](https://www.doctrine-project.org/projects/doctrine1/en/latest/) is now
 available. We still have some more changes to make but most things have
 been updated and added.
 

--- a/source/blog/2009-05-29-doctrine-lazy-loading.md
+++ b/source/blog/2009-05-29-doctrine-lazy-loading.md
@@ -109,10 +109,10 @@ How?
 
 If you need help with keeping track of how many queries you have per
 page, frameworks like
-[Symfony](http://www.symfony-project.org/book/1_0/16-Application-Management-Tools#chapter_16_sub_web_debug_toolbar)
+[Symfony](https://symfony.com/legacy/doc/gentle-introduction/1_4/en/16-Application-Management-Tools#chapter_16_sub_web_debug_toolbar)
 and [Zend Framework](http://framework.zend.com) give you debug tools to
 show you how many queries you have per page. Or of course you can always
 use the
-[Profiling](http://www.doctrine-project.org/documentation/manual/1_1/en/component-overview:profiler)
+[Profiling](https://www.doctrine-project.org/projects/doctrine1/en/latest/manual/component-overview.html#profiler)
 tool built in to Doctrine to log the queries in your application and
 keep track of it that way.

--- a/source/blog/2009-06-24-thank-you-servergrove.md
+++ b/source/blog/2009-06-24-thank-you-servergrove.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2009/06/24/thank-you-servergrove.html
 ---
 As you all may know, we recently
-[moved](http://www.doctrine-project.org/blog/doctrine-changing-homes)
+[moved](https://www.doctrine-project.org/2009/06/16/doctrine-changing-homes.html)
 the Doctrine infrastructure to a brand new home. This is all thanks to
 [ServerGrove](http://www.servergrove.net/). I contacted them a few
 months ago about potentially sponsoring us and they did not hesitate one

--- a/source/blog/2009-08-07-doctrine2-batch-processing.md
+++ b/source/blog/2009-08-07-doctrine2-batch-processing.md
@@ -198,7 +198,7 @@ Good stuff!
 More information on bulk operations with Doctrine 2 can be found in the
 (very new) online manual that is still a work in progress:
 
-http://www.doctrine-project.org/documentation/manual/2\_0/en/batch-processing
+https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/batch-processing.html#batch-processing
 
 UPDATE
 ======

--- a/source/blog/2009-08-15-doctrine2-native-queries.md
+++ b/source/blog/2009-08-15-doctrine2-native-queries.md
@@ -61,4 +61,4 @@ More on NativeQuery and ResultSetMapping can be found in the new
 documentation under:
 
 [Documentation - Native
-Sql](http://www.doctrine-project.org/documentation/manual/2_0/en/native-sql)
+Sql](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/native-sql.html#native-sql)

--- a/source/blog/2009-09-01-doctrine2-preview-release.md
+++ b/source/blog/2009-09-01-doctrine2-preview-release.md
@@ -61,7 +61,7 @@ Documentation
 =============
 
 The documentation for Doctrine 2 can be found
-[here](http://www.doctrine-project.org/documentation/2_0/en). Please be
+[here](https://www.doctrine-project.org/projects/doctrine-orm/en/current/). Please be
 aware that the documentation is still a work in progress and not all
 areas have been completed.
 
@@ -69,7 +69,7 @@ Sandbox
 =======
 
 To get started quickly, please check out our [sandbox quickstart
-tutorial](http://www.doctrine-project.org/documentation/manual/2_0/en/introduction#sandbox-quickstart).
+tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/current/tutorials/getting-started.html).
 You can also obtain Doctrine 2.0.0 ALPHA1 via a PEAR package like normal
 which can be found on the
 [download](http://www.doctrine-project.org/download)

--- a/source/blog/2009-10-07-doctrine-2-documentation.md
+++ b/source/blog/2009-10-07-doctrine-2-documentation.md
@@ -17,25 +17,25 @@ started, code examples, best practices, etc.
 
 The Guide to Doctrine for PHP starts off with the following chapters...
 
--   [Introduction](http://www.doctrine-project.org/documentation/manual/2_0/en/introduction)
--   [Architecture](http://www.doctrine-project.org/documentation/manual/2_0/en/architecture)
--   [Configuration](http://www.doctrine-project.org/documentation/manual/2_0/en/configuration)
+-   [Introduction](https://www.doctrine-project.org/projects/doctrine-orm/en/current/tutorials/getting-started.html)
+-   [Architecture](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/architecture.html)
+-   [Configuration](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/configuration.html)
 -   [Basic
-    Mapping](http://www.doctrine-project.org/documentation/manual/2_0/en/basic-mapping)
+    Mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/basic-mapping.html)
 -   [...and
-    more](http://www.doctrine-project.org/documentation/manual/2_0/en)
+    more](https://www.doctrine-project.org/projects/doctrine-orm/en/current/)
 
 The following chapters have been completed and updated recently...
 
--   [Events](http://www.doctrine-project.org/documentation/manual/2_0/en/events)
--   [Tools](http://www.doctrine-project.org/documentation/manual/2_0/en/tools)
+-   [Events](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/events.html)
+-   [Tools](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/tools.html)
 
 We also have a cookbook with a few articles already too...
 
 -   [Implementing ArrayAccess for domain
-    objects](http://www.doctrine-project.org/documentation/cookbook/2_0/en/implementing-arrayaccess-for-domain-objects)
+    objects](https://www.doctrine-project.org/projects/doctrine-orm/en/current/cookbook/implementing-arrayaccess-for-domain-objects.html)
 -   [Implementing the NOTIFY changetracking
-    policy](http://www.doctrine-project.org/documentation/cookbook/2_0/en/implementing-the-notify-changetracking-policy)
+    policy](https://www.doctrine-project.org/projects/doctrine-orm/en/current/cookbook/implementing-the-notify-changetracking-policy.html)
 
 We hope this helps you a little bit with getting started using Doctrine
 2 and that you enjoy it! :)

--- a/source/blog/2009-11-04-doctrine-1-2-documentation-available.md
+++ b/source/blog/2009-11-04-doctrine-1-2-documentation-available.md
@@ -15,8 +15,8 @@ New Chapters
 ============
 
 -   [Data
-    Hydrators](http://www.doctrine-project.org/documentation/manual/1_2/en/data-hydrators)
--   [Extensions](http://www.doctrine-project.org/documentation/manual/1_2/en/extensions)
+    Hydrators](https://www.doctrine-project.org/projects/doctrine1/en/latest/manual/data-hydrators.html)
+-   [Extensions](https://www.doctrine-project.org/projects/doctrine1/en/latest/manual/extensions.html)
 
 Please read over it and create
 [Jira](http://www.doctrine-project.org/jira) issues for any problems or

--- a/source/blog/2010-02-17-doctrine2-behaviours-nutshell.md
+++ b/source/blog/2010-02-17-doctrine2-behaviours-nutshell.md
@@ -225,7 +225,7 @@ $em->merge($searchedBlogPosts[0]);
 
 Read about Merging, Detached instances and other cool stuff of Doctrines
 object model in the [Working with
-Objects](http://www.doctrine-project.org/documentation/manual/2_0/en/working-with-objects#merging-entities)
+Objects](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/working-with-objects.html#merging-entities)
 chapter of the manual.
 
 Versionable

--- a/source/blog/2010-02-24-doctrine2-versionable.md
+++ b/source/blog/2010-02-24-doctrine2-versionable.md
@@ -109,7 +109,7 @@ class ResourceVersion
 Now we need to solve the problem of generating the `ResourceVersion`
 whenever an `Versionable` entity is persisted or updated. This can be
 done by using the [Doctrine EventManager
-API](http://www.doctrine-project.org/documentation/manual/2_0/en/events).
+API](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/events.html).
 We will implement the `EventSubscriber` interface and hook into the
 "onFlush" event.
 

--- a/source/blog/2010-03-13-doctrine2-validations.md
+++ b/source/blog/2010-03-13-doctrine2-validations.md
@@ -133,7 +133,7 @@ extension, which requires another type of event called "onFlush".
 Also read:
 
 -   [Doctrine 2 Manual:
-    Events](http://www.doctrine-project.org/documentation/manual/2_0/en/events#lifecycle-events)
+    Events](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/events.html#lifecycle-events)
 -   [Doctrine 2 Blog: A reusable Versionable
-    Behaviour](http://www.doctrine-project.org/blog/doctrine2-versionable)
+    Behaviour](https://www.doctrine-project.org/2010/02/24/doctrine2-versionable.html)
 

--- a/source/blog/2010-03-17-doctrine-performance-revisited.md
+++ b/source/blog/2010-03-17-doctrine-performance-revisited.md
@@ -10,7 +10,7 @@ performant ORM experience we are often confronted with benchmarks and
 have been talking about performance topics since last year in several
 talks at many different conferences, and Roman has [talked about his
 opinion on such benchmarks on this
-blog](http://www.doctrine-project.org/blog/php-benchmarking-mythbusters).
+blog](https://www.doctrine-project.org/2009/11/18/php-benchmarking-mythbusters.html).
 
 Recently Francois Zaninotto, lead developer of the soon to be released
 Propel 1.5 (currently in beta) [wrote a blog

--- a/source/blog/2010-03-21-doctrine-2-give-me-my-constructor-back.md
+++ b/source/blog/2010-03-21-doctrine-2-give-me-my-constructor-back.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2010/03/21/doctrine-2-give-me-my-constructor-back.html
 ---
 At [ConFoo
-2010](http://www.doctrine-project.org/blog/doctrine-2-at-confoo-2010)
+2010](https://www.doctrine-project.org/2010/03/15/doctrine-2-at-confoo-2010.html)
 during my presentation, someone asked about the constructor of entities
 in Doctrine 2 and whether or not it could be used. I think this is
 something worth writing about since in Doctrine 1 this was not possible.

--- a/source/blog/2010-06-15-doctrine2-beta2-released.md
+++ b/source/blog/2010-06-15-doctrine2-beta2-released.md
@@ -7,7 +7,7 @@ permalink: /2010/06/15/doctrine2-beta2-released.html
 ---
 Today we are happy to announce the immediate availability of the second
 beta version of Doctrine2. This is the first release after the
-[split](http://www.doctrine-project.org/blog/bringing-it-all-together)
+[split](https://www.doctrine-project.org/2010/05/27/bringing-it-all-together.html)
 of Doctrine2 into three independent projects, Common, DBAL and ORM. This
 change took longer than we expected but we are back to our SVN
 productivity now and strive to surpass it utilizing Git.
@@ -21,7 +21,7 @@ Common
 
 -   Added ClassLoader\#classExists as well as
     ClassLoader\#getClassLoader methods
-    [DCOM-7](http://www.doctrine-project.org/jira/browse/DCOM-7)
+    [DCOM-7](https://github.com/doctrine/common/issues/669)
 -   Changes to Annotation Parser with regards to Autoloading Annotation
     Classes
 
@@ -29,21 +29,21 @@ DBAL
 ====
 
 -   New Driver support for Microsoft PDO Sqlsrv Extension
-    [DBAL-10](http://www.doctrine-project.org/jira/browse/DBAL-10)
+    [DBAL-10](https://github.com/doctrine/dbal/issues/927)
 -   Fixed Mssql/Sqlsrv Platforms and SchemaManager
-    [DBAL-8](http://www.doctrine-project.org/jira/browse/DBAL-8)
+    [DBAL-8](https://github.com/doctrine/dbal/issues/2031)
 -   New Driver and Platform Support for DB2 (PDO\_DB2 and IBM\_DB2
     Extensions)
-    [DDC-494](http://www.doctrine-project.org/jira/browse/DDC-494)
+    [DDC-494](https://github.com/doctrine/orm/issues/4999)
 
 ORM
 ===
 
 -   Basic Pessimistic Locking support using FOR UPDATE or vendor
     specific shared locks
-    [DDC-178](http://www.doctrine-project.org/jira/browse/DDC-178)
+    [DDC-178](https://github.com/doctrine/orm/issues/2432)
 -   Added a Validate Mapping CLI Task
-    [DDC-515](http://www.doctrine-project.org/jira/browse/DDC-515)
+    [DDC-515](https://github.com/doctrine/orm/issues/5023)
 
 Download
 --------

--- a/source/blog/2010-07-12-doctrine2-large-collections.md
+++ b/source/blog/2010-07-12-doctrine2-large-collections.md
@@ -86,7 +86,7 @@ As you can see this is very simple to use, but also missing some bits:
     basis, which would eliminate possible max memory problems compared
     to the complete hydration of a collection.
 -   Methods link()/unlink() like described in
-    [DDC-128](http://www.doctrine-project.org/jira/browse/DDC-128)
+    [DDC-128](https://github.com/doctrine/orm/issues/1892)
 
 I hope I got your attention and maybe someone has an interest in
 extending the LargeCollection a little bit more.

--- a/source/blog/2010-07-27-dbal2-beta3-released.md
+++ b/source/blog/2010-07-27-dbal2-beta3-released.md
@@ -11,12 +11,12 @@ released Doctrine DBAL 2.0.0BETA3 today. Noteworthy changes include:
 -   BC Break: Changed behaviour of Postgres and Oracle DateTime now
     without Timezone (TIMESTAMP WITHOUT TIME ZONE instead of TIMESTAMP
     WITH TIME ZONE) See [Ticket
-    DBAL-22](http://www.doctrine-project.org/jira/browse/DBAL-22) for
+    DBAL-22](https://github.com/doctrine/dbal/issues/1394) for
     more details aswell as migration issues for PostgreSQL and Oracle.
     This will be re-announced for the ORM Beta 3 release, which is
     affected from this change.
 -   SQL Loggers can now log execution times of queries
-    [DBAL-11](http://www.doctrine-project.org/jira/browse/DBAL-11)
+    [DBAL-11](https://github.com/doctrine/dbal/issues/1037)
 -   Several Issue with AutoIncrement Detection in Doctrine
 
 A total of 13 issues on DBAL has been fixed.

--- a/source/blog/2010-07-27-document-oriented-databases-vs-relational-databases.md
+++ b/source/blog/2010-07-27-document-oriented-databases-vs-relational-databases.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2010/07/27/document-oriented-databases-vs-relational-databases.html
 ---
 [My last
-post](http://www.doctrine-project.org/blog/mongodb-for-ecommerce)
+post](https://www.doctrine-project.org/2010/07/22/mongodb-for-ecommerce.html)
 brought up a lot of questions on the differences between
 document-oriented and relational databases, possible use cases for each
 and approaches and gotchas one should remember when dealing with either.

--- a/source/blog/2010-07-30-doctrine-mongodb-odm-1-0-0alpha2-released.md
+++ b/source/blog/2010-07-30-doctrine-mongodb-odm-1-0-0alpha2-released.md
@@ -10,7 +10,7 @@ Doctrine MongoDB Object Document Mapper (ODM). The release contains
 several bug fixes and a few enhancements. You now have the ability to
 mix types of documents in references and embedded documents. You can
 read the [blog
-post](http://www.doctrine-project.org/blog/mixing-types-of-documents)
+post](https://www.doctrine-project.org/2010/07/20/mixing-types-of-documents.html)
 about mixing types of documents to learn more.
 
 <h2>

--- a/source/blog/2010-08-07-dc2-experimental-associations-id-fields.md
+++ b/source/blog/2010-08-07-dc2-experimental-associations-id-fields.md
@@ -21,7 +21,7 @@ be required to add another column `id` on the article\_translations
 table and enforce a unique constraint on article\_id + language.
 
 Under the umbrella of
-[DDC-117](http://www.doctrine-project.org/jira/browse/DDC-117) and some
+[DDC-117](https://github.com/doctrine/orm/issues/1772) and some
 related tickets there were discussions about adding a feature that would
 help solve this problem: Allowing to add @Id to @ManyToOne or @OneToOne
 mappings. I committed this feature into an experimental Git branch today

--- a/source/blog/2011-01-13-roadmap-doctrine2.md
+++ b/source/blog/2011-01-13-roadmap-doctrine2.md
@@ -29,7 +29,7 @@ You can already start testing 2.1 development with two new features as
 of last week:
 
 -   [Foreign Keys as Primary
-    Keys](http://www.doctrine-project.org/jira/browse/DDC-117)
+    Keys](https://github.com/doctrine/orm/issues/1772)
 -   [Extra Lazy
-    Collections](http://www.doctrine-project.org/jira/browse/DDC-546)
+    Collections](https://github.com/doctrine/orm/issues/5053)
 

--- a/source/blog/2011-09-25-doctrine-maintenance-sep2011.md
+++ b/source/blog/2011-09-25-doctrine-maintenance-sep2011.md
@@ -17,6 +17,6 @@ ORM 2.1.2.
 
 A total of 20 bugs have been fixed in all 3 components. The DBAL release
 contains a security fix for the Oracle driver fixing [a possible SQL
-injection issue](http://www.doctrine-project.org/jira/browse/DBAL-164).
+injection issue](https://github.com/doctrine/dbal/issues/1321).
 If you are using Oracle please update immediately. This security fix was
 backported to 2.0 and a new 2.0.9 version was released.

--- a/source/blog/2012-08-29-doctrine-2-3-rc2.md
+++ b/source/blog/2012-08-29-doctrine-2-3-rc2.md
@@ -19,7 +19,7 @@ for details:
 -   [DBAL](https://github.com/doctrine/dbal/blob/master/UPGRADE)
 
 See the [2.3 Beta blog
-post](http://www.doctrine-project.org/blog/doctrine-2-3-beta.html) for
+post](https://www.doctrine-project.org/2012/07/16/doctrine-2-3-beta.html) for
 some information about changes in 2.3.
 
 You can install the release candidate through

--- a/source/blog/2012-09-05-doctrine-2-3-rc3.md
+++ b/source/blog/2012-09-05-doctrine-2-3-rc3.md
@@ -19,7 +19,7 @@ for details:
 -   [DBAL](https://github.com/doctrine/dbal/blob/master/UPGRADE)
 
 See the [2.3 Beta blog
-post](http://www.doctrine-project.org/blog/doctrine-2-3-beta.html) for
+post](https://www.doctrine-project.org/2012/07/16/doctrine-2-3-beta.html) for
 some information about changes in 2.3.
 
 You can install the release candidate through

--- a/source/blog/2012-09-17-doctrine-2-3-rc4.md
+++ b/source/blog/2012-09-17-doctrine-2-3-rc4.md
@@ -19,7 +19,7 @@ for details:
 -   [DBAL](https://github.com/doctrine/dbal/blob/master/UPGRADE)
 
 See the [2.3 Beta blog
-post](http://www.doctrine-project.org/blog/doctrine-2-3-beta.html) for
+post](https://www.doctrine-project.org/2012/07/16/doctrine-2-3-beta.html) for
 some information about changes in 2.3.
 
 You can install the release candidate through

--- a/source/blog/2014-01-01-dbal-242-252beta1.md
+++ b/source/blog/2014-01-01-dbal-242-252beta1.md
@@ -24,7 +24,7 @@ version using Composer and the following `composer.json` contents:
 You can see all the changes on Jira:
 
 -   [DBAL
-    2.4.2](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10620)
+    2.4.2](https://github.com/doctrine/dbal/releases/tag/v2.4.2)
 
 In the first 10 month of 2013 we watched the number of open issues cross
 100 and peak at 250 in mid November, unable to do much about it due to

--- a/source/blog/2014-09-11-orm-244.md
+++ b/source/blog/2014-09-11-orm-244.md
@@ -7,7 +7,7 @@ permalink: /2014/09/11/orm-244.html
 ---
 We are happy to announce the immediate availability of Doctrine ORM
 2.4.4, which fixes a minor regression introduced by
-[DDC-2996](http://www.doctrine-project.org/jira/browse/DDC-2996).
+[DDC-2996](https://github.com/doctrine/orm/issues/3760).
 
 You can find all the changes on JIRA:
 

--- a/source/blog/2014-10-06-orm-246.md
+++ b/source/blog/2014-10-06-orm-246.md
@@ -11,7 +11,7 @@ We are happy to announce the immediate availability of Doctrine ORM
 We fixed a PHP 5.6 compatibility issue which prevented usage of entities
 extending from internal PHP classes or implementing the `Serializable`
 interface with the ORM:
-[DDC-3120](http://www.doctrine-project.org/jira/browse/DDC-3120).
+[DDC-3120](https://github.com/doctrine/orm/issues/3897).
 
 You can find all the changes on JIRA:
 

--- a/source/blog/2014-12-16-orm-247.md
+++ b/source/blog/2014-12-16-orm-247.md
@@ -10,13 +10,13 @@ We are happy to announce the immediate availability of Doctrine ORM
 
 The release includes a fix for `null` values in column mapping options
 support:
-[DDC-3425](http://www.doctrine-project.org/jira/browse/DDC-3425) We also
+[DDC-3425](https://github.com/doctrine/orm/issues/4231) We also
 fixed various `Paginator` tool issues: - allowing DQL queries that have
 `HIDDEN` selected fields appearing both in the `SELECT` and the
 `ORDER BY` clauses:
-[DDC-3434](http://www.doctrine-project.org/jira/browse/DDC-3434) -
+[DDC-3434](https://github.com/doctrine/orm/issues/4241) -
 allowing DQL queries that have `SELECT` clauses containing parameters:
-[DDC-3336](http://www.doctrine-project.org/jira/browse/DDC-3336)
+[DDC-3336](https://github.com/doctrine/orm/issues/4133)
 
 You can find all the changes on JIRA:
 

--- a/source/blog/2015-01-25-orm-2-5-0-alpha-2.md
+++ b/source/blog/2015-01-25-orm-2-5-0-alpha-2.md
@@ -65,64 +65,64 @@ Changes since 2.5.0-alpha1
 
 This is a list of issues solved in `2.5.0-alpha2` since `2.5.0-alpha1`:
 
--   [[DDC-3517]](http://www.doctrine-project.org/jira/browse/DDC-3517)
+-   [[DDC-3517]](https://github.com/doctrine/orm/issues/4331)
     [[GH-1265]](https://github.com/doctrine/doctrine2/pull/1265) Fix
     error undefined index "targetEntity"
--   [[DDC-3516]](http://www.doctrine-project.org/jira/browse/DDC-3516)
+-   [[DDC-3516]](https://github.com/doctrine/orm/issues/4330)
     [[GH-1264]](https://github.com/doctrine/doctrine2/pull/1264) Add
     Changelog/Migration to 2.5 documentation chapter.
--   [[DDC-3520]](http://www.doctrine-project.org/jira/browse/DDC-3520)
-    [[DDC-3521]](http://www.doctrine-project.org/jira/browse/DDC-3521)
+-   [[DDC-3520]](https://github.com/doctrine/orm/issues/4335)
+    [[DDC-3521]](https://github.com/doctrine/orm/issues/4336)
     [[GH-1269]](https://github.com/doctrine/doctrine2/pull/1269)
     `self-update` composer before install
--   [[DDC-3526]](http://www.doctrine-project.org/jira/browse/DDC-3526)
+-   [[DDC-3526]](https://github.com/doctrine/orm/issues/4341)
     [[GH-1273]](https://github.com/doctrine/doctrine2/pull/1273)
     Incorrect `@throws` doc. in `getSingleScalarResult`
--   [[DDC-3465]](http://www.doctrine-project.org/jira/browse/DDC-3465)
+-   [[DDC-3465]](https://github.com/doctrine/orm/issues/4275)
     [[GH-1232]](https://github.com/doctrine/doctrine2/pull/1232)
     Explicit example of partial indexes
--   [[DDC-3300]](http://www.doctrine-project.org/jira/browse/DDC-3300)
-    [[DDC-3503]](http://www.doctrine-project.org/jira/browse/DDC-3503)
+-   [[DDC-3300]](https://github.com/doctrine/orm/issues/4094)
+    [[DDC-3503]](https://github.com/doctrine/orm/issues/4317)
     [[GH-1130]](https://github.com/doctrine/doctrine2/pull/1130)
     [[GH-1232]](https://github.com/doctrine/doctrine2/pull/1232) Resolve
     target entity also in discriminator map (allows interfaces and
     custom names in discriminator map)
--   [[DDC-3378]](http://www.doctrine-project.org/jira/browse/DDC-3378)
+-   [[DDC-3378]](https://github.com/doctrine/orm/pull/1176)
     [[GH-1176]](https://github.com/doctrine/doctrine2/pull/1176) Support
     merging entities with composite identities defined through to-one
     associations
--   [[DDC-3533]](http://www.doctrine-project.org/jira/browse/DDC-3533)
+-   [[DDC-3533]](https://github.com/doctrine/orm/issues/4351)
     [[GH-1279]](https://github.com/doctrine/doctrine2/pull/1279) Fixed
     typos and grammar in the second level cache documentation
--   [[DDC-3343]](http://www.doctrine-project.org/jira/browse/DDC-3343)
-    [[DDC-3536]](http://www.doctrine-project.org/jira/browse/DDC-3536)
-    [[DDC-3544]](http://www.doctrine-project.org/jira/browse/DDC-3544)
+-   [[DDC-3343]](https://github.com/doctrine/orm/issues/4141)
+    [[DDC-3536]](https://github.com/doctrine/orm/issues/4349)
+    [[DDC-3544]](https://github.com/doctrine/orm/issues/4361)
     [[GH-1281]](https://github.com/doctrine/doctrine2/pull/1281)
     [[GH-1288]](https://github.com/doctrine/doctrine2/pull/1288)
     [[GH-1169]](https://github.com/doctrine/doctrine2/pull/1169)
     Entities should not be deleted when using `EXTRA_LAZY` and
     `one-to-many`
--   [[DDC-3538]](http://www.doctrine-project.org/jira/browse/DDC-3538)
-    [[DDC-3519]](http://www.doctrine-project.org/jira/browse/DDC-3519)
+-   [[DDC-3538]](https://github.com/doctrine/orm/issues/4355)
+    [[DDC-3519]](https://github.com/doctrine/orm/issues/4333)
     [[GH-1283]](https://github.com/doctrine/doctrine2/pull/1283)
     [[GH-1267]](https://github.com/doctrine/doctrine2/pull/1267)
     Reverted [\#1220](https://github.com/doctrine/doctrine2/pull/1220),
     fixed order in pagination logic
--   [[DDC-2704]](http://www.doctrine-project.org/jira/browse/DDC-2704)
-    [[DDC-3524]](http://www.doctrine-project.org/jira/browse/DDC-3524)
+-   [[DDC-2704]](https://github.com/doctrine/orm/issues/3446)
+    [[DDC-3524]](https://github.com/doctrine/orm/issues/4339)
     [[GH-1272]](https://github.com/doctrine/doctrine2/pull/1272) merge
     inherited transient properties - merge properties into uninitialized
     proxies
--   [[DDC-3346]](http://www.doctrine-project.org/jira/browse/DDC-3346)
-    [[DDC-3531]](http://www.doctrine-project.org/jira/browse/DDC-3531)
-    [[DDC-3534]](http://www.doctrine-project.org/jira/browse/DDC-3534)
+-   [[DDC-3346]](https://github.com/doctrine/orm/issues/4144)
+    [[DDC-3531]](https://github.com/doctrine/orm/issues/4347)
+    [[DDC-3534]](https://github.com/doctrine/orm/issues/4352)
     [[GH-1280]](https://github.com/doctrine/doctrine2/pull/1280)
     [[GH-1277]](https://github.com/doctrine/doctrine2/pull/1277) fixed
     `findOne*` operations when using a `EAGER` `*-to-many` association
--   [[DDC-3541]](http://www.doctrine-project.org/jira/browse/DDC-3541)
+-   [[DDC-3541]](https://github.com/doctrine/orm/issues/4358)
     [[GH-1286]](https://github.com/doctrine/doctrine2/pull/1286)
     Removing XDebug from non-coverage builds
--   [[DDC-3546]](http://www.doctrine-project.org/jira/browse/DDC-3546)
+-   [[DDC-3546]](https://github.com/doctrine/orm/issues/4363)
     [[GH-1289]](https://github.com/doctrine/doctrine2/pull/1289) Improve
     test suite performance
 

--- a/source/blog/2015-03-18-orm-2-5-0-beta-1.md
+++ b/source/blog/2015-03-18-orm-2-5-0-beta-1.md
@@ -62,48 +62,48 @@ Changes since 2.5.0-alpha2
 
 This is a list of issues solved in `2.5.0-beta1` since `2.5.0-alpha2`:
 
--   [[DDC-3452](http://www.doctrine-project.org/jira/browse/DDC-3452)]
+-   [[DDC-3452](https://github.com/doctrine/orm/issues/4261)]
     Embeddables Support for ClassMetadataBuilder
--   [[DDC-3551](http://www.doctrine-project.org/jira/browse/DDC-3551)]
+-   [[DDC-3551](https://github.com/doctrine/orm/issues/4369)]
     Load platform lazily in ClassMetadataFactory to avoid database
     connections.
--   [[DDC-3258](http://www.doctrine-project.org/jira/browse/DDC-3258)]
+-   [[DDC-3258](https://github.com/doctrine/orm/issues/4047)]
     Improve suport for composite primary keys and associations as keys.
--   [[DDC-3554](http://www.doctrine-project.org/jira/browse/DDC-3554)]
+-   [[DDC-3554](https://github.com/doctrine/orm/issues/4372)]
     Allow to recreate DQL QueryBuilder from parts.
--   [[DDC-3461](http://www.doctrine-project.org/jira/browse/DDC-3461)]
+-   [[DDC-3461](https://github.com/doctrine/orm/issues/4271)]
     Allow setting association as primary key in ClassMetadataBuilder API
     with `makePrimaryKey()`.
--   [[DDC-3587](http://www.doctrine-project.org/jira/browse/DDC-3587)]
+-   [[DDC-3587](https://github.com/doctrine/orm/issues/4408)]
     Added programmatical support to define indexBy on root aliases.
--   [[DDC-3588](http://www.doctrine-project.org/jira/browse/DDC-3588)]
+-   [[DDC-3588](https://github.com/doctrine/orm/issues/4409)]
     Add support for seconds in `DATE_ADD` DQL function.
--   [[DDC-3585](http://www.doctrine-project.org/jira/browse/DDC-3585)]
+-   [[DDC-3585](https://github.com/doctrine/orm/issues/4406)]
     Fix instantiation of nested embeddables.
--   [[DDC-3607](http://www.doctrine-project.org/jira/browse/DDC-3607)]
+-   [[DDC-3607](https://github.com/doctrine/orm/issues/4431)]
     Add support for orphan removal in
     ClassMetadataBuilder/AssocationBuilder
--   [[DDC-3597](http://www.doctrine-project.org/jira/browse/DDC-3597)]
+-   [[DDC-3597](https://github.com/doctrine/orm/issues/4419)]
     Add support for embeddables in MappedSuperclasses.
--   [[DDC-3616](http://www.doctrine-project.org/jira/browse/DDC-3616)]
+-   [[DDC-3616](https://github.com/doctrine/orm/issues/4441)]
     Add support for DateTimeImmutable in Query parameter detection.
--   [[DDC-3622](http://www.doctrine-project.org/jira/browse/DDC-3622)]
+-   [[DDC-3622](https://github.com/doctrine/orm/issues/4448)]
     Improve support for objects as primary key by casting to string in
     UnitOfWork.
--   [[DDC-3619](http://www.doctrine-project.org/jira/browse/DDC-3619)]
+-   [[DDC-3619](https://github.com/doctrine/orm/issues/4444)]
     Update IdentityMap when entity gets managed again fixing
     `spl_object_hash` collision.
--   [[DDC-3608](http://www.doctrine-project.org/jira/browse/DDC-3608)]
+-   [[DDC-3608](https://github.com/doctrine/orm/issues/4432)]
     Fix bug in EntityGenerator to XML/YML with default values.
--   [[DDC-3590](http://www.doctrine-project.org/jira/browse/DDC-3590)]
+-   [[DDC-3590](https://github.com/doctrine/orm/issues/4412)]
     Fix bug in PostgreSQL with naming strategy of non-default schema
     tables.
--   [[DDC-3566](http://www.doctrine-project.org/jira/browse/DDC-3566)]
+-   [[DDC-3566](https://github.com/doctrine/orm/issues/4385)]
     Fix bug in Second-Level Cache with association identifiers.
--   [[DDC-3528](http://www.doctrine-project.org/jira/browse/DDC-3528)]
+-   [[DDC-3528](https://github.com/doctrine/orm/issues/4343)]
     Have `PersistentCollection` implement `AbstractLazyCollection` from
     [doctrine/collections](https://github.com/doctrine/collections).
--   [[DDC-3567](http://www.doctrine-project.org/jira/browse/DDC-3567)]
+-   [[DDC-3567](https://github.com/doctrine/orm/issues/4386)]
     Allow access to all aliases for a QueryBuilder.
 
 Please report any issues you may have with the update on the mailing

--- a/source/blog/2015-03-25-common-2-5-0-beta-1.md
+++ b/source/blog/2015-03-25-common-2-5-0-beta-1.md
@@ -51,79 +51,79 @@ This is a list of issues solved in `2.5.0-beta1` since `2.4.x`:
 Bug
 ---
 
--   [[DCOM-129](http://www.doctrine-project.org/jira/browse/DCOM-129)] -
+-   [[DCOM-129](https://github.com/doctrine/common/issues/428)] -
     Annotation parser matches colon after annotation
--   [[DCOM-151](http://www.doctrine-project.org/jira/browse/DCOM-151)] -
+-   [[DCOM-151](https://github.com/doctrine/common/issues/452)] -
     [[GH-233](https://github.com/doctrine/common/pull/233)] [DocParser]
     Fix trying include classes if its must be ignored.
--   [[DCOM-162](http://www.doctrine-project.org/jira/browse/DCOM-162)] -
+-   [[DCOM-162](https://github.com/doctrine/common/issues/463)] -
     [[GH-244](https://github.com/doctrine/common/pull/244)] return
     parameter for debug method
--   [[DCOM-168](http://www.doctrine-project.org/jira/browse/DCOM-168)] -
+-   [[DCOM-168](https://github.com/doctrine/common/issues/469)] -
     ignoredAnnotationNames doesn't work in Annotation loop
--   [[DCOM-175](http://www.doctrine-project.org/jira/browse/DCOM-175)] -
+-   [[DCOM-175](https://github.com/doctrine/common/issues/477)] -
     Proxies return private properties in \_\_sleep, which is not
     supported by PHP.
--   [[DCOM-191](http://www.doctrine-project.org/jira/browse/DCOM-191)] -
+-   [[DCOM-191](https://github.com/doctrine/common/issues/493)] -
     Wrong inflection for "identity"
--   [[DCOM-212](http://www.doctrine-project.org/jira/browse/DCOM-212)] -
+-   [[DCOM-212](https://github.com/doctrine/common/issues/518)] -
     [[GH-296](https://github.com/doctrine/common/pull/296)] Proxies
     shouldn't serialize static properties in \_\_sleep()
--   [[DCOM-216](http://www.doctrine-project.org/jira/browse/DCOM-216)] -
+-   [[DCOM-216](https://github.com/doctrine/common/issues/522)] -
     [[GH-298](https://github.com/doctrine/common/pull/298)] Silence
     E\_NOTICE warning: "Undefined index".
--   [[DCOM-220](http://www.doctrine-project.org/jira/browse/DCOM-220)] -
+-   [[DCOM-220](https://github.com/doctrine/common/issues/527)] -
     [[GH-304](https://github.com/doctrine/common/pull/304)] fix typo
--   [[DCOM-223](http://www.doctrine-project.org/jira/browse/DCOM-223)] -
+-   [[DCOM-223](https://github.com/doctrine/common/issues/530)] -
     [[GH-308](https://github.com/doctrine/common/pull/308)] fix the
     optimize regex and adapt the tests to actually test classAnnotat...
--   [[DCOM-228](http://www.doctrine-project.org/jira/browse/DCOM-228)] -
+-   [[DCOM-228](https://github.com/doctrine/common/issues/535)] -
     [[GH-312](https://github.com/doctrine/common/pull/312)] Improve
     UnexpectedValueException error message
--   [[DCOM-261](http://www.doctrine-project.org/jira/browse/DCOM-261)] -
+-   [[DCOM-261](https://github.com/doctrine/common/issues/571)] -
     [[GH-344](https://github.com/doctrine/common/pull/344)] Fix fatal
     error when classexist tries to call the protected loader
--   [[DCOM-270](http://www.doctrine-project.org/jira/browse/DCOM-270)] -
+-   [[DCOM-270](https://github.com/doctrine/common/issues/581)] -
     [[GH-351](https://github.com/doctrine/common/pull/351)] Added
     validation where allowed QCNs with ":" NS separator
--   [[DCOM-272](http://www.doctrine-project.org/jira/browse/DCOM-272)] -
+-   [[DCOM-272](https://github.com/doctrine/common/issues/583)] -
     Proxy generator doesn't understand splat operator (PHP 5.6 argument
     unpacking)
 
 Documentation
 -------------
 
--   [[DCOM-237](http://www.doctrine-project.org/jira/browse/DCOM-237)] -
+-   [[DCOM-237](https://github.com/doctrine/common/issues/545)] -
     [[GH-318](https://github.com/doctrine/common/pull/318)] Fixed link
     to Documentation
--   [[DCOM-280](http://www.doctrine-project.org/jira/browse/DCOM-280)] -
+-   [[DCOM-280](https://github.com/doctrine/common/issues/592)] -
     [[GH-359](https://github.com/doctrine/common/pull/359)] Fixed
     missing / incorrect docblocks
 
 Improvement
 -----------
 
--   [[DCOM-246](http://www.doctrine-project.org/jira/browse/DCOM-246)] -
+-   [[DCOM-246](https://github.com/doctrine/common/issues/554)] -
     [[GH-328](https://github.com/doctrine/common/pull/328)] Optimized
     imports
--   [[DCOM-247](http://www.doctrine-project.org/jira/browse/DCOM-247)] -
+-   [[DCOM-247](https://github.com/doctrine/common/issues/555)] -
     [[GH-329](https://github.com/doctrine/common/pull/329)] Remove dead
     config
--   [[DCOM-263](http://www.doctrine-project.org/jira/browse/DCOM-263)] -
+-   [[DCOM-263](https://github.com/doctrine/common/issues/573)] -
     [[GH-347](https://github.com/doctrine/common/pull/347)] Class
     loader: skip non-existing files and files not containing the
     requested class
--   [[DCOM-278](http://www.doctrine-project.org/jira/browse/DCOM-278)] -
+-   [[DCOM-278](https://github.com/doctrine/common/issues/589)] -
     [[GH-358](https://github.com/doctrine/common/pull/358)] travis: PHP
     7.0 nightly added, allowed failure
 
 New Feature
 -----------
 
--   [[DCOM-257](http://www.doctrine-project.org/jira/browse/DCOM-257)] -
+-   [[DCOM-257](https://github.com/doctrine/common/issues/566)] -
     [[GH-342](https://github.com/doctrine/common/pull/342)] Class
     metadata loading fallback hook in AbstractClassMetadataFactory
--   [[DCOM-277](http://www.doctrine-project.org/jira/browse/DCOM-277)] -
+-   [[DCOM-277](https://github.com/doctrine/common/issues/588)] -
     [[GH-357](https://github.com/doctrine/common/pull/357)] Custom
     namespace separators for SymfonyFileLocator
 

--- a/source/blog/2015-03-25-orm-2-5-0-rc-1.md
+++ b/source/blog/2015-03-25-orm-2-5-0-rc-1.md
@@ -53,7 +53,25 @@ following `composer.json` contents:
 }
 ~~~~
 
-`` `  Changes since 2.5.0-beta2 ~~~~~~~~~~~~~~~~~~~~~~~~~  This is a list of issues solved in ``2.5.0-RC1`since`2.5.0-beta1`` :  - [`DDC-3632 <http://www.doctrine-project.org/jira/browse/DDC-3632>`_]   [`#1345 <https://github.com/doctrine/doctrine2/pull/1345>`_] Fix crashes in ``ConvertMappingCommand`and`GenerateEntitiesCommand`` when using entities with joined table inheritance - [`DDC-3634 <http://www.doctrine-project.org/jira/browse/DDC-3634>`_]   [`#1346 <https://github.com/doctrine/doctrine2/pull/1346>`_] Fix: generated IDs are converted to integer even   when they are big integers - [`DDC-3630 <http://www.doctrine-project.org/jira/browse/DDC-3630>`_]   [`DDC-3621 <http://www.doctrine-project.org/jira/browse/DDC-3621>`_]   [`#1343 <https://github.com/doctrine/doctrine2/pull/1343>`_] Support embeddables in partial object query expression - [`DDC-3623 <http://www.doctrine-project.org/jira/browse/DDC-3623>`_]   [`DDC-3629 <http://www.doctrine-project.org/jira/browse/DDC-3629>`_]   [`#1337 <https://github.com/doctrine/doctrine2/pull/1337>`_]   [`#1342 <https://github.com/doctrine/doctrine2/pull/1342>`_] Paginator functional tests and sorting corrections - [`DDC-2224 <http://www.doctrine-project.org/jira/browse/DDC-2224>`_]   [`DDC-3625 <http://www.doctrine-project.org/jira/browse/DDC-3625>`_]   [`#1339 <https://github.com/doctrine/doctrine2/pull/1339>`_] Honor ``convertToDatabaseValueSQ\`\` in DQL query
+Changes since 2.5.0-beta1
+=========================
+
+This is a list of issues solved in `2.5.0-RC1` since `2.5.0-beta1`:
+
+-   [[DDC-3632](https://github.com/doctrine/orm/issues/4459)] -
+    [[GH-1345](https://github.com/doctrine/doctrine2/pull/1345)] Fix crashes in ``ConvertMappingCommand`and`GenerateEntitiesCommand`` when using entities with joined table inheritance
+-   [[DDC-3634](https://github.com/doctrine/orm/issues/4461)] -
+    [[GH-1346](https://github.com/doctrine/doctrine2/pull/1346)] Fix: generated IDs are converted to integer even   when they are big integers
+-   [[DDC-3630](https://github.com/doctrine/orm/issues/4457)]
+    [[DDC-3621](https://github.com/doctrine/orm/issues/4447)] -
+    [[GH-1343](https://github.com/doctrine/doctrine2/pull/1343)] Support embeddables in partial object query expression
+-   [[DDC-3623](https://github.com/doctrine/orm/issues/4449)]
+    [[DDC-3629](https://github.com/doctrine/orm/issues/4455)] -
+    [[GH-1337](https://github.com/doctrine/doctrine2/pull/1337)]
+    [[GH-1342](https://github.com/doctrine/doctrine2/pull/1342)] Paginator functional tests and sorting corrections
+-   [[DDC-2224](https://github.com/doctrine/orm/issues/2922)]
+    [[DDC-3625](https://github.com/doctrine/orm/issues/4451)] -
+    [[GH-1339](https://github.com/doctrine/doctrine2/pull/1339)] Honor `convertToDatabaseValueSQL` in DQL query
 :   parameters and caches
 
 Please report any issues you may have with the update on the mailing

--- a/source/blog/2015-03-31-orm-2-5-0-rc-2.md
+++ b/source/blog/2015-03-31-orm-2-5-0-rc-2.md
@@ -50,18 +50,21 @@ following `composer.json` contents:
 }
 ~~~~
 
-`` `  Changes since 2.5.0-RC1 ~~~~~~~~~~~~~~~~~~~~~~~  This is a list of issues solved in ``2.5.0-RC2`since`2.5.0-RC1\`\`:
+Changes since 2.5.0-RC1
+=======================
 
--   [[DDC-3643](http://www.doctrine-project.org/jira/browse/DDC-3643)]
-    [[\#1352](https://github.com/doctrine/doctrine2/pull/1352)] Fix
-    \`EntityGenerator\` \`RegenerateEntityIfExists\` logic
--   [[DDC-3645](http://www.doctrine-project.org/jira/browse/DDC-3645)]
+This is a list of issues solved in `2.5.0-RC2` since `2.5.0-RC1`:
+
+-   [[DDC-3643](https://github.com/doctrine/orm/issues/4471)]
+    [[#1352](https://github.com/doctrine/doctrine2/pull/1352)] Fix
+    `EntityGenerator` `RegenerateEntityIfExists` logic
+-   [[DDC-3645](https://github.com/doctrine/orm/issues/4473)]
     [[\#1353](https://github.com/doctrine/doctrine2/pull/1353)]
-    [[DDC-3637](http://www.doctrine-project.org/jira/browse/DDC-3637)]
+    [[DDC-3637](https://github.com/doctrine/orm/issues/4464)]
     [[\#1347](https://github.com/doctrine/doctrine2/pull/1347)]
-    [[DDC-3642](http://www.doctrine-project.org/jira/browse/DDC-3642)]
+    [[DDC-3642](https://github.com/doctrine/orm/issues/4470)]
     [[\#1351](https://github.com/doctrine/doctrine2/pull/1351)]
-    Paginator logic fixes (complex queries/sorting/db support\>\`\_]
+    Paginator logic fixes (complex queries/sorting/db support )
 
     parameters and caches
 

--- a/source/blog/2015-04-02-common-2-5-0.md
+++ b/source/blog/2015-04-02-common-2-5-0.md
@@ -30,79 +30,79 @@ This is a list of issues solved in `2.5.0` since `2.4.x`:
 Bug
 ---
 
--   [[DCOM-129](http://www.doctrine-project.org/jira/browse/DCOM-129)] -
+-   [[DCOM-129](https://github.com/doctrine/common/issues/428)] -
     Annotation parser matches colon after annotation
--   [[DCOM-151](http://www.doctrine-project.org/jira/browse/DCOM-151)] -
+-   [[DCOM-151](https://github.com/doctrine/common/issues/452)] -
     [[GH-233](https://github.com/doctrine/common/pull/233)] [DocParser]
     Fix trying include classes if its must be ignored.
--   [[DCOM-162](http://www.doctrine-project.org/jira/browse/DCOM-162)] -
+-   [[DCOM-162](https://github.com/doctrine/common/issues/463)] -
     [[GH-244](https://github.com/doctrine/common/pull/244)] return
     parameter for debug method
--   [[DCOM-168](http://www.doctrine-project.org/jira/browse/DCOM-168)] -
+-   [[DCOM-168](https://github.com/doctrine/common/issues/469)] -
     ignoredAnnotationNames doesn't work in Annotation loop
--   [[DCOM-175](http://www.doctrine-project.org/jira/browse/DCOM-175)] -
+-   [[DCOM-175](https://github.com/doctrine/common/issues/477)] -
     Proxies return private properties in \_\_sleep, which is not
     supported by PHP.
--   [[DCOM-191](http://www.doctrine-project.org/jira/browse/DCOM-191)] -
+-   [[DCOM-191](https://github.com/doctrine/common/issues/493)] -
     Wrong inflection for "identity"
--   [[DCOM-212](http://www.doctrine-project.org/jira/browse/DCOM-212)] -
+-   [[DCOM-212](https://github.com/doctrine/common/issues/518)] -
     [[GH-296](https://github.com/doctrine/common/pull/296)] Proxies
     shouldn't serialize static properties in \_\_sleep()
--   [[DCOM-216](http://www.doctrine-project.org/jira/browse/DCOM-216)] -
+-   [[DCOM-216](https://github.com/doctrine/common/issues/522)] -
     [[GH-298](https://github.com/doctrine/common/pull/298)] Silence
     E\_NOTICE warning: "Undefined index".
--   [[DCOM-220](http://www.doctrine-project.org/jira/browse/DCOM-220)] -
+-   [[DCOM-220](https://github.com/doctrine/common/issues/527)] -
     [[GH-304](https://github.com/doctrine/common/pull/304)] fix typo
--   [[DCOM-223](http://www.doctrine-project.org/jira/browse/DCOM-223)] -
+-   [[DCOM-223](https://github.com/doctrine/common/issues/530)] -
     [[GH-308](https://github.com/doctrine/common/pull/308)] fix the
     optimize regex and adapt the tests to actually test classAnnotat...
--   [[DCOM-228](http://www.doctrine-project.org/jira/browse/DCOM-228)] -
+-   [[DCOM-228](https://github.com/doctrine/common/issues/535)] -
     [[GH-312](https://github.com/doctrine/common/pull/312)] Improve
     UnexpectedValueException error message
--   [[DCOM-261](http://www.doctrine-project.org/jira/browse/DCOM-261)] -
+-   [[DCOM-261](https://github.com/doctrine/common/issues/571)] -
     [[GH-344](https://github.com/doctrine/common/pull/344)] Fix fatal
     error when classexist tries to call the protected loader
--   [[DCOM-270](http://www.doctrine-project.org/jira/browse/DCOM-270)] -
+-   [[DCOM-270](https://github.com/doctrine/common/issues/581)] -
     [[GH-351](https://github.com/doctrine/common/pull/351)] Added
     validation where allowed QCNs with ":" NS separator
--   [[DCOM-272](http://www.doctrine-project.org/jira/browse/DCOM-272)] -
+-   [[DCOM-272](https://github.com/doctrine/common/issues/583)] -
     Proxy generator doesn't understand splat operator (PHP 5.6 argument
     unpacking)
 
 Documentation
 -------------
 
--   [[DCOM-237](http://www.doctrine-project.org/jira/browse/DCOM-237)] -
+-   [[DCOM-237](https://github.com/doctrine/common/issues/545)] -
     [[GH-318](https://github.com/doctrine/common/pull/318)] Fixed link
     to Documentation
--   [[DCOM-280](http://www.doctrine-project.org/jira/browse/DCOM-280)] -
+-   [[DCOM-280](https://github.com/doctrine/common/issues/592)] -
     [[GH-359](https://github.com/doctrine/common/pull/359)] Fixed
     missing / incorrect docblocks
 
 Improvement
 -----------
 
--   [[DCOM-246](http://www.doctrine-project.org/jira/browse/DCOM-246)] -
+-   [[DCOM-246](https://github.com/doctrine/common/issues/554)] -
     [[GH-328](https://github.com/doctrine/common/pull/328)] Optimized
     imports
--   [[DCOM-247](http://www.doctrine-project.org/jira/browse/DCOM-247)] -
+-   [[DCOM-247](https://github.com/doctrine/common/issues/555)] -
     [[GH-329](https://github.com/doctrine/common/pull/329)] Remove dead
     config
--   [[DCOM-263](http://www.doctrine-project.org/jira/browse/DCOM-263)] -
+-   [[DCOM-263](https://github.com/doctrine/common/issues/573)] -
     [[GH-347](https://github.com/doctrine/common/pull/347)] Class
     loader: skip non-existing files and files not containing the
     requested class
--   [[DCOM-278](http://www.doctrine-project.org/jira/browse/DCOM-278)] -
+-   [[DCOM-278](https://github.com/doctrine/common/issues/589)] -
     [[GH-358](https://github.com/doctrine/common/pull/358)] travis: PHP
     7.0 nightly added, allowed failure
 
 New Feature
 -----------
 
--   [[DCOM-257](http://www.doctrine-project.org/jira/browse/DCOM-257)] -
+-   [[DCOM-257](https://github.com/doctrine/common/issues/566)] -
     [[GH-342](https://github.com/doctrine/common/pull/342)] Class
     metadata loading fallback hook in AbstractClassMetadataFactory
--   [[DCOM-277](http://www.doctrine-project.org/jira/browse/DCOM-277)] -
+-   [[DCOM-277](https://github.com/doctrine/common/issues/588)] -
     [[GH-357](https://github.com/doctrine/common/pull/357)] Custom
     namespace separators for SymfonyFileLocator
 

--- a/source/blog/2015-04-02-orm-2-5-0.md
+++ b/source/blog/2015-04-02-orm-2-5-0.md
@@ -13,7 +13,7 @@ effort by the team and the community to make the ORM more robust and
 performant.
 
 [457
-issues](http://www.doctrine-project.org/jira/browse/DDC-3322?jql=project%20%3D%20DDC%20AND%20fixVersion%20%3D%202.5%20ORDER%20BY%20status%20DESC%2C%20priority%20DESC)
+issues](?jql=project%20%3D%20DDC%20AND%20fixVersion%20%3D%202.5%20ORDER%20BY%20status%20DESC%2C%20priority%20DESC)
 were resolved in this release, so we are very proud of the work being
 done by the community and the core team.
 
@@ -77,1391 +77,1392 @@ This is a list of issues resolved in `2.5.0` since `2.4.0`:
 New Feature
 -----------
 
--   [DDC-93](http://www.doctrine-project.org/jira/browse/DDC-93) - It
+-   [DDC-93](https://github.com/doctrine/orm/issues/1581) - It
     would be nice if we could have support for ValueObjects
--   [DDC-1149](http://www.doctrine-project.org/jira/browse/DDC-1149)
+-   [DDC-1149](https://github.com/doctrine/orm/issues/1749)
     -Optimize OneToMany and ManyToMany without join
--   [DDC-1216](http://www.doctrine-project.org/jira/browse/DDC-1216)
+-   [DDC-1216](https://github.com/doctrine/orm/issues/1823)
     -A way to mark an entity to always use result cache. Like
     @UseResultCache class annotation.
--   [DDC-1247](http://www.doctrine-project.org/jira/browse/DDC-1247)
+-   [DDC-1247](https://github.com/doctrine/orm/issues/1856)
     -Implement AnnotationDriver::addExcludePath
--   [DDC-1563](http://www.doctrine-project.org/jira/browse/DDC-1563)
+-   [DDC-1563](https://github.com/doctrine/orm/issues/2199)
     -Result cache for repository queries
--   [DDC-2021](http://www.doctrine-project.org/jira/browse/DDC-2021)
+-   [DDC-2021](https://github.com/doctrine/orm/issues/2698)
     -Array Data in Member OF
--   [DDC-2773](http://www.doctrine-project.org/jira/browse/DDC-2773)
+-   [DDC-2773](https://github.com/doctrine/orm/issues/3520)
     -[\#835](https://github.com/doctrine/doctrine2/pull/835) Value
     objects (Based on \#634)
--   [DDC-2959](http://www.doctrine-project.org/jira/browse/DDC-2959)
+-   [DDC-2959](https://github.com/doctrine/orm/issues/3722)
     -[\#937](https://github.com/doctrine/doctrine2/pull/937)
     Extra-lazy for containsKey on collections
--   [DDC-3117](http://www.doctrine-project.org/jira/browse/DDC-3117)
+-   [DDC-3117](https://github.com/doctrine/orm/issues/3893)
     -[\#1027](https://github.com/doctrine/doctrine2/pull/1027) Support
     for Partial Indexes for PostgreSql and Sqlite
--   [DDC-3161](http://www.doctrine-project.org/jira/browse/DDC-3161)
+-   [DDC-3161](https://github.com/doctrine/orm/issues/3941)
     -[\#1054](https://github.com/doctrine/doctrine2/pull/1054)
     SQLFilters enahancements
--   [DDC-3186](http://www.doctrine-project.org/jira/browse/DDC-3186)
+-   [DDC-3186](https://github.com/doctrine/orm/issues/3968)
     -[\#1069](https://github.com/doctrine/doctrine2/pull/1069) added
     method to be able to reuse the console application
--   [DDC-3231](http://www.doctrine-project.org/jira/browse/DDC-3231)
+-   [DDC-3231](https://github.com/doctrine/orm/issues/4019)
     -[\#1089](https://github.com/doctrine/doctrine2/pull/1089) Entity
     repository generator default repository
--   [DDC-3300](http://www.doctrine-project.org/jira/browse/DDC-3300)
+-   [DDC-3300](https://github.com/doctrine/orm/issues/4094)
     -[\#1130](https://github.com/doctrine/doctrine2/pull/1130) Added
     resolve entities support in discrim. map
--   [DDC-3385](http://www.doctrine-project.org/jira/browse/DDC-3385)
+-   [DDC-3385](https://github.com/doctrine/orm/issues/4187)
     -[\#1181](https://github.com/doctrine/doctrine2/pull/1181) Support
     fetching entities by aliased name
--   [DDC-3462](http://www.doctrine-project.org/jira/browse/DDC-3462)
+-   [DDC-3462](https://github.com/doctrine/orm/issues/4272)
     -[\#1230](https://github.com/doctrine/doctrine2/pull/1230) Allow
     dumping SQL query when passing DQL on cli
--   [DDC-3503](http://www.doctrine-project.org/jira/browse/DDC-3503)
+-   [DDC-3503](https://github.com/doctrine/orm/issues/4317)
     -[\#1257](https://github.com/doctrine/doctrine2/pull/1257) Resolve
     target entity also in discriminator map (allows interfaces and
     custom names in discriminator map)
--   [DDC-3567](http://www.doctrine-project.org/jira/browse/DDC-3567)
+-   [DDC-3567](https://github.com/doctrine/orm/issues/4386)
     -[\#1303](https://github.com/doctrine/doctrine2/pull/1303) make
     QueryBuilder::getAllAliases public
 
 Improvement
 -----------
 
--   [DDC-54](http://www.doctrine-project.org/jira/browse/DDC-54)
+-   [DDC-54](https://github.com/doctrine/orm/issues/5047)
     -Trigger postLoad events and callbacks after associations have been
     initialized
--   [DDC-1590](http://www.doctrine-project.org/jira/browse/DDC-1590)
+-   [DDC-1590](https://github.com/doctrine/orm/issues/2227)
     -Fix Inheritance in Code-Generation
--   [DDC-1787](http://www.doctrine-project.org/jira/browse/DDC-1787)
+-   [DDC-1787](https://github.com/doctrine/orm/issues/2441)
     -Fix for JoinedSubclassPersister, multiple inserts with versioning
     throws an optimistic locking exception
--   [DDC-1858](http://www.doctrine-project.org/jira/browse/DDC-1858)
+-   [DDC-1858](https://github.com/doctrine/orm/issues/2519)
     -LIKE and IS NULL operators not supported in HAVING clause
--   [DDC-2052](http://www.doctrine-project.org/jira/browse/DDC-2052)
+-   [DDC-2052](https://github.com/doctrine/orm/issues/2732)
     -Custom tree walkers are not allowed to add new components to the
     query
--   [DDC-2061](http://www.doctrine-project.org/jira/browse/DDC-2061)
+-   [DDC-2061](https://github.com/doctrine/orm/issues/2742)
     -Matching Criteria on a PersistentCollection only works on OneToMany
     associations
--   [DDC-2128](http://www.doctrine-project.org/jira/browse/DDC-2128)
+-   [DDC-2128](https://github.com/doctrine/orm/issues/2815)
     -[\#507](https://github.com/doctrine/doctrine2/pull/507) Now
     MetaDataFilter takess also regexp. For example whern you want to
--   [DDC-2183](http://www.doctrine-project.org/jira/browse/DDC-2183)
+-   [DDC-2183](https://github.com/doctrine/orm/issues/2876)
     -Second Level Cache improvements
--   [DDC-2210](http://www.doctrine-project.org/jira/browse/DDC-2210)
+-   [DDC-2210](https://github.com/doctrine/orm/issues/2907)
     -PHP warning in ProxyFactory when renaming proxy file
--   [DDC-2217](http://www.doctrine-project.org/jira/browse/DDC-2217)
+-   [DDC-2217](https://github.com/doctrine/orm/issues/2914)
     -Return a lazy collection from
     PersistentCollection::match(\$criteria)
--   [DDC-2319](http://www.doctrine-project.org/jira/browse/DDC-2319)
+-   [DDC-2319](https://github.com/doctrine/orm/issues/3023)
     -[\#590](https://github.com/doctrine/doctrine2/pull/590) DQL
     Query: process ArrayCollection values to ease development
--   [DDC-2534](http://www.doctrine-project.org/jira/browse/DDC-2534)
+-   [DDC-2534](https://github.com/doctrine/orm/issues/3258)
     -[\#711](https://github.com/doctrine/doctrine2/pull/711) Coveralls
     code coverage
--   [DDC-2538](http://www.doctrine-project.org/jira/browse/DDC-2538)
+-   [DDC-2538](https://github.com/doctrine/orm/issues/3262)
     -[\#713](https://github.com/doctrine/doctrine2/pull/713) Quick
     grammar fix
--   [DDC-2544](http://www.doctrine-project.org/jira/browse/DDC-2544)
+-   [DDC-2544](https://github.com/doctrine/orm/issues/3269)
     -[\#717](https://github.com/doctrine/doctrine2/pull/717) Allow
     query parameters starting with an underscore
--   [DDC-2546](http://www.doctrine-project.org/jira/browse/DDC-2546)
+-   [DDC-2546](https://github.com/doctrine/orm/issues/3271)
     -[\#719](https://github.com/doctrine/doctrine2/pull/719) Access
     properties via static:: instead of self::.
--   [DDC-2615](http://www.doctrine-project.org/jira/browse/DDC-2615)
+-   [DDC-2615](https://github.com/doctrine/orm/issues/3347)
     -LIKE operator not supported in HAVING clause
--   [DDC-2636](http://www.doctrine-project.org/jira/browse/DDC-2636)
+-   [DDC-2636](https://github.com/doctrine/orm/issues/3370)
     -Handle SQLite with dot notation in @Table and @JoinTable
--   [DDC-2639](http://www.doctrine-project.org/jira/browse/DDC-2639)
+-   [DDC-2639](https://github.com/doctrine/orm/issues/3373)
     -[\#771](https://github.com/doctrine/doctrine2/pull/771) Added
     indexBy option to createQueryBuilder
--   [DDC-2770](http://www.doctrine-project.org/jira/browse/DDC-2770)
+-   [DDC-2770](https://github.com/doctrine/orm/issues/3517)
     -[\#833](https://github.com/doctrine/doctrine2/pull/833)
     Generate-Entities-Console-Command: Adding an 'avoid backup' flag
--   [DDC-2789](http://www.doctrine-project.org/jira/browse/DDC-2789)
+-   [DDC-2789](https://github.com/doctrine/orm/issues/3537)
     -[\#844](https://github.com/doctrine/doctrine2/pull/844) Teach
     orm:validate-schema to --skip-mapping and --skip-sync
--   [DDC-2794](http://www.doctrine-project.org/jira/browse/DDC-2794)
+-   [DDC-2794](https://github.com/doctrine/orm/issues/3543)
     -the Paginator does not support arbitrary join
--   [DDC-2814](http://www.doctrine-project.org/jira/browse/DDC-2814)
+-   [DDC-2814](https://github.com/doctrine/orm/issues/3566)
     -[\#858](https://github.com/doctrine/doctrine2/pull/858) lifts an
     unnecessary restriction on ResultSetMappingBuilder
--   [DDC-2824](http://www.doctrine-project.org/jira/browse/DDC-2824)
+-   [DDC-2824](https://github.com/doctrine/orm/issues/3577)
     -[\#863](https://github.com/doctrine/doctrine2/pull/863) The new
     configuration option: defaultQueryHints
--   [DDC-2861](http://www.doctrine-project.org/jira/browse/DDC-2861)
+-   [DDC-2861](https://github.com/doctrine/orm/issues/3617)
     -[\#881](https://github.com/doctrine/doctrine2/pull/881) Fix
     persistence exception on a table with a schema on a platform without
     schema support
--   [DDC-2865](http://www.doctrine-project.org/jira/browse/DDC-2865)
+-   [DDC-2865](https://github.com/doctrine/orm/issues/3621)
     -[\#882](https://github.com/doctrine/doctrine2/pull/882) Efficient
     counting on Criteria
--   [DDC-2868](http://www.doctrine-project.org/jira/browse/DDC-2868)
+-   [DDC-2868](https://github.com/doctrine/orm/issues/3624)
     -[\#885](https://github.com/doctrine/doctrine2/pull/885) Add
     support for ManyToMany Criteria
--   [DDC-2926](http://www.doctrine-project.org/jira/browse/DDC-2926)
+-   [DDC-2926](https://github.com/doctrine/orm/issues/3686)
     -[\#914](https://github.com/doctrine/doctrine2/pull/914) added
     license badge
--   [DDC-2970](http://www.doctrine-project.org/jira/browse/DDC-2970)
+-   [DDC-2970](https://github.com/doctrine/orm/issues/3735)
     -[\#946](https://github.com/doctrine/doctrine2/pull/946) Cleaned
     up unused imports
--   [DDC-2981](http://www.doctrine-project.org/jira/browse/DDC-2981)
+-   [DDC-2981](https://github.com/doctrine/orm/issues/3745)
     -Multi get for second level cache (Doctrine Cache related)
--   [DDC-2982](http://www.doctrine-project.org/jira/browse/DDC-2982)
+-   [DDC-2982](https://github.com/doctrine/orm/issues/3746)
     -[\#954](https://github.com/doctrine/doctrine2/pull/954) Multi Get
     support for Second Level Cache
--   [DDC-2984](http://www.doctrine-project.org/jira/browse/DDC-2984)
+-   [DDC-2984](https://github.com/doctrine/orm/issues/3748)
     -Support Custom DBAL types to be used as identifiers
--   [DDC-2991](http://www.doctrine-project.org/jira/browse/DDC-2991)
+-   [DDC-2991](https://github.com/doctrine/orm/issues/3755)
     -[\#957](https://github.com/doctrine/doctrine2/pull/957) makes
     doctrine less dependent upon the symfony yaml component
--   [DDC-2999](http://www.doctrine-project.org/jira/browse/DDC-2999)
+-   [DDC-2999](https://github.com/doctrine/orm/issues/3763)
     -[\#962](https://github.com/doctrine/doctrine2/pull/962) Stop
     executeDeletions when there is nothing to to delete anymore
--   [DDC-3000](http://www.doctrine-project.org/jira/browse/DDC-3000)
+-   [DDC-3000](https://github.com/doctrine/orm/issues/3767)
     -[\#963](https://github.com/doctrine/doctrine2/pull/963) SQLFilter
     -- allows to check if a parameter was set
--   [DDC-3004](http://www.doctrine-project.org/jira/browse/DDC-3004)
+-   [DDC-3004](https://github.com/doctrine/orm/issues/3771)
     -[\#966](https://github.com/doctrine/doctrine2/pull/966) Simplify
     build matrix
--   [DDC-3005](http://www.doctrine-project.org/jira/browse/DDC-3005)
+-   [DDC-3005](https://github.com/doctrine/orm/issues/3772)
     -Events::postLoad fires without filled associations
--   [DDC-3014](http://www.doctrine-project.org/jira/browse/DDC-3014)
+-   [DDC-3014](https://github.com/doctrine/orm/issues/3781)
     -[\#973](https://github.com/doctrine/doctrine2/pull/973) Added
     index flags support in annotation, xml & yaml mapping drivers.
--   [DDC-3032](http://www.doctrine-project.org/jira/browse/DDC-3032)
+-   [DDC-3032](https://github.com/doctrine/orm/issues/3801)
     -[\#980](https://github.com/doctrine/doctrine2/pull/980) Added
     options attribute export to Annotation, Xml & Yaml exporters.
--   [DDC-3039](http://www.doctrine-project.org/jira/browse/DDC-3039)
+-   [DDC-3039](https://github.com/doctrine/orm/issues/3808)
     -[\#983](https://github.com/doctrine/doctrine2/pull/983) Added
     MEMBER OF and INSTANCE OF to ExpressionBuilder
--   [DDC-3068](http://www.doctrine-project.org/jira/browse/DDC-3068)
+-   [DDC-3068](https://github.com/doctrine/orm/issues/3840)
     -EntityManager::find does not accept an array of object as a primary
     key
--   [DDC-3070](http://www.doctrine-project.org/jira/browse/DDC-3070)
+-   [DDC-3070](https://github.com/doctrine/orm/issues/3843)
     -[\#1001](https://github.com/doctrine/doctrine2/pull/1001)
-    [DDC-3005](http://www.doctrine-project.org/jira/browse/DDC-3005)
+    [DDC-3005](https://github.com/doctrine/orm/issues/3772)
     Defer invoking of postLoad event to the end of hydration cycle.
--   [DDC-3076](http://www.doctrine-project.org/jira/browse/DDC-3076)
+-   [DDC-3076](https://github.com/doctrine/orm/issues/3849)
     -[\#1006](https://github.com/doctrine/doctrine2/pull/1006)
     Handling invalid discriminator values
--   [DDC-3114](http://www.doctrine-project.org/jira/browse/DDC-3114)
+-   [DDC-3114](https://github.com/doctrine/orm/issues/3891)
     -[\#1026](https://github.com/doctrine/doctrine2/pull/1026) Remove
     some redundant clauses
--   [DDC-3133](http://www.doctrine-project.org/jira/browse/DDC-3133)
+-   [DDC-3133](https://github.com/doctrine/orm/issues/3911)
     -[\#1036](https://github.com/doctrine/doctrine2/pull/1036) Move
     space addition to implementation.
--   [DDC-3138](http://www.doctrine-project.org/jira/browse/DDC-3138)
+-   [DDC-3138](https://github.com/doctrine/orm/issues/3916)
     -[\#1037](https://github.com/doctrine/doctrine2/pull/1037) I can't
     look at those semicolons, sorry ;-)
--   [DDC-3150](http://www.doctrine-project.org/jira/browse/DDC-3150)
+-   [DDC-3150](https://github.com/doctrine/orm/issues/3929)
     -[\#1047](https://github.com/doctrine/doctrine2/pull/1047) Minor
     grammatical corrections
--   [DDC-3178](http://www.doctrine-project.org/jira/browse/DDC-3178)
+-   [DDC-3178](https://github.com/doctrine/orm/issues/3959)
     -[\#1064](https://github.com/doctrine/doctrine2/pull/1064) remove
     on-update from join-column
--   [DDC-3249](http://www.doctrine-project.org/jira/browse/DDC-3249)
+-   [DDC-3249](https://github.com/doctrine/orm/issues/4037)
     -[\#1105](https://github.com/doctrine/doctrine2/pull/1105) Add
     support for nesting embeddables
--   [DDC-3257](http://www.doctrine-project.org/jira/browse/DDC-3257)
+-   [DDC-3257](https://github.com/doctrine/orm/issues/4046)
     -[\#1112](https://github.com/doctrine/doctrine2/pull/1112)
     DefaultRepositoryFactory: single repository for aliased entities
--   [DDC-3258](http://www.doctrine-project.org/jira/browse/DDC-3258)
+-   [DDC-3258](https://github.com/doctrine/orm/issues/4047)
     -[\#1113](https://github.com/doctrine/doctrine2/pull/1113) Added
     support for composite primary key on findBy methods and Criteria
--   [DDC-3274](http://www.doctrine-project.org/jira/browse/DDC-3274)
+-   [DDC-3274](https://github.com/doctrine/orm/issues/4064)
     -Improve schema validator error message
--   [DDC-3275](http://www.doctrine-project.org/jira/browse/DDC-3275)
+-   [DDC-3275](https://github.com/doctrine/orm/issues/4065)
     -[\#1121](https://github.com/doctrine/doctrine2/pull/1121)
-    [DDC-3274](http://www.doctrine-project.org/jira/browse/DDC-3274)
+    [DDC-3274](https://github.com/doctrine/orm/issues/4064)
     Improve schema validator error message for invalid bi-directional
     relations
--   [DDC-3276](http://www.doctrine-project.org/jira/browse/DDC-3276)
+-   [DDC-3276](https://github.com/doctrine/orm/issues/4066)
     -[\#1122](https://github.com/doctrine/doctrine2/pull/1122) Support
     arithmetic expressions in `COUNT()`
--   [DDC-3304](http://www.doctrine-project.org/jira/browse/DDC-3304)
+-   [DDC-3304](https://github.com/doctrine/orm/issues/4098)
     -[EntityGenerator] Embeddables properties and methods are broken
--   [DDC-3305](http://www.doctrine-project.org/jira/browse/DDC-3305)
+-   [DDC-3305](https://github.com/doctrine/orm/issues/4099)
     -[\#1133](https://github.com/doctrine/doctrine2/pull/1133)
     [Embeddables] Improved exception message
--   [DDC-3307](http://www.doctrine-project.org/jira/browse/DDC-3307)
+-   [DDC-3307](https://github.com/doctrine/orm/issues/4101)
     -[\#1135](https://github.com/doctrine/doctrine2/pull/1135)
-    [DDC-3304](http://www.doctrine-project.org/jira/browse/DDC-3304)
+    [DDC-3304](https://github.com/doctrine/orm/issues/4098)
     Add support for embeddables in entity generator
--   [DDC-3418](http://www.doctrine-project.org/jira/browse/DDC-3418)
+-   [DDC-3418](https://github.com/doctrine/orm/issues/4223)
     -Indexes not inherited from mapped superclass
--   [DDC-3457](http://www.doctrine-project.org/jira/browse/DDC-3457)
+-   [DDC-3457](https://github.com/doctrine/orm/issues/4266)
     -[\#1227](https://github.com/doctrine/doctrine2/pull/1227) Ensure
     query cache is not ArrayCache in production
--   [DDC-3461](http://www.doctrine-project.org/jira/browse/DDC-3461)
+-   [DDC-3461](https://github.com/doctrine/orm/issues/4271)
     -[\#1229](https://github.com/doctrine/doctrine2/pull/1229)
     Identity in onetoone association builder
--   [DDC-3477](http://www.doctrine-project.org/jira/browse/DDC-3477)
+-   [DDC-3477](https://github.com/doctrine/orm/issues/4287)
     -[\#1238](https://github.com/doctrine/doctrine2/pull/1238) Avoid
     prefixing columns when `false` is assigned to `column-prefix`
--   [DDC-3479](http://www.doctrine-project.org/jira/browse/DDC-3479)
+-   [DDC-3479](https://github.com/doctrine/orm/issues/4289)
     -[\#1240](https://github.com/doctrine/doctrine2/pull/1240) Include
     IDs in the exception message to ease debugging
--   [DDC-3483](http://www.doctrine-project.org/jira/browse/DDC-3483)
+-   [DDC-3483](https://github.com/doctrine/orm/issues/4294)
     -[\#1243](https://github.com/doctrine/doctrine2/pull/1243) Fixed
     phpunit tests autoload requirements and moved to composer
     autoload-dev
--   [DDC-3486](http://www.doctrine-project.org/jira/browse/DDC-3486)
+-   [DDC-3486](https://github.com/doctrine/orm/issues/4297)
     -[\#1245](https://github.com/doctrine/doctrine2/pull/1245)
     Implemented support for one to many extra lazy with joined
     inheritance.
--   [DDC-3487](http://www.doctrine-project.org/jira/browse/DDC-3487)
+-   [DDC-3487](https://github.com/doctrine/orm/issues/4298)
     -[\#1246](https://github.com/doctrine/doctrine2/pull/1246) Moved
     delete() and update() to proper locations.
--   [DDC-3490](http://www.doctrine-project.org/jira/browse/DDC-3490)
+-   [DDC-3490](https://github.com/doctrine/orm/issues/4302)
     -[\#1248](https://github.com/doctrine/doctrine2/pull/1248)
     improved error handling for invalid association values \#2
--   [DDC-3492](http://www.doctrine-project.org/jira/browse/DDC-3492)
+-   [DDC-3492](https://github.com/doctrine/orm/issues/4304)
     -[\#1249](https://github.com/doctrine/doctrine2/pull/1249) Support
     for extra lazy get for both owning and inverse side on many to many
     associations.
--   [DDC-3495](http://www.doctrine-project.org/jira/browse/DDC-3495)
+-   [DDC-3495](https://github.com/doctrine/orm/issues/4307)
     -[\#1251](https://github.com/doctrine/doctrine2/pull/1251) travis:
     optimize to run coverage only once
--   [DDC-3496](http://www.doctrine-project.org/jira/browse/DDC-3496)
+-   [DDC-3496](https://github.com/doctrine/orm/issues/4308)
     -[\#1252](https://github.com/doctrine/doctrine2/pull/1252) Include
     className in calls to NamingStrategy joinColumnName method
--   [DDC-3501](http://www.doctrine-project.org/jira/browse/DDC-3501)
+-   [DDC-3501](https://github.com/doctrine/orm/issues/4315)
     -[\#1255](https://github.com/doctrine/doctrine2/pull/1255)
     Cleanup: PHP 5.3 support end
--   [DDC-3504](http://www.doctrine-project.org/jira/browse/DDC-3504)
+-   [DDC-3504](https://github.com/doctrine/orm/issues/4318)
     -[\#1258](https://github.com/doctrine/doctrine2/pull/1258)
     Classify persisters into more granular namespaces.
--   [DDC-3514](http://www.doctrine-project.org/jira/browse/DDC-3514)
+-   [DDC-3514](https://github.com/doctrine/orm/issues/4328)
     -LimitSubqueryOutputWalker should not duplicate orderBy clauses
--   [DDC-3521](http://www.doctrine-project.org/jira/browse/DDC-3521)
+-   [DDC-3521](https://github.com/doctrine/orm/issues/4336)
     -[\#1269](https://github.com/doctrine/doctrine2/pull/1269)
-    [DDC-3520](http://www.doctrine-project.org/jira/browse/DDC-3520)
+    [DDC-3520](https://github.com/doctrine/orm/issues/4335)
     self-update composer before install
--   [DDC-3528](http://www.doctrine-project.org/jira/browse/DDC-3528)
+-   [DDC-3528](https://github.com/doctrine/orm/issues/4343)
     -[\#1274](https://github.com/doctrine/doctrine2/pull/1274)
     PersistentCollection now extends AbstractLazyCollection.
--   [DDC-3541](http://www.doctrine-project.org/jira/browse/DDC-3541)
+-   [DDC-3541](https://github.com/doctrine/orm/issues/4358)
     -[\#1286](https://github.com/doctrine/doctrine2/pull/1286)
     Removing XDebug from non-coverage builds
--   [DDC-3546](http://www.doctrine-project.org/jira/browse/DDC-3546)
+-   [DDC-3546](https://github.com/doctrine/orm/issues/4363)
     -[\#1289](https://github.com/doctrine/doctrine2/pull/1289) Improve
     test suite
--   [DDC-3549](http://www.doctrine-project.org/jira/browse/DDC-3549)
+-   [DDC-3549](https://github.com/doctrine/orm/issues/4366)
     -[\#1292](https://github.com/doctrine/doctrine2/pull/1292) Mark
     getSelectConditionStatementColumnSQL method as private
--   [DDC-3588](http://www.doctrine-project.org/jira/browse/DDC-3588)
+-   [DDC-3588](https://github.com/doctrine/orm/issues/4409)
     -[\#1314](https://github.com/doctrine/doctrine2/pull/1314)
     DATE\_ADD
     - Support for seconds
--   [DDC-3590](http://www.doctrine-project.org/jira/browse/DDC-3590)
+-   [DDC-3590](https://github.com/doctrine/orm/issues/4412)
     -[\#1316](https://github.com/doctrine/doctrine2/pull/1316) Allow
     to join non-public schema tables
--   [DDC-3594](http://www.doctrine-project.org/jira/browse/DDC-3594)
+-   [DDC-3594](https://github.com/doctrine/orm/issues/4416)
     -[\#1319](https://github.com/doctrine/doctrine2/pull/1319) travis:
     PHP 7.0 nightly added
--   [DDC-3607](http://www.doctrine-project.org/jira/browse/DDC-3607)
+-   [DDC-3607](https://github.com/doctrine/orm/issues/4431)
     -[\#1326](https://github.com/doctrine/doctrine2/pull/1326) Allow
     AssociationBuilder to set a relation as orphan removal
--   [DDC-3630](http://www.doctrine-project.org/jira/browse/DDC-3630)
+-   [DDC-3630](https://github.com/doctrine/orm/issues/4457)
     -[\#1343](https://github.com/doctrine/doctrine2/pull/1343) Support
     embeddables in partial object query expression
-    [DDC-3621](http://www.doctrine-project.org/jira/browse/DDC-3621)
--   [DDC-2850](http://www.doctrine-project.org/jira/browse/DDC-2850)
+    [DDC-3621](https://github.com/doctrine/orm/issues/4447)
+-   [DDC-2850](https://github.com/doctrine/orm/issues/3605)
     -Allow cascaded clearing of Entities associated to the indicated
     Entity
 
 Bugfix
 ------
 
--   [DDC-1624](http://www.doctrine-project.org/jira/browse/DDC-1624)
+-   [DDC-1624](https://github.com/doctrine/orm/issues/2265)
     -Locking CTI doesnt work on SQL Server
--   [DDC-2310](http://www.doctrine-project.org/jira/browse/DDC-2310)
+-   [DDC-2310](https://github.com/doctrine/orm/issues/3014)
     -Recent changes to DBAL SQL Server platform lock hinting breaks ORM
     SqlWalker in DQL queries with joins
--   [DDC-2352](http://www.doctrine-project.org/jira/browse/DDC-2352)
+-   [DDC-2352](https://github.com/doctrine/orm/issues/3059)
     -[\#615](https://github.com/doctrine/doctrine2/pull/615) Update
     SqlWalker.php
--   [DDC-2372](http://www.doctrine-project.org/jira/browse/DDC-2372)
+-   [DDC-2372](https://github.com/doctrine/orm/issues/3081)
     -[\#632](https://github.com/doctrine/doctrine2/pull/632) entity
     generator - ignore trait properties and methods
--   [DDC-2504](http://www.doctrine-project.org/jira/browse/DDC-2504)
+-   [DDC-2504](https://github.com/doctrine/orm/issues/3226)
     -[\#696](https://github.com/doctrine/doctrine2/pull/696) extra
     lazy joined test
--   [DDC-2559](http://www.doctrine-project.org/jira/browse/DDC-2559)
+-   [DDC-2559](https://github.com/doctrine/orm/issues/3285)
     -[\#728](https://github.com/doctrine/doctrine2/pull/728) Color
     message like the update tools
--   [DDC-2561](http://www.doctrine-project.org/jira/browse/DDC-2561)
+-   [DDC-2561](https://github.com/doctrine/orm/issues/3288)
     -[\#729](https://github.com/doctrine/doctrine2/pull/729) add
     missing hint about lifecycle callback
--   [DDC-2562](http://www.doctrine-project.org/jira/browse/DDC-2562)
+-   [DDC-2562](https://github.com/doctrine/orm/issues/3289)
     -[\#730](https://github.com/doctrine/doctrine2/pull/730) To avoid
     "SpacingAfterParams" error with PHPCS Symfony2 coding standard
--   [DDC-2566](http://www.doctrine-project.org/jira/browse/DDC-2566)
+-   [DDC-2566](https://github.com/doctrine/orm/issues/3293)
     -[\#732](https://github.com/doctrine/doctrine2/pull/732) Update
     working-with-associations.rst
--   [DDC-2568](http://www.doctrine-project.org/jira/browse/DDC-2568)
+-   [DDC-2568](https://github.com/doctrine/orm/issues/3295)
     -[\#733](https://github.com/doctrine/doctrine2/pull/733) Update
     Parser.php
--   [DDC-2572](http://www.doctrine-project.org/jira/browse/DDC-2572)
+-   [DDC-2572](https://github.com/doctrine/orm/issues/3300)
     -ResolveTargetEntityListener does not work as documented.
--   [DDC-2573](http://www.doctrine-project.org/jira/browse/DDC-2573)
+-   [DDC-2573](https://github.com/doctrine/orm/issues/3301)
     -[\#735](https://github.com/doctrine/doctrine2/pull/735) Fix proxy
     performance test
--   [DDC-2575](http://www.doctrine-project.org/jira/browse/DDC-2575)
+-   [DDC-2575](https://github.com/doctrine/orm/issues/3303)
     -Hydration bug
--   [DDC-2580](http://www.doctrine-project.org/jira/browse/DDC-2580)
+-   [DDC-2580](https://github.com/doctrine/orm/issues/3309)
     -[\#739](https://github.com/doctrine/doctrine2/pull/739) Fix
     DDC-2579
--   [DDC-2581](http://www.doctrine-project.org/jira/browse/DDC-2581)
+-   [DDC-2581](https://github.com/doctrine/orm/issues/3310)
     -[\#740](https://github.com/doctrine/doctrine2/pull/740)
     Synchronized support of FilterCollection with ODM by adding missing
     method
--   [DDC-2584](http://www.doctrine-project.org/jira/browse/DDC-2584)
+-   [DDC-2584](https://github.com/doctrine/orm/issues/3313)
     -[\#743](https://github.com/doctrine/doctrine2/pull/743) Added
     coverage to DDC-2524. Updated DDC-1719 to fix related DBAL bug.
--   [DDC-2588](http://www.doctrine-project.org/jira/browse/DDC-2588)
+-   [DDC-2588](https://github.com/doctrine/orm/issues/3317)
     -[\#745](https://github.com/doctrine/doctrine2/pull/745) Update
     basic-mapping.rst
--   [DDC-2591](http://www.doctrine-project.org/jira/browse/DDC-2591)
+-   [DDC-2591](https://github.com/doctrine/orm/issues/3321)
     -[\#747](https://github.com/doctrine/doctrine2/pull/747) fix some
     file mode 755-\>644
--   [DDC-2592](http://www.doctrine-project.org/jira/browse/DDC-2592)
+-   [DDC-2592](https://github.com/doctrine/orm/issues/3322)
     -[\#748](https://github.com/doctrine/doctrine2/pull/748) Add hour
     to DATE\_ADD and DATE\_SUB
--   [DDC-2603](http://www.doctrine-project.org/jira/browse/DDC-2603)
+-   [DDC-2603](https://github.com/doctrine/orm/issues/3334)
     -[\#751](https://github.com/doctrine/doctrine2/pull/751) Added
     coverage for querying support during postLoad.
--   [DDC-2604](http://www.doctrine-project.org/jira/browse/DDC-2604)
+-   [DDC-2604](https://github.com/doctrine/orm/issues/3335)
     -[\#752](https://github.com/doctrine/doctrine2/pull/752) ORM side
     fixes.
--   [DDC-2616](http://www.doctrine-project.org/jira/browse/DDC-2616)
+-   [DDC-2616](https://github.com/doctrine/orm/issues/3348)
     -[\#759](https://github.com/doctrine/doctrine2/pull/759) Fixed out
     of sync code examples in getting-started.rst
--   [DDC-2624](http://www.doctrine-project.org/jira/browse/DDC-2624)
+-   [DDC-2624](https://github.com/doctrine/orm/issues/3357)
     -ManyToManyPersister fails to handle cloned PeristentCollections
--   [DDC-2652](http://www.doctrine-project.org/jira/browse/DDC-2652)
+-   [DDC-2652](https://github.com/doctrine/orm/issues/3388)
     -[\#777](https://github.com/doctrine/doctrine2/pull/777) Fixed
     typo in mapping documentation
--   [DDC-2653](http://www.doctrine-project.org/jira/browse/DDC-2653)
+-   [DDC-2653](https://github.com/doctrine/orm/issues/3389)
     -[\#778](https://github.com/doctrine/doctrine2/pull/778) Fixed
     typo in property mapping
--   [DDC-2654](http://www.doctrine-project.org/jira/browse/DDC-2654)
+-   [DDC-2654](https://github.com/doctrine/orm/issues/3390)
     -[\#779](https://github.com/doctrine/doctrine2/pull/779) Fixed
     grammar in custom data types
--   [DDC-2656](http://www.doctrine-project.org/jira/browse/DDC-2656)
+-   [DDC-2656](https://github.com/doctrine/orm/issues/3392)
     -[\#780](https://github.com/doctrine/doctrine2/pull/780)
-    [DCC-2655] Don't let getOneOrNullResult throw NoResultException
--   [DDC-2668](http://www.doctrine-project.org/jira/browse/DDC-2668)
+    [DDC-2655](https://github.com/doctrine/orm/issues/3391)
+    Don't let getOneOrNullResult throw NoResultException
+-   [DDC-2668](https://github.com/doctrine/orm/issues/3405)
     -DQL TRIM function is not converted into TRIM SQL correctly
--   [DDC-2673](http://www.doctrine-project.org/jira/browse/DDC-2673)
+-   [DDC-2673](https://github.com/doctrine/orm/issues/3411)
     -[\#785](https://github.com/doctrine/doctrine2/pull/785) Update
     dql-custom-walkers.rst
--   [DDC-2676](http://www.doctrine-project.org/jira/browse/DDC-2676)
+-   [DDC-2676](https://github.com/doctrine/orm/issues/3414)
     -[\#786](https://github.com/doctrine/doctrine2/pull/786) Minor
     updates while reading the basic-mapping page
--   [DDC-2678](http://www.doctrine-project.org/jira/browse/DDC-2678)
+-   [DDC-2678](https://github.com/doctrine/orm/issues/3416)
     -[\#787](https://github.com/doctrine/doctrine2/pull/787) Update
     DDC719Test.php to be compatible with MsSQL
--   [DDC-2681](http://www.doctrine-project.org/jira/browse/DDC-2681)
+-   [DDC-2681](https://github.com/doctrine/orm/issues/3420)
     -[\#790](https://github.com/doctrine/doctrine2/pull/790) HHVM
     compatibility: func\_get\_args
--   [DDC-2682](http://www.doctrine-project.org/jira/browse/DDC-2682)
+-   [DDC-2682](https://github.com/doctrine/orm/issues/3421)
     -[\#791](https://github.com/doctrine/doctrine2/pull/791)
     Implemented "contains" operator for Criteria expressions
--   [DDC-2683](http://www.doctrine-project.org/jira/browse/DDC-2683)
+-   [DDC-2683](https://github.com/doctrine/orm/issues/3422)
     -[\#792](https://github.com/doctrine/doctrine2/pull/792)
-    [DDC-2668](http://www.doctrine-project.org/jira/browse/DDC-2668)
+    [DDC-2668](https://github.com/doctrine/orm/issues/3405)
     Fix trim leading zero string
--   [DDC-2689](http://www.doctrine-project.org/jira/browse/DDC-2689)
+-   [DDC-2689](https://github.com/doctrine/orm/issues/3428)
     -Doctrine ORM test suite failing on MySQL
--   [DDC-2690](http://www.doctrine-project.org/jira/browse/DDC-2690)
+-   [DDC-2690](https://github.com/doctrine/orm/issues/3430)
     -Doctrine ORM test suite failing on PostgresSQL
--   [DDC-2696](http://www.doctrine-project.org/jira/browse/DDC-2696)
+-   [DDC-2696](https://github.com/doctrine/orm/issues/3436)
     -[\#795](https://github.com/doctrine/doctrine2/pull/795) Update
     query-builder.rst
--   [DDC-2699](http://www.doctrine-project.org/jira/browse/DDC-2699)
+-   [DDC-2699](https://github.com/doctrine/orm/issues/3439)
     -[\#797](https://github.com/doctrine/doctrine2/pull/797) CS fixes
--   [DDC-2700](http://www.doctrine-project.org/jira/browse/DDC-2700)
+-   [DDC-2700](https://github.com/doctrine/orm/issues/3442)
     -[\#798](https://github.com/doctrine/doctrine2/pull/798)
     Identifier can be empty for MappedSuperclasses
--   [DDC-2702](http://www.doctrine-project.org/jira/browse/DDC-2702)
+-   [DDC-2702](https://github.com/doctrine/orm/issues/3444)
     -[\#799](https://github.com/doctrine/doctrine2/pull/799) remove
     unused test case
--   [DDC-2704](http://www.doctrine-project.org/jira/browse/DDC-2704)
+-   [DDC-2704](https://github.com/doctrine/orm/issues/3446)
     -When using Discriminator EntityManager\#merge fails
--   [DDC-2706](http://www.doctrine-project.org/jira/browse/DDC-2706)
+-   [DDC-2706](https://github.com/doctrine/orm/issues/3448)
     -[\#801](https://github.com/doctrine/doctrine2/pull/801) Update
     SqlWalker.php fixed wrong GROUP BY clause on SQL Server platform
--   [DDC-2707](http://www.doctrine-project.org/jira/browse/DDC-2707)
+-   [DDC-2707](https://github.com/doctrine/orm/issues/3449)
     -[\#802](https://github.com/doctrine/doctrine2/pull/802) Respect
     unsigned fields when tables get converted to entities.
--   [DDC-2711](http://www.doctrine-project.org/jira/browse/DDC-2711)
+-   [DDC-2711](https://github.com/doctrine/orm/issues/3453)
     -[\#803](https://github.com/doctrine/doctrine2/pull/803) Appended
     newline to (newly) generated files for PSR2 compatibility
--   [DDC-2716](http://www.doctrine-project.org/jira/browse/DDC-2716)
+-   [DDC-2716](https://github.com/doctrine/orm/issues/3458)
     -[\#808](https://github.com/doctrine/doctrine2/pull/808) Second
     level cache
--   [DDC-2718](http://www.doctrine-project.org/jira/browse/DDC-2718)
+-   [DDC-2718](https://github.com/doctrine/orm/issues/3460)
     -[\#809](https://github.com/doctrine/doctrine2/pull/809) Fix
     DDC-1514 test
--   [DDC-2720](http://www.doctrine-project.org/jira/browse/DDC-2720)
+-   [DDC-2720](https://github.com/doctrine/orm/issues/3462)
     -[\#811](https://github.com/doctrine/doctrine2/pull/811) Update
     SingleScalarHydrator error message
--   [DDC-2722](http://www.doctrine-project.org/jira/browse/DDC-2722)
+-   [DDC-2722](https://github.com/doctrine/orm/issues/3464)
     -[\#812](https://github.com/doctrine/doctrine2/pull/812) [Doc] add
     direct links to dbal and dql documentation
--   [DDC-2728](http://www.doctrine-project.org/jira/browse/DDC-2728)
+-   [DDC-2728](https://github.com/doctrine/orm/issues/3470)
     -[\#815](https://github.com/doctrine/doctrine2/pull/815) Remove
     unused use statement
--   [DDC-2732](http://www.doctrine-project.org/jira/browse/DDC-2732)
+-   [DDC-2732](https://github.com/doctrine/orm/issues/3475)
     -[\#816](https://github.com/doctrine/doctrine2/pull/816) Options
     not respected for ID Fields in XML Mapping Driver
--   [DDC-2737](http://www.doctrine-project.org/jira/browse/DDC-2737)
+-   [DDC-2737](https://github.com/doctrine/orm/issues/3480)
     -[\#817](https://github.com/doctrine/doctrine2/pull/817) Removed
     "minimum-stability" : "dev" from composer.json
--   [DDC-2738](http://www.doctrine-project.org/jira/browse/DDC-2738)
+-   [DDC-2738](https://github.com/doctrine/orm/issues/3481)
     -[\#818](https://github.com/doctrine/doctrine2/pull/818) Clarified
     tutorial context in section introducing `orm:scehma-tool:*` commnads
--   [DDC-2740](http://www.doctrine-project.org/jira/browse/DDC-2740)
+-   [DDC-2740](https://github.com/doctrine/orm/issues/3484)
     -[\#819](https://github.com/doctrine/doctrine2/pull/819) Fixes a
     Fatal Error when using a subexpression in parenthesis
--   [DDC-2741](http://www.doctrine-project.org/jira/browse/DDC-2741)
+-   [DDC-2741](https://github.com/doctrine/orm/issues/3486)
     -[\#820](https://github.com/doctrine/doctrine2/pull/820) Added
     support for field options to FieldBuilder
--   [DDC-2750](http://www.doctrine-project.org/jira/browse/DDC-2750)
+-   [DDC-2750](https://github.com/doctrine/orm/issues/3495)
     -[\#822](https://github.com/doctrine/doctrine2/pull/822) DDC-2748
     DQL expression "in" not working with Collection
--   [DDC-2753](http://www.doctrine-project.org/jira/browse/DDC-2753)
+-   [DDC-2753](https://github.com/doctrine/orm/issues/3498)
     -[\#824](https://github.com/doctrine/doctrine2/pull/824)
     s/PostgreSQLPlatform/PostgreSqlPlatform/
--   [DDC-2757](http://www.doctrine-project.org/jira/browse/DDC-2757)
+-   [DDC-2757](https://github.com/doctrine/orm/issues/3502)
     -Manual transcation handling not possible when transaction fails,
     documentation gives wrong example
--   [DDC-2759](http://www.doctrine-project.org/jira/browse/DDC-2759)
+-   [DDC-2759](https://github.com/doctrine/orm/issues/3504)
     -ArrayHydration: Only first entity in OneToMany association is
     hydrated
--   [DDC-2760](http://www.doctrine-project.org/jira/browse/DDC-2760)
+-   [DDC-2760](https://github.com/doctrine/orm/issues/3506)
     -[\#827](https://github.com/doctrine/doctrine2/pull/827) Added a
     failing test case for DDC-2759.
--   [DDC-2764](http://www.doctrine-project.org/jira/browse/DDC-2764)
+-   [DDC-2764](https://github.com/doctrine/orm/issues/3510)
     -An orderBy on Criteria leads to DQL semantical error
--   [DDC-2765](http://www.doctrine-project.org/jira/browse/DDC-2765)
+-   [DDC-2765](https://github.com/doctrine/orm/issues/3511)
     -[\#830](https://github.com/doctrine/doctrine2/pull/830)
-    [DDC-2764](http://www.doctrine-project.org/jira/browse/DDC-2764)
+    [DDC-2764](https://github.com/doctrine/orm/issues/3510)
     Prefix criteria orderBy with rootAlias
--   [DDC-2769](http://www.doctrine-project.org/jira/browse/DDC-2769)
+-   [DDC-2769](https://github.com/doctrine/orm/issues/3515)
     -[\#832](https://github.com/doctrine/doctrine2/pull/832) Added
     "readOnly: true" to YAML reference
--   [DDC-2771](http://www.doctrine-project.org/jira/browse/DDC-2771)
+-   [DDC-2771](https://github.com/doctrine/orm/issues/3518)
     -[\#834](https://github.com/doctrine/doctrine2/pull/834) Add
     example use of repositoryClass in YAML
--   [DDC-2774](http://www.doctrine-project.org/jira/browse/DDC-2774)
+-   [DDC-2774](https://github.com/doctrine/orm/issues/3521)
     -[\#836](https://github.com/doctrine/doctrine2/pull/836) Update
     annotations-reference.rst
--   [DDC-2775](http://www.doctrine-project.org/jira/browse/DDC-2775)
+-   [DDC-2775](https://github.com/doctrine/orm/pull/837)
     -Bug with cascade remove
--   [DDC-2782](http://www.doctrine-project.org/jira/browse/DDC-2782)
+-   [DDC-2782](https://github.com/doctrine/orm/issues/3530)
     -[\#842](https://github.com/doctrine/doctrine2/pull/842) Added
     EntityManager query creation tests
--   [DDC-2790](http://www.doctrine-project.org/jira/browse/DDC-2790)
+-   [DDC-2790](https://github.com/doctrine/orm/issues/3539)
     -[\#845](https://github.com/doctrine/doctrine2/pull/845) Don't
     compute changeset for entities that are going to be deleted
--   [DDC-2792](http://www.doctrine-project.org/jira/browse/DDC-2792)
+-   [DDC-2792](https://github.com/doctrine/orm/issues/3541)
     -[\#846](https://github.com/doctrine/doctrine2/pull/846)
     joinColumn is not required in manyToMany
--   [DDC-2798](http://www.doctrine-project.org/jira/browse/DDC-2798)
+-   [DDC-2798](https://github.com/doctrine/orm/issues/3547)
     -[\#849](https://github.com/doctrine/doctrine2/pull/849) Error
     with Same Field, Multiple Values, Criteria and QueryBuilder
--   [DDC-2799](http://www.doctrine-project.org/jira/browse/DDC-2799)
+-   [DDC-2799](https://github.com/doctrine/orm/issues/3548)
     -[\#850](https://github.com/doctrine/doctrine2/pull/850) Event
     listener to programmatically attach entity listeners.
--   [DDC-2811](http://www.doctrine-project.org/jira/browse/DDC-2811)
+-   [DDC-2811](https://github.com/doctrine/orm/issues/3563)
     -[\#854](https://github.com/doctrine/doctrine2/pull/854) fix
     relative path to doctrine/common
--   [DDC-2812](http://www.doctrine-project.org/jira/browse/DDC-2812)
+-   [DDC-2812](https://github.com/doctrine/orm/issues/3564)
     -[\#856](https://github.com/doctrine/doctrine2/pull/856) Fix
     dependency for
     tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
--   [DDC-2827](http://www.doctrine-project.org/jira/browse/DDC-2827)
+-   [DDC-2827](https://github.com/doctrine/orm/issues/3580)
     -[\#864](https://github.com/doctrine/doctrine2/pull/864) Updated
     parser to support aggegrate functions in null comparisons
--   [DDC-2831](http://www.doctrine-project.org/jira/browse/DDC-2831)
+-   [DDC-2831](https://github.com/doctrine/orm/issues/3584)
     -[\#866](https://github.com/doctrine/doctrine2/pull/866)
     Mentioning the 'refresh' cascading property in the documentation
     list
--   [DDC-2843](http://www.doctrine-project.org/jira/browse/DDC-2843)
+-   [DDC-2843](https://github.com/doctrine/orm/issues/3597)
     -SchemaTool update SQL always contains queries to set default value
     on columns, even if they haven't changed.
--   [DDC-2847](http://www.doctrine-project.org/jira/browse/DDC-2847)
+-   [DDC-2847](https://github.com/doctrine/orm/issues/3601)
     -[\#871](https://github.com/doctrine/doctrine2/pull/871) XCache
     cannot be flushed on the CLI -\> for pretty much the same reason as
     APC
--   [DDC-2853](http://www.doctrine-project.org/jira/browse/DDC-2853)
+-   [DDC-2853](https://github.com/doctrine/orm/issues/3608)
     -[\#873](https://github.com/doctrine/doctrine2/pull/873) Try
     running unit tests on HHVM
--   [DDC-2855](http://www.doctrine-project.org/jira/browse/DDC-2855)
+-   [DDC-2855](https://github.com/doctrine/orm/issues/3610)
     -[\#875](https://github.com/doctrine/doctrine2/pull/875) Adding
     tests that confirm that DDC-2845 is fixed
--   [DDC-2856](http://www.doctrine-project.org/jira/browse/DDC-2856)
+-   [DDC-2856](https://github.com/doctrine/orm/issues/3611)
     -[\#876](https://github.com/doctrine/doctrine2/pull/876) Fixing
     wrong key for allowing HHVM failures
--   [DDC-2862](http://www.doctrine-project.org/jira/browse/DDC-2862)
+-   [DDC-2862](https://github.com/doctrine/orm/issues/3618)
     -When update cached entitiy, entity lost OneToOne relationship
--   [DDC-2866](http://www.doctrine-project.org/jira/browse/DDC-2866)
+-   [DDC-2866](https://github.com/doctrine/orm/issues/3622)
     -[\#883](https://github.com/doctrine/doctrine2/pull/883)
-    [DDC-2862](http://www.doctrine-project.org/jira/browse/DDC-2862)
+    [DDC-2862](https://github.com/doctrine/orm/issues/3618)
     Fix non initialized association proxy
--   [DDC-2867](http://www.doctrine-project.org/jira/browse/DDC-2867)
+-   [DDC-2867](https://github.com/doctrine/orm/issues/3623)
     -[\#884](https://github.com/doctrine/doctrine2/pull/884) [SLC] Fix
     cache misses using one-to-one inverse side
--   [DDC-2869](http://www.doctrine-project.org/jira/browse/DDC-2869)
+-   [DDC-2869](https://github.com/doctrine/orm/issues/3625)
     -[\#886](https://github.com/doctrine/doctrine2/pull/886)
-    [DDC-1256](http://www.doctrine-project.org/jira/browse/DDC-1256)
+    [DDC-1256](https://github.com/doctrine/orm/issues/1866)
     Fix applying ON/WITH conditions to first join in Class Table
     Inheritance
--   [DDC-2875](http://www.doctrine-project.org/jira/browse/DDC-2875)
+-   [DDC-2875](https://github.com/doctrine/orm/issues/3632)
     -[\#890](https://github.com/doctrine/doctrine2/pull/890)
     [DBAL-563] Add general IDENTITY generator type support for sequence
     emulating platforms
--   [DDC-2876](http://www.doctrine-project.org/jira/browse/DDC-2876)
+-   [DDC-2876](https://github.com/doctrine/orm/issues/3633)
     -[\#891](https://github.com/doctrine/doctrine2/pull/891) Allow to
     not generate extra use
--   [DDC-2878](http://www.doctrine-project.org/jira/browse/DDC-2878)
+-   [DDC-2878](https://github.com/doctrine/orm/issues/3635)
     -[\#893](https://github.com/doctrine/doctrine2/pull/893)
     autoGenerate arg from bool to int
--   [DDC-2880](http://www.doctrine-project.org/jira/browse/DDC-2880)
+-   [DDC-2880](https://github.com/doctrine/orm/issues/3638)
     -[\#894](https://github.com/doctrine/doctrine2/pull/894) Fix typos
     -QueryBuilder
--   [DDC-2884](http://www.doctrine-project.org/jira/browse/DDC-2884)
+-   [DDC-2884](https://github.com/doctrine/orm/issues/3641)
     -[\#896](https://github.com/doctrine/doctrine2/pull/896) Ensure
     elements preceed
--   [DDC-2885](http://www.doctrine-project.org/jira/browse/DDC-2885)
+-   [DDC-2885](https://github.com/doctrine/orm/issues/3642)
     -[\#897](https://github.com/doctrine/doctrine2/pull/897) Respected
     'inheritanceType' at Entity level
--   [DDC-2889](http://www.doctrine-project.org/jira/browse/DDC-2889)
+-   [DDC-2889](https://github.com/doctrine/orm/issues/3646)
     -[\#900](https://github.com/doctrine/doctrine2/pull/900) Fix
     connection mock fetchColumn signature
--   [DDC-2890](http://www.doctrine-project.org/jira/browse/DDC-2890)
+-   [DDC-2890](https://github.com/doctrine/orm/issues/3648)
     -Paginator generates invalid sql for some dql with
     setUseOutputWalkers(false) and \$fetchJoinCollection = true
--   [DDC-2903](http://www.doctrine-project.org/jira/browse/DDC-2903)
+-   [DDC-2903](https://github.com/doctrine/orm/issues/3662)
     -[\#906](https://github.com/doctrine/doctrine2/pull/906) removed
     erroneous tip
--   [DDC-2907](http://www.doctrine-project.org/jira/browse/DDC-2907)
+-   [DDC-2907](https://github.com/doctrine/orm/issues/3665)
     -[\#907](https://github.com/doctrine/doctrine2/pull/907)
-    [DDC-1632](http://www.doctrine-project.org/jira/browse/DDC-1632)
+    [DDC-1632](https://github.com/doctrine/orm/issues/2273)
     OneToMany Fetch eager
--   [DDC-2908](http://www.doctrine-project.org/jira/browse/DDC-2908)
+-   [DDC-2908](https://github.com/doctrine/orm/issues/3666)
     -[\#908](https://github.com/doctrine/doctrine2/pull/908)
-    [DDC-2862](http://www.doctrine-project.org/jira/browse/DDC-2862)
+    [DDC-2862](https://github.com/doctrine/orm/issues/3618)
     Fix lazy association load
--   [DDC-2913](http://www.doctrine-project.org/jira/browse/DDC-2913)
+-   [DDC-2913](https://github.com/doctrine/orm/issues/3672)
     -[\#909](https://github.com/doctrine/doctrine2/pull/909) Fix
     DatabaseDriverTest on SQL Server
--   [DDC-2914](http://www.doctrine-project.org/jira/browse/DDC-2914)
+-   [DDC-2914](https://github.com/doctrine/orm/issues/3673)
     -[\#910](https://github.com/doctrine/doctrine2/pull/910)
-    [DDC-2310](http://www.doctrine-project.org/jira/browse/DDC-2310)
+    [DDC-2310](https://github.com/doctrine/orm/issues/3014)
     Fix SQL generation on table lock hint capable platforms
--   [DDC-2916](http://www.doctrine-project.org/jira/browse/DDC-2916)
+-   [DDC-2916](https://github.com/doctrine/orm/issues/3675)
     -[\#911](https://github.com/doctrine/doctrine2/pull/911) fix
     foreach coding style
--   [DDC-2919](http://www.doctrine-project.org/jira/browse/DDC-2919)
+-   [DDC-2919](https://github.com/doctrine/orm/issues/3678)
     -LockMode::NONE evaluation inconsistencies in ORM
--   [DDC-2921](http://www.doctrine-project.org/jira/browse/DDC-2921)
+-   [DDC-2921](https://github.com/doctrine/orm/issues/3681)
     -[\#912](https://github.com/doctrine/doctrine2/pull/912) Avoid
     PersistentCollection::isEmpty() to fully load the collection.
--   [DDC-2931](http://www.doctrine-project.org/jira/browse/DDC-2931)
+-   [DDC-2931](https://github.com/doctrine/orm/issues/3692)
     -OneToOne self-referencing fails when loading referenced objects
--   [DDC-2933](http://www.doctrine-project.org/jira/browse/DDC-2933)
+-   [DDC-2933](https://github.com/doctrine/orm/issues/3694)
     -[\#917](https://github.com/doctrine/doctrine2/pull/917) DDC-2931
--   [DDC-2934](http://www.doctrine-project.org/jira/browse/DDC-2934)
+-   [DDC-2934](https://github.com/doctrine/orm/issues/3695)
     -[\#918](https://github.com/doctrine/doctrine2/pull/918) Fix use
     of function in OrderBy
--   [DDC-2935](http://www.doctrine-project.org/jira/browse/DDC-2935)
+-   [DDC-2935](https://github.com/doctrine/orm/issues/3696)
     -[\#919](https://github.com/doctrine/doctrine2/pull/919) tests for
     DDC-2890
--   [DDC-2937](http://www.doctrine-project.org/jira/browse/DDC-2937)
+-   [DDC-2937](https://github.com/doctrine/orm/issues/3700)
     -[\#920](https://github.com/doctrine/doctrine2/pull/920)
     SingleScalarHydrator reports ambiguous error.
--   [DDC-2943](http://www.doctrine-project.org/jira/browse/DDC-2943)
+-   [DDC-2943](https://github.com/doctrine/orm/issues/3705)
     -Paginator not work with second level cache in Doctrine 2.5
--   [DDC-2946](http://www.doctrine-project.org/jira/browse/DDC-2946)
+-   [DDC-2946](https://github.com/doctrine/orm/issues/3708)
     -[\#926](https://github.com/doctrine/doctrine2/pull/926)
     Feature/console em helper interface
--   [DDC-2947](http://www.doctrine-project.org/jira/browse/DDC-2947)
+-   [DDC-2947](https://github.com/doctrine/orm/issues/3709)
     -[\#927](https://github.com/doctrine/doctrine2/pull/927)
     s/EntityManager/EntityManagerInterface/ in a few places
--   [DDC-2948](http://www.doctrine-project.org/jira/browse/DDC-2948)
+-   [DDC-2948](https://github.com/doctrine/orm/issues/3710)
     -[\#928](https://github.com/doctrine/doctrine2/pull/928) Support
     PHPUnit 3.8+ Compatibility
--   [DDC-2952](http://www.doctrine-project.org/jira/browse/DDC-2952)
+-   [DDC-2952](https://github.com/doctrine/orm/issues/3715)
     -[\#932](https://github.com/doctrine/doctrine2/pull/932)
-    [DDC-2919](http://www.doctrine-project.org/jira/browse/DDC-2919)
+    [DDC-2919](https://github.com/doctrine/orm/issues/3678)
     Make lock mode usage consistent
--   [DDC-2956](http://www.doctrine-project.org/jira/browse/DDC-2956)
+-   [DDC-2956](https://github.com/doctrine/orm/issues/3719)
     -[\#934](https://github.com/doctrine/doctrine2/pull/934) faild
     test with multiple HINT\_CUSTOM\_TREE\_WALKERS
--   [DDC-2957](http://www.doctrine-project.org/jira/browse/DDC-2957)
+-   [DDC-2957](https://github.com/doctrine/orm/issues/3720)
     -[\#935](https://github.com/doctrine/doctrine2/pull/935) Remove
     incorrect (outdated) validation for public fields in SchemaValidator
--   [DDC-2958](http://www.doctrine-project.org/jira/browse/DDC-2958)
+-   [DDC-2958](https://github.com/doctrine/orm/issues/3721)
     -[\#936](https://github.com/doctrine/doctrine2/pull/936) Making
     testing dependencies explicit
--   [DDC-2961](http://www.doctrine-project.org/jira/browse/DDC-2961)
+-   [DDC-2961](https://github.com/doctrine/orm/issues/3725)
     -[\#938](https://github.com/doctrine/doctrine2/pull/938) Missing
     join-tables added in example
--   [DDC-2967](http://www.doctrine-project.org/jira/browse/DDC-2967)
+-   [DDC-2967](https://github.com/doctrine/orm/issues/3731)
     -[\#943](https://github.com/doctrine/doctrine2/pull/943) Validate
     embeddables do not contain other embeddables.
--   [DDC-2968](http://www.doctrine-project.org/jira/browse/DDC-2968)
+-   [DDC-2968](https://github.com/doctrine/orm/issues/3732)
     -[\#944](https://github.com/doctrine/doctrine2/pull/944) Fixed
     InputOption modes
--   [DDC-2969](http://www.doctrine-project.org/jira/browse/DDC-2969)
+-   [DDC-2969](https://github.com/doctrine/orm/issues/3733)
     -[\#945](https://github.com/doctrine/doctrine2/pull/945) Fix CS
--   [DDC-2971](http://www.doctrine-project.org/jira/browse/DDC-2971)
+-   [DDC-2971](https://github.com/doctrine/orm/issues/3736)
     -[\#947](https://github.com/doctrine/doctrine2/pull/947) Cleaned
     up further unused imports.
--   [DDC-2974](http://www.doctrine-project.org/jira/browse/DDC-2974)
+-   [DDC-2974](https://github.com/doctrine/orm/issues/3739)
     -[\#950](https://github.com/doctrine/doctrine2/pull/950) Can cache
     empty collections
--   [DDC-2975](http://www.doctrine-project.org/jira/browse/DDC-2975)
+-   [DDC-2975](https://github.com/doctrine/orm/issues/3740)
     -[\#951](https://github.com/doctrine/doctrine2/pull/951) More
     informational entity not found exception
--   [DDC-2976](http://www.doctrine-project.org/jira/browse/DDC-2976)
+-   [DDC-2976](https://github.com/doctrine/orm/issues/3741)
     -[\#952](https://github.com/doctrine/doctrine2/pull/952) Add
     DB-level onDelete CASCADE example
--   [DDC-2989](http://www.doctrine-project.org/jira/browse/DDC-2989)
+-   [DDC-2989](https://github.com/doctrine/orm/issues/3753)
     -ORM should allow custom index names for foreign associations.
--   [DDC-2996](http://www.doctrine-project.org/jira/browse/DDC-2996)
+-   [DDC-2996](https://github.com/doctrine/orm/issues/3760)
     -UnitOfWork::recomputeSingleEntityChangeSet() will not add a new
     change set
--   [DDC-2997](http://www.doctrine-project.org/jira/browse/DDC-2997)
+-   [DDC-2997](https://github.com/doctrine/orm/issues/3761)
     -[\#960](https://github.com/doctrine/doctrine2/pull/960) allow
     passing EntityManagerInterface when creating a HelperSet
--   [DDC-2998](http://www.doctrine-project.org/jira/browse/DDC-2998)
+-   [DDC-2998](https://github.com/doctrine/orm/issues/3762)
     -[\#961](https://github.com/doctrine/doctrine2/pull/961)
-    [DDC-2984](http://www.doctrine-project.org/jira/browse/DDC-2984)
+    [DDC-2984](https://github.com/doctrine/orm/issues/3748)
     Provide TestCase to reproduce bug
--   [DDC-3002](http://www.doctrine-project.org/jira/browse/DDC-3002)
+-   [DDC-3002](https://github.com/doctrine/orm/issues/3769)
     -[\#964](https://github.com/doctrine/doctrine2/pull/964)
-    [SLC][DDC-2943]([http://www.doctrine-project.org/jira/browse/DDC-2943](http://www.doctrine-project.org/jira/browse/DDC-2943))
-    Disable slc for pagination queries
--   [DDC-3003](http://www.doctrine-project.org/jira/browse/DDC-3003)
+    [DDC-2943](https://github.com/doctrine/orm/issues/3705)
+    [SLC] Disable slc for pagination queries
+-   [DDC-3003](https://github.com/doctrine/orm/issues/3770)
     -[\#965](https://github.com/doctrine/doctrine2/pull/965) [SLC] Add
     support for criteria
--   [DDC-3008](http://www.doctrine-project.org/jira/browse/DDC-3008)
+-   [DDC-3008](https://github.com/doctrine/orm/issues/3774)
     -[\#967](https://github.com/doctrine/doctrine2/pull/967) [SLC] Add
     query builder options
--   [DDC-3009](http://www.doctrine-project.org/jira/browse/DDC-3009)
+-   [DDC-3009](https://github.com/doctrine/orm/issues/3775)
     -[\#968](https://github.com/doctrine/doctrine2/pull/968) Test: Add
     failing test
--   [DDC-3010](http://www.doctrine-project.org/jira/browse/DDC-3010)
+-   [DDC-3010](https://github.com/doctrine/orm/issues/3777)
     -[\#969](https://github.com/doctrine/doctrine2/pull/969) [Doc]
     added note about Criteria limits on PersistentCollection
--   [DDC-3012](http://www.doctrine-project.org/jira/browse/DDC-3012)
+-   [DDC-3012](https://github.com/doctrine/orm/issues/3779)
     -[\#971](https://github.com/doctrine/doctrine2/pull/971) [SLC] Fix
     query association proxy
--   [DDC-3013](http://www.doctrine-project.org/jira/browse/DDC-3013)
+-   [DDC-3013](https://github.com/doctrine/orm/issues/3780)
     -[\#972](https://github.com/doctrine/doctrine2/pull/972)
     Capitalize @GeneratedValue (annotations-reference.rst)
--   [DDC-3015](http://www.doctrine-project.org/jira/browse/DDC-3015)
+-   [DDC-3015](https://github.com/doctrine/orm/issues/3782)
     -[\#974](https://github.com/doctrine/doctrine2/pull/974) [SLC]
     Resolve association cache entry
--   [DDC-3018](http://www.doctrine-project.org/jira/browse/DDC-3018)
+-   [DDC-3018](https://github.com/doctrine/orm/issues/3786)
     -DQL “NEW” Operator and Literal type "String"
--   [DDC-3021](http://www.doctrine-project.org/jira/browse/DDC-3021)
+-   [DDC-3021](https://github.com/doctrine/orm/issues/3789)
     -[\#976](https://github.com/doctrine/doctrine2/pull/976) Add cache
     invalidation strategy to AbstractQuery
--   [DDC-3023](http://www.doctrine-project.org/jira/browse/DDC-3023)
+-   [DDC-3023](https://github.com/doctrine/orm/issues/3791)
     -[\#977](https://github.com/doctrine/doctrine2/pull/977) Fix wrong
     annotation
--   [DDC-3028](http://www.doctrine-project.org/jira/browse/DDC-3028)
+-   [DDC-3028](https://github.com/doctrine/orm/issues/3796)
     -[\#978](https://github.com/doctrine/doctrine2/pull/978)
-    [DDC-2987](http://www.doctrine-project.org/jira/browse/DDC-2987)
+    [DDC-2987](https://github.com/doctrine/orm/issues/3751)
     Enable empty prefixes for inlined embeddable
--   [DDC-3033](http://www.doctrine-project.org/jira/browse/DDC-3033)
+-   [DDC-3033](https://github.com/doctrine/orm/issues/3802)
     -Regression in computeChangeSets (ManyToMany relation)
--   [DDC-3038](http://www.doctrine-project.org/jira/browse/DDC-3038)
+-   [DDC-3038](https://github.com/doctrine/orm/issues/3807)
     -[\#982](https://github.com/doctrine/doctrine2/pull/982) Failing
     Test (since commit 53a5a48aed7d87aa1533c0bcbd72e41b686527d8)
--   [DDC-3041](http://www.doctrine-project.org/jira/browse/DDC-3041)
+-   [DDC-3041](https://github.com/doctrine/orm/issues/3811)
     -[\#984](https://github.com/doctrine/doctrine2/pull/984) Use
     boolean values for 'unique' attribute
--   [DDC-3042](http://www.doctrine-project.org/jira/browse/DDC-3042)
+-   [DDC-3042](https://github.com/doctrine/orm/issues/3812)
     -select issue field names with numbers
--   [DDC-3045](http://www.doctrine-project.org/jira/browse/DDC-3045)
+-   [DDC-3045](https://github.com/doctrine/orm/issues/3815)
     -SQL Injection in Persister API
--   [DDC-3047](http://www.doctrine-project.org/jira/browse/DDC-3047)
+-   [DDC-3047](https://github.com/doctrine/orm/issues/3817)
     -XML Exporter driver does not export association fetch-mode
--   [DDC-3049](http://www.doctrine-project.org/jira/browse/DDC-3049)
+-   [DDC-3049](https://github.com/doctrine/orm/issues/3819)
     -[\#988](https://github.com/doctrine/doctrine2/pull/988) Exporter
     support for association fetch modes
--   [DDC-3054](http://www.doctrine-project.org/jira/browse/DDC-3054)
+-   [DDC-3054](https://github.com/doctrine/orm/issues/3825)
     -[\#991](https://github.com/doctrine/doctrine2/pull/991) Ability
     to define custom functions with callback instead of class name
--   [DDC-3058](http://www.doctrine-project.org/jira/browse/DDC-3058)
+-   [DDC-3058](https://github.com/doctrine/orm/issues/3829)
     -[\#993](https://github.com/doctrine/doctrine2/pull/993) Update
     JoinColumn.php
--   [DDC-3060](http://www.doctrine-project.org/jira/browse/DDC-3060)
+-   [DDC-3060](https://github.com/doctrine/orm/issues/3832)
     -[\#995](https://github.com/doctrine/doctrine2/pull/995) Allow
     cascaded clearing of associated Entities
--   [DDC-3061](http://www.doctrine-project.org/jira/browse/DDC-3061)
+-   [DDC-3061](https://github.com/doctrine/orm/issues/3833)
     -[\#996](https://github.com/doctrine/doctrine2/pull/996)
-    [DDC-3027](http://www.doctrine-project.org/jira/browse/DDC-3027)
+    [DDC-3027](https://github.com/doctrine/orm/issues/3795)
     Embedded in MappedSuperclass
--   [DDC-3065](http://www.doctrine-project.org/jira/browse/DDC-3065)
+-   [DDC-3065](https://github.com/doctrine/orm/issues/3837)
     -Generated 'IN' clause doesn't handle 'null' values (needs to add
     'IS NULL' check)
--   [DDC-3067](http://www.doctrine-project.org/jira/browse/DDC-3067)
+-   [DDC-3067](https://github.com/doctrine/orm/issues/3839)
     -[\#999](https://github.com/doctrine/doctrine2/pull/999) DDC-3065
     null value in in criteria support
--   [DDC-3069](http://www.doctrine-project.org/jira/browse/DDC-3069)
+-   [DDC-3069](https://github.com/doctrine/orm/issues/3841)
     -[\#1000](https://github.com/doctrine/doctrine2/pull/1000)
-    [DDC-3068](http://www.doctrine-project.org/jira/browse/DDC-3068)
+    [DDC-3068](https://github.com/doctrine/orm/issues/3840)
     EntityManager::find accept array of object as id
--   [DDC-3071](http://www.doctrine-project.org/jira/browse/DDC-3071)
+-   [DDC-3071](https://github.com/doctrine/orm/issues/3844)
     -[\#1002](https://github.com/doctrine/doctrine2/pull/1002) Fixed
     wrongly initialized property.
--   [DDC-3074](http://www.doctrine-project.org/jira/browse/DDC-3074)
+-   [DDC-3074](https://github.com/doctrine/orm/issues/3847)
     -[\#1004](https://github.com/doctrine/doctrine2/pull/1004) Removed
     all useless occurrence of require\_once TestInit.php
--   [DDC-3075](http://www.doctrine-project.org/jira/browse/DDC-3075)
+-   [DDC-3075](https://github.com/doctrine/orm/issues/3848)
     -[\#1005](https://github.com/doctrine/doctrine2/pull/1005) Added
     support of the subselect expressions into NEW expressions
--   [DDC-3078](http://www.doctrine-project.org/jira/browse/DDC-3078)
+-   [DDC-3078](https://github.com/doctrine/orm/issues/3851)
     -Doctrine::\_\_construct is in an interface
--   [DDC-3080](http://www.doctrine-project.org/jira/browse/DDC-3080)
+-   [DDC-3080](https://github.com/doctrine/orm/issues/3854)
     -[\#1008](https://github.com/doctrine/doctrine2/pull/1008)
     DDC-3078 SLC Cache interface ctor removal
--   [DDC-3081](http://www.doctrine-project.org/jira/browse/DDC-3081)
+-   [DDC-3081](https://github.com/doctrine/orm/issues/3855)
     -[\#1009](https://github.com/doctrine/doctrine2/pull/1009) HHVM
     compatibility
--   [DDC-3082](http://www.doctrine-project.org/jira/browse/DDC-3082)
+-   [DDC-3082](https://github.com/doctrine/orm/issues/3856)
     -[\#1010](https://github.com/doctrine/doctrine2/pull/1010) Fixed
     validation message
--   [DDC-3085](http://www.doctrine-project.org/jira/browse/DDC-3085)
+-   [DDC-3085](https://github.com/doctrine/orm/issues/3859)
     -NULL comparison are not supported for result variables in the
     HAVING clause
--   [DDC-3092](http://www.doctrine-project.org/jira/browse/DDC-3092)
+-   [DDC-3092](https://github.com/doctrine/orm/issues/3867)
     -[\#1012](https://github.com/doctrine/doctrine2/pull/1012) Ddc
     3078 slc cache interface ctor removal
--   [DDC-3093](http://www.doctrine-project.org/jira/browse/DDC-3093)
+-   [DDC-3093](https://github.com/doctrine/orm/issues/3868)
     -[\#1013](https://github.com/doctrine/doctrine2/pull/1013) Remove
     SimpleXmlElement hack
--   [DDC-3095](http://www.doctrine-project.org/jira/browse/DDC-3095)
+-   [DDC-3095](https://github.com/doctrine/orm/issues/3870)
     -[\#1014](https://github.com/doctrine/doctrine2/pull/1014) Update
     second level cache doc
--   [DDC-3100](http://www.doctrine-project.org/jira/browse/DDC-3100)
+-   [DDC-3100](https://github.com/doctrine/orm/issues/3876)
     -[\#1018](https://github.com/doctrine/doctrine2/pull/1018)
     DBAL-878 Wrong mapping type
--   [DDC-3103](http://www.doctrine-project.org/jira/browse/DDC-3103)
+-   [DDC-3103](https://github.com/doctrine/orm/issues/3879)
     -Is embedded class information in ClassMetadata is not stored when
     serializing.
--   [DDC-3106](http://www.doctrine-project.org/jira/browse/DDC-3106)
+-   [DDC-3106](https://github.com/doctrine/orm/issues/3882)
     -[\#1023](https://github.com/doctrine/doctrine2/pull/1023)
-    [DDC-3027](http://www.doctrine-project.org/jira/browse/DDC-3027)
+    [DDC-3027](https://github.com/doctrine/orm/issues/3795)
     Avoid duplicated mapping using Embedded in MappedSuperclass
--   [DDC-3107](http://www.doctrine-project.org/jira/browse/DDC-3107)
+-   [DDC-3107](https://github.com/doctrine/orm/issues/3883)
     -[\#1024](https://github.com/doctrine/doctrine2/pull/1024)
     [Persister] Remove the insertSql cache
--   [DDC-3108](http://www.doctrine-project.org/jira/browse/DDC-3108)
+-   [DDC-3108](https://github.com/doctrine/orm/issues/3884)
     -Criteria cannot reference a joined tables' fields when used with an
     ORM QueryBuilder
--   [DDC-3118](http://www.doctrine-project.org/jira/browse/DDC-3118)
+-   [DDC-3118](https://github.com/doctrine/orm/issues/3894)
     -[\#1028](https://github.com/doctrine/doctrine2/pull/1028) Add
     method getAssociationsByType to ClassMetadata
--   [DDC-3120](http://www.doctrine-project.org/jira/browse/DDC-3120)
+-   [DDC-3120](https://github.com/doctrine/orm/issues/3897)
     -Warning: Erroneous data format for unserializing PHP5.6+
--   [DDC-3123](http://www.doctrine-project.org/jira/browse/DDC-3123)
+-   [DDC-3123](https://github.com/doctrine/orm/issues/3898)
     -Extra updates are not cleaned after execution
--   [DDC-3124](http://www.doctrine-project.org/jira/browse/DDC-3124)
+-   [DDC-3124](https://github.com/doctrine/orm/issues/3901)
     -[\#1030](https://github.com/doctrine/doctrine2/pull/1030)
     DDC-3123 extra updates cleanup
--   [DDC-3129](http://www.doctrine-project.org/jira/browse/DDC-3129)
+-   [DDC-3129](https://github.com/doctrine/orm/issues/3906)
     -[\#1032](https://github.com/doctrine/doctrine2/pull/1032) Add
     support for optimized contains
--   [DDC-3143](http://www.doctrine-project.org/jira/browse/DDC-3143)
+-   [DDC-3143](https://github.com/doctrine/orm/issues/3922)
     -[\#1041](https://github.com/doctrine/doctrine2/pull/1041) Allow
     all EntityManagerInterface implementations
--   [DDC-3151](http://www.doctrine-project.org/jira/browse/DDC-3151)
+-   [DDC-3151](https://github.com/doctrine/orm/issues/3930)
     -[\#1048](https://github.com/doctrine/doctrine2/pull/1048) Fix
     typo in exception message
--   [DDC-3152](http://www.doctrine-project.org/jira/browse/DDC-3152)
+-   [DDC-3152](https://github.com/doctrine/orm/issues/3931)
     -Generating methods does not check for existing methods with
     different case
--   [DDC-3160](http://www.doctrine-project.org/jira/browse/DDC-3160)
+-   [DDC-3160](https://github.com/doctrine/orm/issues/3940)
     -Regression in reComputeSingleEntityChangeset
--   [DDC-3177](http://www.doctrine-project.org/jira/browse/DDC-3177)
+-   [DDC-3177](https://github.com/doctrine/orm/issues/3958)
     -[\#1063](https://github.com/doctrine/doctrine2/pull/1063)
     singularize variable name on add/remove methods for EntityGenerator
--   [DDC-3190](http://www.doctrine-project.org/jira/browse/DDC-3190)
+-   [DDC-3190](https://github.com/doctrine/orm/issues/3973)
     -[\#1071](https://github.com/doctrine/doctrine2/pull/1071)
     Setup::createConfiguration breaks Cache interface contract
--   [DDC-3191](http://www.doctrine-project.org/jira/browse/DDC-3191)
+-   [DDC-3191](https://github.com/doctrine/orm/issues/3974)
     -[\#1072](https://github.com/doctrine/doctrine2/pull/1072) Fix
     attempt of traversing bool in FileLockRegion
--   [DDC-3192](http://www.doctrine-project.org/jira/browse/DDC-3192)
+-   [DDC-3192](https://github.com/doctrine/orm/issues/3975)
     -Custom types do not get converted to PHP Value when result is
     gotten from custom query
--   [DDC-3198](http://www.doctrine-project.org/jira/browse/DDC-3198)
+-   [DDC-3198](https://github.com/doctrine/orm/issues/3981)
     -[\#1075](https://github.com/doctrine/doctrine2/pull/1075) Fixed
     query cache id generation: added platform to hash
--   [DDC-3199](http://www.doctrine-project.org/jira/browse/DDC-3199)
+-   [DDC-3199](https://github.com/doctrine/orm/issues/3982)
     -[\#1076](https://github.com/doctrine/doctrine2/pull/1076) Fix
     switch non-uniform syntax
--   [DDC-3210](http://www.doctrine-project.org/jira/browse/DDC-3210)
+-   [DDC-3210](https://github.com/doctrine/orm/issues/3996)
     -[\#1080](https://github.com/doctrine/doctrine2/pull/1080)
     possible fix for DDC-2021
--   [DDC-3214](http://www.doctrine-project.org/jira/browse/DDC-3214)
+-   [DDC-3214](https://github.com/doctrine/orm/issues/4000)
     -[\#1082](https://github.com/doctrine/doctrine2/pull/1082) added
     more informative error messages when invalid parameter count
--   [DDC-3223](http://www.doctrine-project.org/jira/browse/DDC-3223)
+-   [DDC-3223](https://github.com/doctrine/orm/issues/4010)
     -Failing test (get id return string type)
--   [DDC-3225](http://www.doctrine-project.org/jira/browse/DDC-3225)
+-   [DDC-3225](https://github.com/doctrine/orm/issues/4012)
     -[\#1087](https://github.com/doctrine/doctrine2/pull/1087) Remove
     the error control operator
--   [DDC-3227](http://www.doctrine-project.org/jira/browse/DDC-3227)
+-   [DDC-3227](https://github.com/doctrine/orm/issues/4014)
     -[\#1088](https://github.com/doctrine/doctrine2/pull/1088) Fix the
     composer autoload paths for the doctrine CLT
--   [DDC-3233](http://www.doctrine-project.org/jira/browse/DDC-3233)
+-   [DDC-3233](https://github.com/doctrine/orm/issues/4021)
     -[\#1092](https://github.com/doctrine/doctrine2/pull/1092)
     Arbitrary Join count walkers solution
--   [DDC-3237](http://www.doctrine-project.org/jira/browse/DDC-3237)
+-   [DDC-3237](https://github.com/doctrine/orm/issues/4025)
     -[\#1096](https://github.com/doctrine/doctrine2/pull/1096) Changes
     for grammar and clarity
--   [DDC-3239](http://www.doctrine-project.org/jira/browse/DDC-3239)
+-   [DDC-3239](https://github.com/doctrine/orm/pull/1097)
     -[\#1097](https://github.com/doctrine/doctrine2/pull/1097)
     `expandParameters`/`getType` in BasicEntityPersister seems to really
     cover just few cases
--   [DDC-3240](http://www.doctrine-project.org/jira/browse/DDC-3240)
+-   [DDC-3240](https://github.com/doctrine/orm/issues/4028)
     -[\#1098](https://github.com/doctrine/doctrine2/pull/1098)
     \#DDC-1590: Fix Inheritance in Code-Generation
--   [DDC-3254](http://www.doctrine-project.org/jira/browse/DDC-3254)
+-   [DDC-3254](https://github.com/doctrine/orm/issues/4043)
     -[\#1111](https://github.com/doctrine/doctrine2/pull/1111) Fix
     inheritance hierarchy wrong exception message
--   [DDC-3269](http://www.doctrine-project.org/jira/browse/DDC-3269)
+-   [DDC-3269](https://github.com/doctrine/orm/issues/4058)
     -[\#1120](https://github.com/doctrine/doctrine2/pull/1120)
-    [DDC-3205](http://www.doctrine-project.org/jira/browse/DDC-3205)
+    [DDC-3205](https://github.com/doctrine/orm/issues/3990)
     Metadata info
--   [DDC-3272](http://www.doctrine-project.org/jira/browse/DDC-3272)
+-   [DDC-3272](https://github.com/doctrine/orm/issues/4062)
     -EntityGenerator writes 'MappedSuperClass' instead of
     'MappedSuperclass'
--   [DDC-3278](http://www.doctrine-project.org/jira/browse/DDC-3278)
+-   [DDC-3278](https://github.com/doctrine/orm/issues/4068)
     -[\#1123](https://github.com/doctrine/doctrine2/pull/1123) Fixed
     the structure of the reverse-engineered mapping
--   [DDC-3283](http://www.doctrine-project.org/jira/browse/DDC-3283)
+-   [DDC-3283](https://github.com/doctrine/orm/issues/4074)
     -[\#1125](https://github.com/doctrine/doctrine2/pull/1125) Update
     improving-performance.rst
--   [DDC-3288](http://www.doctrine-project.org/jira/browse/DDC-3288)
+-   [DDC-3288](https://github.com/doctrine/orm/issues/4079)
     -[\#1126](https://github.com/doctrine/doctrine2/pull/1126) Fixed
     new line in docblock
--   [DDC-3293](http://www.doctrine-project.org/jira/browse/DDC-3293)
+-   [DDC-3293](https://github.com/doctrine/orm/issues/4085)
     -XML Mappings disallow disabling column prefix for embeddables
--   [DDC-3302](http://www.doctrine-project.org/jira/browse/DDC-3302)
+-   [DDC-3302](https://github.com/doctrine/orm/issues/4096)
     -[\#1132](https://github.com/doctrine/doctrine2/pull/1132)
     DDC-3272 entity generator mapped superclass casing
--   [DDC-3310](http://www.doctrine-project.org/jira/browse/DDC-3310)
+-   [DDC-3310](https://github.com/doctrine/orm/issues/4105)
     -[\#1138](https://github.com/doctrine/doctrine2/pull/1138) Join
     column index names
--   [DDC-3318](http://www.doctrine-project.org/jira/browse/DDC-3318)
+-   [DDC-3318](https://github.com/doctrine/orm/issues/4113)
     -[\#1143](https://github.com/doctrine/doctrine2/pull/1143) Fixed a
     bug so that a versioned entity with a oneToOne id can be created
--   [DDC-3322](http://www.doctrine-project.org/jira/browse/DDC-3322)
+-   [DDC-3322](https://github.com/doctrine/orm/issues/4118)
     -[\#1146](https://github.com/doctrine/doctrine2/pull/1146) Allow
     orderBy to reference associations
--   [DDC-3336](http://www.doctrine-project.org/jira/browse/DDC-3336)
+-   [DDC-3336](https://github.com/doctrine/orm/issues/4133)
     -Undefined property: Doctrine::\$field
--   [DDC-3341](http://www.doctrine-project.org/jira/browse/DDC-3341)
+-   [DDC-3341](https://github.com/doctrine/orm/issues/4139)
     -SessionValidator gives an error message on orderBy association, but
     it is no error.
--   [DDC-3343](http://www.doctrine-project.org/jira/browse/DDC-3343)
+-   [DDC-3343](https://github.com/doctrine/orm/issues/4141)
     -`PersistentCollection::removeElement` schedules an entity for
     deletion when relationship is EXTRA\_LAZY, with `orphanRemoval`
     false.
--   [DDC-3346](http://www.doctrine-project.org/jira/browse/DDC-3346)
+-   [DDC-3346](https://github.com/doctrine/orm/issues/4144)
     -findOneBy returns an object with partial collection for the
     properties with mapping oneToMany/Fetch Eager
--   [DDC-3350](http://www.doctrine-project.org/jira/browse/DDC-3350)
+-   [DDC-3350](https://github.com/doctrine/orm/issues/4149)
     -[\#1160](https://github.com/doctrine/doctrine2/pull/1160) \#1159
     -multiple entity managers per repository factory should be supported
--   [DDC-3355](http://www.doctrine-project.org/jira/browse/DDC-3355)
+-   [DDC-3355](https://github.com/doctrine/orm/issues/4154)
     -[\#1164](https://github.com/doctrine/doctrine2/pull/1164)
     [QueryBuilder] Remove unused method parameters to run on HHVM/PHP7
--   [DDC-3358](http://www.doctrine-project.org/jira/browse/DDC-3358)
+-   [DDC-3358](https://github.com/doctrine/orm/issues/4157)
     -[\#1166](https://github.com/doctrine/doctrine2/pull/1166) Fixing
     HHVM+XSD validation tests as of documented HHVM inconsistencies
--   [DDC-3368](http://www.doctrine-project.org/jira/browse/DDC-3368)
+-   [DDC-3368](https://github.com/doctrine/orm/issues/4168)
     -[\#1172](https://github.com/doctrine/doctrine2/pull/1172) Don't
     initialize detached proxies when merging them.
--   [DDC-3370](http://www.doctrine-project.org/jira/browse/DDC-3370)
+-   [DDC-3370](https://github.com/doctrine/orm/issues/4171)
     -[\#1173](https://github.com/doctrine/doctrine2/pull/1173) Fix
     merging of entities with associations to identical entities.
--   [DDC-3378](http://www.doctrine-project.org/jira/browse/DDC-3378)
+-   [DDC-3378](https://github.com/doctrine/orm/issues/4179)
     -[\#1176](https://github.com/doctrine/doctrine2/pull/1176) Support
     merging entities with composite identities defined through to-one
     associations
--   [DDC-3379](http://www.doctrine-project.org/jira/browse/DDC-3379)
+-   [DDC-3379](https://github.com/doctrine/orm/issues/4180)
     -[\#1177](https://github.com/doctrine/doctrine2/pull/1177) Ensure
     metadata cache is not ArrayCache in production
--   [DDC-3380](http://www.doctrine-project.org/jira/browse/DDC-3380)
+-   [DDC-3380](https://github.com/doctrine/orm/issues/4182)
     -[\#1178](https://github.com/doctrine/doctrine2/pull/1178) Fixing
     associations using UUIDs
--   [DDC-3387](http://www.doctrine-project.org/jira/browse/DDC-3387)
+-   [DDC-3387](https://github.com/doctrine/orm/issues/4189)
     -[\#1182](https://github.com/doctrine/doctrine2/pull/1182) \#1086
     identifier type in proxies
--   [DDC-3394](http://www.doctrine-project.org/jira/browse/DDC-3394)
+-   [DDC-3394](https://github.com/doctrine/orm/issues/4197)
     -UOW CreateEntity failure with zerofill columns
--   [DDC-3404](http://www.doctrine-project.org/jira/browse/DDC-3404)
+-   [DDC-3404](https://github.com/doctrine/orm/issues/4208)
     -[\#1188](https://github.com/doctrine/doctrine2/pull/1188) Fixed
     counting exception
--   [DDC-3419](http://www.doctrine-project.org/jira/browse/DDC-3419)
+-   [DDC-3419](https://github.com/doctrine/orm/issues/4224)
     -[\#1196](https://github.com/doctrine/doctrine2/pull/1196) Inherit
     indexes from mapped superclass
--   [DDC-3425](http://www.doctrine-project.org/jira/browse/DDC-3425)
+-   [DDC-3425](https://github.com/doctrine/orm/issues/4231)
     -[\#1202](https://github.com/doctrine/doctrine2/pull/1202) Checks
     key exists rather than isset
--   [DDC-3427](http://www.doctrine-project.org/jira/browse/DDC-3427)
+-   [DDC-3427](https://github.com/doctrine/orm/issues/4233)
     -Doctrineexplicitly accepts EntityManager
--   [DDC-3428](http://www.doctrine-project.org/jira/browse/DDC-3428)
+-   [DDC-3428](https://github.com/doctrine/orm/issues/4234)
     -[\#1204](https://github.com/doctrine/doctrine2/pull/1204) Fix
     sequence-generator in MetaData exporter for XML Driver.
--   [DDC-3429](http://www.doctrine-project.org/jira/browse/DDC-3429)
+-   [DDC-3429](https://github.com/doctrine/orm/issues/4235)
     -[\#1205](https://github.com/doctrine/doctrine2/pull/1205) Hotfix
     -\#1200 symfony 2.7 deprecation fixes
--   [DDC-3430](http://www.doctrine-project.org/jira/browse/DDC-3430)
+-   [DDC-3430](https://github.com/doctrine/orm/issues/4237)
     -[\#1206](https://github.com/doctrine/doctrine2/pull/1206)
     matching should not change critera
--   [DDC-3431](http://www.doctrine-project.org/jira/browse/DDC-3431)
+-   [DDC-3431](https://github.com/doctrine/orm/issues/4238)
     -[\#1207](https://github.com/doctrine/doctrine2/pull/1207)
     Embedded classes reflection new instance creation with internal PHP
     classes
--   [DDC-3432](http://www.doctrine-project.org/jira/browse/DDC-3432)
+-   [DDC-3432](https://github.com/doctrine/orm/issues/4239)
     -[\#1208](https://github.com/doctrine/doctrine2/pull/1208)
     DDC-3427
     - class metadata factory should accept `EntityManagerInterface`
     instances
--   [DDC-3433](http://www.doctrine-project.org/jira/browse/DDC-3433)
+-   [DDC-3433](https://github.com/doctrine/orm/issues/4240)
     -[\#1210](https://github.com/doctrine/doctrine2/pull/1210)
     DDC-3336
     - undefined property with paginator walker and scalar expression in
     ORDER BY clause
--   [DDC-3434](http://www.doctrine-project.org/jira/browse/DDC-3434)
+-   [DDC-3434](https://github.com/doctrine/orm/issues/4241)
     -LimitSubqueryOutputWalker does not retain correct ORDER BY
     expression fields when dealing with HIDDEN sort fields
--   [DDC-3435](http://www.doctrine-project.org/jira/browse/DDC-3435)
+-   [DDC-3435](https://github.com/doctrine/orm/issues/4242)
     -[\#1211](https://github.com/doctrine/doctrine2/pull/1211)
     DDC-3434
     - paginator ignores `HIDDEN` fields in `ORDER BY` query
--   [DDC-3436](http://www.doctrine-project.org/jira/browse/DDC-3436)
+-   [DDC-3436](https://github.com/doctrine/orm/issues/4243)
     -[\#1212](https://github.com/doctrine/doctrine2/pull/1212)
-    [DDC-3108](http://www.doctrine-project.org/jira/browse/DDC-3108)
+    [DDC-3108](https://github.com/doctrine/orm/issues/3884)
     Fix regression where join aliases were no longer accessible in
     Criteria expressions
--   [DDC-3437](http://www.doctrine-project.org/jira/browse/DDC-3437)
+-   [DDC-3437](https://github.com/doctrine/orm/issues/4244)
     -[\#1213](https://github.com/doctrine/doctrine2/pull/1213) fix
     instantiation of embedded object in ReflectionEmbeddedProperty
--   [DDC-3439](http://www.doctrine-project.org/jira/browse/DDC-3439)
+-   [DDC-3439](https://github.com/doctrine/orm/issues/4246)
     -[\#1216](https://github.com/doctrine/doctrine2/pull/1216) test
     XML export driver, the field options, for \#1214
--   [DDC-3452](http://www.doctrine-project.org/jira/browse/DDC-3452)
+-   [DDC-3452](https://github.com/doctrine/orm/issues/4261)
     -[\#1222](https://github.com/doctrine/doctrine2/pull/1222)
     Embeddables in metadata builder
--   [DDC-3454](http://www.doctrine-project.org/jira/browse/DDC-3454)
+-   [DDC-3454](https://github.com/doctrine/orm/issues/4263)
     -[\#1224](https://github.com/doctrine/doctrine2/pull/1224) Updated
     setParameters function for not replace all parameters
--   [DDC-3466](http://www.doctrine-project.org/jira/browse/DDC-3466)
+-   [DDC-3466](https://github.com/doctrine/orm/issues/4276)
     -[\#1233](https://github.com/doctrine/doctrine2/pull/1233) [Minor]
     Refactoring to avoid duplicate code
--   [DDC-3470](http://www.doctrine-project.org/jira/browse/DDC-3470)
+-   [DDC-3470](https://github.com/doctrine/orm/issues/4280)
     -[\#1235](https://github.com/doctrine/doctrine2/pull/1235)
     Consistent return type confirming with interface
--   [DDC-3478](http://www.doctrine-project.org/jira/browse/DDC-3478)
+-   [DDC-3478](https://github.com/doctrine/orm/issues/4288)
     -[\#1239](https://github.com/doctrine/doctrine2/pull/1239) Fix
     index duplication for unique association join columns
--   [DDC-3482](http://www.doctrine-project.org/jira/browse/DDC-3482)
+-   [DDC-3482](https://github.com/doctrine/orm/issues/4293)
     -[\#1242](https://github.com/doctrine/doctrine2/pull/1242)
     Attempting to lock a proxy object fails as UOW doesn't init proxy
     first
--   [DDC-3493](http://www.doctrine-project.org/jira/browse/DDC-3493)
+-   [DDC-3493](https://github.com/doctrine/orm/issues/4305)
     -New (PHP 5.5) "class" keyword - wrong parsing by EntityGenerator
--   [DDC-3494](http://www.doctrine-project.org/jira/browse/DDC-3494)
+-   [DDC-3494](https://github.com/doctrine/orm/issues/4306)
     -[\#1250](https://github.com/doctrine/doctrine2/pull/1250) Test
     case for "class" keyword
--   [DDC-3502](http://www.doctrine-project.org/jira/browse/DDC-3502)
+-   [DDC-3502](https://github.com/doctrine/orm/issues/4316)
     -[\#1256](https://github.com/doctrine/doctrine2/pull/1256)
     DDC-3493
     - fixed EntityGenerator parsing for php 5.5 "::class" syntax
--   [DDC-3506](http://www.doctrine-project.org/jira/browse/DDC-3506)
+-   [DDC-3506](https://github.com/doctrine/orm/issues/4320)
     -[\#1259](https://github.com/doctrine/doctrine2/pull/1259) Hotfix:
     Cache region should not mutate injected cache instance settings
--   [DDC-3513](http://www.doctrine-project.org/jira/browse/DDC-3513)
+-   [DDC-3513](https://github.com/doctrine/orm/issues/4327)
     -[\#1262](https://github.com/doctrine/doctrine2/pull/1262) Fixes
     the broken DQL command
--   [DDC-3517](http://www.doctrine-project.org/jira/browse/DDC-3517)
+-   [DDC-3517](https://github.com/doctrine/orm/issues/4331)
     -[\#1265](https://github.com/doctrine/doctrine2/pull/1265) Fix
     error undefined index "targetEntity" in persister
--   [DDC-3524](http://www.doctrine-project.org/jira/browse/DDC-3524)
+-   [DDC-3524](https://github.com/doctrine/orm/issues/4339)
     -[\#1272](https://github.com/doctrine/doctrine2/pull/1272)
-    [DDC-2704](http://www.doctrine-project.org/jira/browse/DDC-2704)
+    [DDC-2704](https://github.com/doctrine/orm/issues/3446)
     -merge inherited transient properties - merge properties into
     uninitialized proxies
--   [DDC-3534](http://www.doctrine-project.org/jira/browse/DDC-3534)
+-   [DDC-3534](https://github.com/doctrine/orm/issues/4352)
     -[\#1280](https://github.com/doctrine/doctrine2/pull/1280)
-    [DDC-3346](http://www.doctrine-project.org/jira/browse/DDC-3346)
+    [DDC-3346](https://github.com/doctrine/orm/issues/4144)
     \#1277 find one with eager loads is failing
--   [DDC-3536](http://www.doctrine-project.org/jira/browse/DDC-3536)
+-   [DDC-3536](https://github.com/doctrine/orm/issues/4349)
     -[\#1281](https://github.com/doctrine/doctrine2/pull/1281)
     Hotfix/\#1169 extra lazy one to many should not delete referenced
     entities
--   [DDC-3538](http://www.doctrine-project.org/jira/browse/DDC-3538)
+-   [DDC-3538](https://github.com/doctrine/orm/issues/4355)
     -[\#1283](https://github.com/doctrine/doctrine2/pull/1283) \#1267
     -order by broken in pagination logic (reverts \#1220)
--   [DDC-3544](http://www.doctrine-project.org/jira/browse/DDC-3544)
+-   [DDC-3544](https://github.com/doctrine/orm/issues/4361)
     -[\#1288](https://github.com/doctrine/doctrine2/pull/1288) Hotfix
     -\#1169 - extra lazy one to many must be no-op when not doing orphan
     removal
--   [DDC-3551](http://www.doctrine-project.org/jira/browse/DDC-3551)
+-   [DDC-3551](https://github.com/doctrine/orm/issues/4369)
     -[\#1294](https://github.com/doctrine/doctrine2/pull/1294) Avoid
     Connection error when calling ClassMetadataFactor::getAllMetadata()
--   [DDC-3554](http://www.doctrine-project.org/jira/browse/DDC-3554)
+-   [DDC-3554](https://github.com/doctrine/orm/issues/4372)
     -[\#1295](https://github.com/doctrine/doctrine2/pull/1295) Fix
     join when recreation of query from parts.
--   [DDC-3564](http://www.doctrine-project.org/jira/browse/DDC-3564)
+-   [DDC-3564](https://github.com/doctrine/orm/issues/4383)
     -[\#1301](https://github.com/doctrine/doctrine2/pull/1301) Add
     failing test with ToOne SL2 association
--   [DDC-3566](http://www.doctrine-project.org/jira/browse/DDC-3566)
+-   [DDC-3566](https://github.com/doctrine/orm/issues/4385)
     -[\#1302](https://github.com/doctrine/doctrine2/pull/1302) Store
     column values of not cache-able associations
--   [DDC-3585](http://www.doctrine-project.org/jira/browse/DDC-3585)
+-   [DDC-3585](https://github.com/doctrine/orm/issues/4406)
     -[\#1311](https://github.com/doctrine/doctrine2/pull/1311)
-    [DDC-3582](http://www.doctrine-project.org/jira/browse/DDC-3582)
+    [DDC-3582](https://github.com/doctrine/orm/issues/4403)
     Wrong class is instantiated when using nested embeddables
--   [DDC-3586](http://www.doctrine-project.org/jira/browse/DDC-3586)
+-   [DDC-3586](https://github.com/doctrine/orm/issues/4407)
     -[\#1312](https://github.com/doctrine/doctrine2/pull/1312) Add
     proper pluralization into UpdateCommand
--   [DDC-3587](http://www.doctrine-project.org/jira/browse/DDC-3587)
+-   [DDC-3587](https://github.com/doctrine/orm/issues/4408)
     -[\#1313](https://github.com/doctrine/doctrine2/pull/1313) Added
     programmatical support to define indexBy on root aliases.
--   [DDC-3597](http://www.doctrine-project.org/jira/browse/DDC-3597)
+-   [DDC-3597](https://github.com/doctrine/orm/issues/4419)
     -[\#1321](https://github.com/doctrine/doctrine2/pull/1321)
     embeddedClasses support in mapped superclasses
--   [DDC-3606](http://www.doctrine-project.org/jira/browse/DDC-3606)
+-   [DDC-3606](https://github.com/doctrine/orm/issues/4430)
     -[\#1325](https://github.com/doctrine/doctrine2/pull/1325) fixed
     PostgreSQL and Oracle pagination issues
--   [DDC-3608](http://www.doctrine-project.org/jira/browse/DDC-3608)
+-   [DDC-3608](https://github.com/doctrine/orm/issues/4432)
     -[\#1327](https://github.com/doctrine/doctrine2/pull/1327)
     Properly generate default value from yml & xml mapping
--   [DDC-3616](http://www.doctrine-project.org/jira/browse/DDC-3616)
+-   [DDC-3616](https://github.com/doctrine/orm/issues/4441)
     -[\#1333](https://github.com/doctrine/doctrine2/pull/1333) Allow
     DateTimeImmutable as parameter value
--   [DDC-3619](http://www.doctrine-project.org/jira/browse/DDC-3619)
+-   [DDC-3619](https://github.com/doctrine/orm/issues/4444)
     -spl\_object\_hash collision
--   [DDC-3622](http://www.doctrine-project.org/jira/browse/DDC-3622)
+-   [DDC-3622](https://github.com/doctrine/orm/issues/4448)
     -[\#1336](https://github.com/doctrine/doctrine2/pull/1336) Fix UoW
     warning with custom id object types
--   [DDC-3623](http://www.doctrine-project.org/jira/browse/DDC-3623)
+-   [DDC-3623](https://github.com/doctrine/orm/issues/4449)
     -[\#1337](https://github.com/doctrine/doctrine2/pull/1337)
     Paginator OrderBy fix take 2
--   [DDC-3624](http://www.doctrine-project.org/jira/browse/DDC-3624)
+-   [DDC-3624](https://github.com/doctrine/orm/issues/4450)
     -[\#1338](https://github.com/doctrine/doctrine2/pull/1338)
-    [DDC-3619](http://www.doctrine-project.org/jira/browse/DDC-3619)
+    [DDC-3619](https://github.com/doctrine/orm/issues/4444)
     Update identityMap when entity gets managed again
--   [DDC-3625](http://www.doctrine-project.org/jira/browse/DDC-3625)
+-   [DDC-3625](https://github.com/doctrine/orm/issues/4451)
     -[\#1339](https://github.com/doctrine/doctrine2/pull/1339)
-    [DDC-2224](http://www.doctrine-project.org/jira/browse/DDC-2224)
+    [DDC-2224](https://github.com/doctrine/orm/issues/2922)
     Honor convertToDatabaseValueSQL() in DQL query parameters
--   [DDC-3629](http://www.doctrine-project.org/jira/browse/DDC-3629)
+-   [DDC-3629](https://github.com/doctrine/orm/issues/4455)
     -[\#1342](https://github.com/doctrine/doctrine2/pull/1342)
     Paginator functional tests
--   [DDC-3631](http://www.doctrine-project.org/jira/browse/DDC-3631)
+-   [DDC-3631](https://github.com/doctrine/orm/issues/4458)
     -[\#1344](https://github.com/doctrine/doctrine2/pull/1344) Fix
     tests for SLC console commands failing due to console output
     decoration
--   [DDC-3632](http://www.doctrine-project.org/jira/browse/DDC-3632)
+-   [DDC-3632](https://github.com/doctrine/orm/issues/4459)
     -[\#1345](https://github.com/doctrine/doctrine2/pull/1345) Fix
     crashes in ConvertMappingCommand and GenerateEntitiesCommand...
--   [DDC-3634](http://www.doctrine-project.org/jira/browse/DDC-3634)
+-   [DDC-3634](https://github.com/doctrine/orm/issues/4461)
     -[\#1346](https://github.com/doctrine/doctrine2/pull/1346) Fix:
     generated IDs are converted to integer
--   [DDC-3641](http://www.doctrine-project.org/jira/browse/DDC-3641)
+-   [DDC-3641](https://github.com/doctrine/orm/issues/4469)
     -[\#1350](https://github.com/doctrine/doctrine2/pull/1350)
     Assigned default value to array
--   [DDC-3643](http://www.doctrine-project.org/jira/browse/DDC-3643)
+-   [DDC-3643](https://github.com/doctrine/orm/issues/4471)
     -[\#1352](https://github.com/doctrine/doctrine2/pull/1352) fix
     EntityGenerator RegenerateEntityIfExists
--   [DDC-3645](http://www.doctrine-project.org/jira/browse/DDC-3645)
+-   [DDC-3645](https://github.com/doctrine/orm/issues/4473)
     -[\#1353](https://github.com/doctrine/doctrine2/pull/1353)
     Paginator fixes take3
--   [DDC-3650](http://www.doctrine-project.org/jira/browse/DDC-3650)
+-   [DDC-3650](https://github.com/doctrine/orm/issues/4479)
     -[\#1357](https://github.com/doctrine/doctrine2/pull/1357) Drop
     useless execution bit
 
 Documentation
 -------------
 
--   [DDC-2510](http://www.doctrine-project.org/jira/browse/DDC-2510)
+-   [DDC-2510](https://github.com/doctrine/orm/issues/3233)
     -[\#700](https://github.com/doctrine/doctrine2/pull/700) Update
     getting-started.rst
--   [DDC-2511](http://www.doctrine-project.org/jira/browse/DDC-2511)
+-   [DDC-2511](https://github.com/doctrine/orm/issues/3234)
     -[\#701](https://github.com/doctrine/doctrine2/pull/701)
     list\_bugs.php needs to call to getters for protected vars
--   [DDC-2549](http://www.doctrine-project.org/jira/browse/DDC-2549)
+-   [DDC-2549](https://github.com/doctrine/orm/issues/3274)
     -[\#721](https://github.com/doctrine/doctrine2/pull/721) Updated
     batch-processing link extension
--   [DDC-2553](http://www.doctrine-project.org/jira/browse/DDC-2553)
+-   [DDC-2553](https://github.com/doctrine/orm/issues/3280)
     -[\#723](https://github.com/doctrine/doctrine2/pull/723) Remove
     extra semicolon before -\>setParameter() calls
--   [DDC-2571](http://www.doctrine-project.org/jira/browse/DDC-2571)
+-   [DDC-2571](https://github.com/doctrine/orm/issues/3299)
     -[\#734](https://github.com/doctrine/doctrine2/pull/734) Cleaned
     up documentation
--   [DDC-2620](http://www.doctrine-project.org/jira/browse/DDC-2620)
+-   [DDC-2620](https://github.com/doctrine/orm/issues/3353)
     -[\#762](https://github.com/doctrine/doctrine2/pull/762) YAML
     mapping documentation of uniqueConstraint
--   [DDC-2755](http://www.doctrine-project.org/jira/browse/DDC-2755)
+-   [DDC-2755](https://github.com/doctrine/orm/issues/3500)
     -[\#825](https://github.com/doctrine/doctrine2/pull/825) Spelling
     fix
--   [DDC-2777](http://www.doctrine-project.org/jira/browse/DDC-2777)
+-   [DDC-2777](https://github.com/doctrine/orm/issues/3524)
     -[\#838](https://github.com/doctrine/doctrine2/pull/838) Spelling
     fix
--   [DDC-2778](http://www.doctrine-project.org/jira/browse/DDC-2778)
+-   [DDC-2778](https://github.com/doctrine/orm/issues/3525)
     -[\#839](https://github.com/doctrine/doctrine2/pull/839) Spelling
     fix
--   [DDC-2801](http://www.doctrine-project.org/jira/browse/DDC-2801)
+-   [DDC-2801](https://github.com/doctrine/orm/issues/3552)
     -[\#851](https://github.com/doctrine/doctrine2/pull/851)
     Documentation about how to use INSTANCE OF in inheritance
--   [DDC-2819](http://www.doctrine-project.org/jira/browse/DDC-2819)
+-   [DDC-2819](https://github.com/doctrine/orm/issues/3571)
     -[\#860](https://github.com/doctrine/doctrine2/pull/860) Mention
     SQL Anywhere in basic mapping documentation
--   [DDC-2821](http://www.doctrine-project.org/jira/browse/DDC-2821)
+-   [DDC-2821](https://github.com/doctrine/orm/issues/3574)
     -[\#862](https://github.com/doctrine/doctrine2/pull/862) Added a
     note about changing the fetch mode for to-many relations
--   [DDC-2834](http://www.doctrine-project.org/jira/browse/DDC-2834)
+-   [DDC-2834](https://github.com/doctrine/orm/issues/3587)
     -[\#868](https://github.com/doctrine/doctrine2/pull/868) Added
     documentation section for Memcached
--   [DDC-2846](http://www.doctrine-project.org/jira/browse/DDC-2846)
+-   [DDC-2846](https://github.com/doctrine/orm/issues/3600)
     -[\#870](https://github.com/doctrine/doctrine2/pull/870)
     Documenting interface methods (based on entity manager)
--   [DDC-2848](http://www.doctrine-project.org/jira/browse/DDC-2848)
+-   [DDC-2848](https://github.com/doctrine/orm/issues/3602)
     -[\#872](https://github.com/doctrine/doctrine2/pull/872) Doctrine
     2.4 now supports SQLite ALTER TABLE
--   [DDC-2873](http://www.doctrine-project.org/jira/browse/DDC-2873)
+-   [DDC-2873](https://github.com/doctrine/orm/issues/3630)
     -[\#888](https://github.com/doctrine/doctrine2/pull/888) Add an
     example to doc of YAML mapping
--   [DDC-2887](http://www.doctrine-project.org/jira/browse/DDC-2887)
+-   [DDC-2887](https://github.com/doctrine/orm/issues/3644)
     -[\#898](https://github.com/doctrine/doctrine2/pull/898) Added
     note to STI
--   [DDC-2925](http://www.doctrine-project.org/jira/browse/DDC-2925)
+-   [DDC-2925](https://github.com/doctrine/orm/issues/3685)
     -[\#913](https://github.com/doctrine/doctrine2/pull/913) Added
     exception class names
--   [DDC-2928](http://www.doctrine-project.org/jira/browse/DDC-2928)
+-   [DDC-2928](https://github.com/doctrine/orm/issues/3688)
     -[\#915](https://github.com/doctrine/doctrine2/pull/915) Improved
     DQL's "new" operator documentation
--   [DDC-2963](http://www.doctrine-project.org/jira/browse/DDC-2963)
+-   [DDC-2963](https://github.com/doctrine/orm/issues/3727)
     -[\#940](https://github.com/doctrine/doctrine2/pull/940) Fixed
     typo & horizontal scrolling
--   [DDC-2979](http://www.doctrine-project.org/jira/browse/DDC-2979)
+-   [DDC-2979](https://github.com/doctrine/orm/issues/3742)
     -[\#953](https://github.com/doctrine/doctrine2/pull/953) Update
     doc with latest news about extra lazy assoc
--   [DDC-2985](http://www.doctrine-project.org/jira/browse/DDC-2985)
+-   [DDC-2985](https://github.com/doctrine/orm/issues/3749)
     -[\#955](https://github.com/doctrine/doctrine2/pull/955) iteration
     risk note
--   [DDC-3019](http://www.doctrine-project.org/jira/browse/DDC-3019)
+-   [DDC-3019](https://github.com/doctrine/orm/issues/3785)
     -[\#975](https://github.com/doctrine/doctrine2/pull/975) Added
     info about automatic discriminator map
--   [DDC-3048](http://www.doctrine-project.org/jira/browse/DDC-3048)
+-   [DDC-3048](https://github.com/doctrine/orm/issues/3818)
     -[\#987](https://github.com/doctrine/doctrine2/pull/987) Fixes
     typo in dql-doctrine-query-language.rst
--   [DDC-3053](http://www.doctrine-project.org/jira/browse/DDC-3053)
+-   [DDC-3053](https://github.com/doctrine/orm/issues/3824)
     -[\#990](https://github.com/doctrine/doctrine2/pull/990) Typo in
     documentation
--   [DDC-3057](http://www.doctrine-project.org/jira/browse/DDC-3057)
+-   [DDC-3057](https://github.com/doctrine/orm/issues/3828)
     -[\#992](https://github.com/doctrine/doctrine2/pull/992) Fixed
     typos
--   [DDC-3059](http://www.doctrine-project.org/jira/browse/DDC-3059)
+-   [DDC-3059](https://github.com/doctrine/orm/issues/3830)
     -[\#994](https://github.com/doctrine/doctrine2/pull/994) Update
     EntityGenerator comment
--   [DDC-3073](http://www.doctrine-project.org/jira/browse/DDC-3073)
+-   [DDC-3073](https://github.com/doctrine/orm/issues/3846)
     -@Column options
--   [DDC-3077](http://www.doctrine-project.org/jira/browse/DDC-3077)
+-   [DDC-3077](https://github.com/doctrine/orm/issues/3850)
     -[\#1007](https://github.com/doctrine/doctrine2/pull/1007) Minor
     dockblock change
--   [DDC-3086](http://www.doctrine-project.org/jira/browse/DDC-3086)
+-   [DDC-3086](https://github.com/doctrine/orm/issues/3860)
     -[\#1011](https://github.com/doctrine/doctrine2/pull/1011) Single
     quotes can't nest
--   [DDC-3097](http://www.doctrine-project.org/jira/browse/DDC-3097)
+-   [DDC-3097](https://github.com/doctrine/orm/issues/3872)
     -[\#1015](https://github.com/doctrine/doctrine2/pull/1015) Add
     ExpressionBuilder::contains() to docs
--   [DDC-3111](http://www.doctrine-project.org/jira/browse/DDC-3111)
+-   [DDC-3111](https://github.com/doctrine/orm/issues/3888)
     -[\#1025](https://github.com/doctrine/doctrine2/pull/1025) Removed
     duplicate entry in documentation TOC.
--   [DDC-3127](http://www.doctrine-project.org/jira/browse/DDC-3127)
+-   [DDC-3127](https://github.com/doctrine/orm/issues/3904)
     -[\#1031](https://github.com/doctrine/doctrine2/pull/1031)
     Documentation for \#991
--   [DDC-3131](http://www.doctrine-project.org/jira/browse/DDC-3131)
+-   [DDC-3131](https://github.com/doctrine/orm/issues/3909)
     -[\#1034](https://github.com/doctrine/doctrine2/pull/1034) Update
     caching.rst
--   [DDC-3139](http://www.doctrine-project.org/jira/browse/DDC-3139)
+-   [DDC-3139](https://github.com/doctrine/orm/issues/3917)
     -[\#1038](https://github.com/doctrine/doctrine2/pull/1038) Add
     documentation for the `HIDDEN` keyword in DQL
--   [DDC-3140](http://www.doctrine-project.org/jira/browse/DDC-3140)
+-   [DDC-3140](https://github.com/doctrine/orm/issues/3919)
     -[\#1039](https://github.com/doctrine/doctrine2/pull/1039) Add yml
     example to single table inheritance
--   [DDC-3144](http://www.doctrine-project.org/jira/browse/DDC-3144)
+-   [DDC-3144](https://github.com/doctrine/orm/issues/3924)
     -[\#1042](https://github.com/doctrine/doctrine2/pull/1042) Fix
     second level cache doc
--   [DDC-3145](http://www.doctrine-project.org/jira/browse/DDC-3145)
+-   [DDC-3145](https://github.com/doctrine/orm/issues/3923)
     -[\#1044](https://github.com/doctrine/doctrine2/pull/1044) Use of
     -\>andWhere() whithout any -\>where() before is valid
--   [DDC-3166](http://www.doctrine-project.org/jira/browse/DDC-3166)
+-   [DDC-3166](https://github.com/doctrine/orm/issues/3946)
     -[\#1058](https://github.com/doctrine/doctrine2/pull/1058) Drop
     Unicode character
--   [DDC-3168](http://www.doctrine-project.org/jira/browse/DDC-3168)
+-   [DDC-3168](https://github.com/doctrine/orm/issues/3948)
     -[\#1059](https://github.com/doctrine/doctrine2/pull/1059) fix
     spacing for yaml example
--   [DDC-3185](http://www.doctrine-project.org/jira/browse/DDC-3185)
+-   [DDC-3185](https://github.com/doctrine/orm/issues/3967)
     -[\#1068](https://github.com/doctrine/doctrine2/pull/1068) Fix
     typo in documentation
--   [DDC-3216](http://www.doctrine-project.org/jira/browse/DDC-3216)
+-   [DDC-3216](https://github.com/doctrine/orm/issues/4002)
     -[\#1083](https://github.com/doctrine/doctrine2/pull/1083)
-    [DDC-3073](http://www.doctrine-project.org/jira/browse/DDC-3073)
+    [DDC-3073](https://github.com/doctrine/orm/issues/3846)
     Add documentation about how to map column options
--   [DDC-3217](http://www.doctrine-project.org/jira/browse/DDC-3217)
+-   [DDC-3217](https://github.com/doctrine/orm/issues/4003)
     -[\#1084](https://github.com/doctrine/doctrine2/pull/1084) Update
     advanced-field-value-conversion-using-custom-mapping-types.rst
--   [DDC-3253](http://www.doctrine-project.org/jira/browse/DDC-3253)
+-   [DDC-3253](https://github.com/doctrine/orm/issues/4042)
     -[\#1110](https://github.com/doctrine/doctrine2/pull/1110) Changed
     table name to be more appropriate.
--   [DDC-3261](http://www.doctrine-project.org/jira/browse/DDC-3261)
+-   [DDC-3261](https://github.com/doctrine/orm/issues/4050)
     -Bad link in 34.3 Advanced Configuration - Connection Options
--   [DDC-3262](http://www.doctrine-project.org/jira/browse/DDC-3262)
+-   [DDC-3262](https://github.com/doctrine/orm/issues/4051)
     -[\#1115](https://github.com/doctrine/doctrine2/pull/1115) Fix
     wrong variable name
--   [DDC-3266](http://www.doctrine-project.org/jira/browse/DDC-3266)
+-   [DDC-3266](https://github.com/doctrine/orm/issues/4055)
     -[\#1116](https://github.com/doctrine/doctrine2/pull/1116)
-    [DDC-3265](http://www.doctrine-project.org/jira/browse/DDC-3265)
+    [DDC-3265](https://github.com/doctrine/orm/issues/4054)
     Fix DocBlock
--   [DDC-3292](http://www.doctrine-project.org/jira/browse/DDC-3292)
+-   [DDC-3292](https://github.com/doctrine/orm/issues/4084)
     -[\#1127](https://github.com/doctrine/doctrine2/pull/1127)
     Document embeddables column prefixing
--   [DDC-3324](http://www.doctrine-project.org/jira/browse/DDC-3324)
+-   [DDC-3324](https://github.com/doctrine/orm/issues/4120)
     -[\#1147](https://github.com/doctrine/doctrine2/pull/1147)
     Extended the docs for mapping attributes precision and scale
--   [DDC-3326](http://www.doctrine-project.org/jira/browse/DDC-3326)
+-   [DDC-3326](https://github.com/doctrine/orm/issues/4122)
     -[\#1148](https://github.com/doctrine/doctrine2/pull/1148)
     [DWEB-118] Fixed small typo in documentation about extra lazy
     associations
--   [DDC-3347](http://www.doctrine-project.org/jira/browse/DDC-3347)
+-   [DDC-3347](https://github.com/doctrine/orm/issues/4145)
     -[\#1157](https://github.com/doctrine/doctrine2/pull/1157) Fixing
     calls of schema-update tools
--   [DDC-3348](http://www.doctrine-project.org/jira/browse/DDC-3348)
+-   [DDC-3348](https://github.com/doctrine/orm/issues/4146)
     -[\#1158](https://github.com/doctrine/doctrine2/pull/1158) Update
     QueryBuilder reference documentation.
--   [DDC-3351](http://www.doctrine-project.org/jira/browse/DDC-3351)
+-   [DDC-3351](https://github.com/doctrine/orm/issues/4150)
     -[\#1161](https://github.com/doctrine/doctrine2/pull/1161) Fixing
     error with from() parameters in example
--   [DDC-3353](http://www.doctrine-project.org/jira/browse/DDC-3353)
+-   [DDC-3353](https://github.com/doctrine/orm/issues/4152)
     -[\#1163](https://github.com/doctrine/doctrine2/pull/1163) Update
     xml-mapping.rst
--   [DDC-3388](http://www.doctrine-project.org/jira/browse/DDC-3388)
+-   [DDC-3388](https://github.com/doctrine/orm/issues/4190)
     -[\#1183](https://github.com/doctrine/doctrine2/pull/1183) Update
     tools.rst
--   [DDC-3389](http://www.doctrine-project.org/jira/browse/DDC-3389)
+-   [DDC-3389](https://github.com/doctrine/orm/issues/4191)
     -[\#1184](https://github.com/doctrine/doctrine2/pull/1184)
     Postgres SERIAL is not a post-insert identifier generation strategy
--   [DDC-3408](http://www.doctrine-project.org/jira/browse/DDC-3408)
+-   [DDC-3408](https://github.com/doctrine/orm/issues/4212)
     -[\#1190](https://github.com/doctrine/doctrine2/pull/1190)
     Document that AUTOGENERATE\_ constants are allowed
--   [DDC-3411](http://www.doctrine-project.org/jira/browse/DDC-3411)
+-   [DDC-3411](https://github.com/doctrine/orm/issues/4216)
     -[\#1192](https://github.com/doctrine/doctrine2/pull/1192) Fixed a
     very minor typo
--   [DDC-3417](http://www.doctrine-project.org/jira/browse/DDC-3417)
+-   [DDC-3417](https://github.com/doctrine/orm/issues/4222)
     -[\#1195](https://github.com/doctrine/doctrine2/pull/1195)
     Correction Events.rs - Entity Listeners Resolver
--   [DDC-3420](http://www.doctrine-project.org/jira/browse/DDC-3420)
+-   [DDC-3420](https://github.com/doctrine/orm/issues/4226)
     -[\#1198](https://github.com/doctrine/doctrine2/pull/1198) Tables
     for buttons.
--   [DDC-3421](http://www.doctrine-project.org/jira/browse/DDC-3421)
+-   [DDC-3421](https://github.com/doctrine/orm/issues/4227)
     -[\#1199](https://github.com/doctrine/doctrine2/pull/1199) minor
     typo
--   [DDC-3456](http://www.doctrine-project.org/jira/browse/DDC-3456)
+-   [DDC-3456](https://github.com/doctrine/orm/issues/4265)
     -[\#1226](https://github.com/doctrine/doctrine2/pull/1226) Update
     Travis badges to use the SVG version
--   [DDC-3465](http://www.doctrine-project.org/jira/browse/DDC-3465)
+-   [DDC-3465](https://github.com/doctrine/orm/issues/4275)
     -[\#1232](https://github.com/doctrine/doctrine2/pull/1232)
     Explicit example of partial indexes
--   [DDC-3471](http://www.doctrine-project.org/jira/browse/DDC-3471)
+-   [DDC-3471](https://github.com/doctrine/orm/issues/4281)
     -[\#1236](https://github.com/doctrine/doctrine2/pull/1236) Minor
     docs fix: missing word 'do'
--   [DDC-3484](http://www.doctrine-project.org/jira/browse/DDC-3484)
+-   [DDC-3484](https://github.com/doctrine/orm/issues/4295)
     -[\#1244](https://github.com/doctrine/doctrine2/pull/1244) Change
     \$this return type to static in AbstractQuery
--   [DDC-3499](http://www.doctrine-project.org/jira/browse/DDC-3499)
+-   [DDC-3499](https://github.com/doctrine/orm/issues/4311)
     -[\#1253](https://github.com/doctrine/doctrine2/pull/1253) Fix
     dead link
--   [DDC-3516](http://www.doctrine-project.org/jira/browse/DDC-3516)
+-   [DDC-3516](https://github.com/doctrine/orm/issues/4330)
     -[\#1264](https://github.com/doctrine/doctrine2/pull/1264) Add
     Changelog/Migration to 2.5 documentation chapter.
--   [DDC-3523](http://www.doctrine-project.org/jira/browse/DDC-3523)
+-   [DDC-3523](https://github.com/doctrine/orm/issues/4338)
     -[\#1271](https://github.com/doctrine/doctrine2/pull/1271) Update
     migration\_2\_5.rst
--   [DDC-3526](http://www.doctrine-project.org/jira/browse/DDC-3526)
+-   [DDC-3526](https://github.com/doctrine/orm/issues/4341)
     -[\#1273](https://github.com/doctrine/doctrine2/pull/1273)
     Incorrect @throws doc. in getSingleScalarResult
--   [DDC-3533](http://www.doctrine-project.org/jira/browse/DDC-3533)
+-   [DDC-3533](https://github.com/doctrine/orm/issues/4351)
     -[\#1279](https://github.com/doctrine/doctrine2/pull/1279)
     [Doc][Reference][2nd level cache]
--   [DDC-3542](http://www.doctrine-project.org/jira/browse/DDC-3542)
+-   [DDC-3542](https://github.com/doctrine/orm/issues/4359)
     -[\#1287](https://github.com/doctrine/doctrine2/pull/1287) Typo
     fix
--   [DDC-3547](http://www.doctrine-project.org/jira/browse/DDC-3547)
+-   [DDC-3547](https://github.com/doctrine/orm/issues/4364)
     -[\#1290](https://github.com/doctrine/doctrine2/pull/1290) [Doc]
     [Reference] [Second Level Cache]
--   [DDC-3555](http://www.doctrine-project.org/jira/browse/DDC-3555)
+-   [DDC-3555](https://github.com/doctrine/orm/issues/4373)
     -[\#1296](https://github.com/doctrine/doctrine2/pull/1296) Flip
     key value in \$namespaces array
--   [DDC-3556](http://www.doctrine-project.org/jira/browse/DDC-3556)
+-   [DDC-3556](https://github.com/doctrine/orm/issues/4374)
     -[\#1297](https://github.com/doctrine/doctrine2/pull/1297)
-    [DDC-3480](http://www.doctrine-project.org/jira/browse/DDC-3480)
+    [DDC-3480](https://github.com/doctrine/orm/issues/4291)
     Docs: Embeddable supported mappings
--   [DDC-3557](http://www.doctrine-project.org/jira/browse/DDC-3557)
+-   [DDC-3557](https://github.com/doctrine/orm/issues/4375)
     -[\#1298](https://github.com/doctrine/doctrine2/pull/1298) Docs:
     Remove empty pages from TOC
--   [DDC-3559](http://www.doctrine-project.org/jira/browse/DDC-3559)
+-   [DDC-3559](https://github.com/doctrine/orm/issues/4377)
     -[\#1299](https://github.com/doctrine/doctrine2/pull/1299) Fixed
     missing quote in one DQL example
--   [DDC-3570](http://www.doctrine-project.org/jira/browse/DDC-3570)
+-   [DDC-3570](https://github.com/doctrine/orm/issues/4390)
     -[\#1305](https://github.com/doctrine/doctrine2/pull/1305)
     Documentation : fix table prefix with STI
--   [DDC-3595](http://www.doctrine-project.org/jira/browse/DDC-3595)
+-   [DDC-3595](https://github.com/doctrine/orm/issues/4417)
     -[\#1320](https://github.com/doctrine/doctrine2/pull/1320) Fix
     'entitiy' typo in Getting Started tutorial
--   [DDC-3599](http://www.doctrine-project.org/jira/browse/DDC-3599)
+-   [DDC-3599](https://github.com/doctrine/orm/issues/4421)
     -[\#1322](https://github.com/doctrine/doctrine2/pull/1322) Typo in
     documentation
--   [DDC-3611](http://www.doctrine-project.org/jira/browse/DDC-3611)
+-   [DDC-3611](https://github.com/doctrine/orm/issues/4435)
     -[\#1329](https://github.com/doctrine/doctrine2/pull/1329) Fix for
     inconsistent use of getSQLDeclaration
--   [DDC-3613](http://www.doctrine-project.org/jira/browse/DDC-3613)
+-   [DDC-3613](https://github.com/doctrine/orm/issues/4438)
     -[\#1330](https://github.com/doctrine/doctrine2/pull/1330) Fix
     @Column options sections in documentation
--   [DDC-3614](http://www.doctrine-project.org/jira/browse/DDC-3614)
+-   [DDC-3614](https://github.com/doctrine/orm/issues/4439)
     -[\#1331](https://github.com/doctrine/doctrine2/pull/1331) [DOCS]
     Fixed class name in aggregate fields example
--   [DDC-3617](http://www.doctrine-project.org/jira/browse/DDC-3617)
+-   [DDC-3617](https://github.com/doctrine/orm/issues/4442)
     -[\#1334](https://github.com/doctrine/doctrine2/pull/1334) Changed
     some wrong usage of the @internal phpdoc
--   [DDC-3620](http://www.doctrine-project.org/jira/browse/DDC-3620)
+-   [DDC-3620](https://github.com/doctrine/orm/issues/4446)
     -[\#1335](https://github.com/doctrine/doctrine2/pull/1335) Fix
     AbstractQuery::getParameter() documented return type
--   [DDC-3627](http://www.doctrine-project.org/jira/browse/DDC-3627)
+-   [DDC-3627](https://github.com/doctrine/orm/issues/4453)
     -[\#1341](https://github.com/doctrine/doctrine2/pull/1341) [doc]
     Minor fixes and typos
--   [DDC-3648](http://www.doctrine-project.org/jira/browse/DDC-3648)
+-   [DDC-3648](https://github.com/doctrine/orm/issues/4476)
     -[\#1355](https://github.com/doctrine/doctrine2/pull/1355) [Docs]
     TablePrefix example - Check for being the owning side
--   [DDC-3651](http://www.doctrine-project.org/jira/browse/DDC-3651)
+-   [DDC-3651](https://github.com/doctrine/orm/issues/4480)
     -[\#1358](https://github.com/doctrine/doctrine2/pull/1358) Update
     docs for clear-cache commands
 

--- a/source/blog/2015-11-23-orm-2-5-2.md
+++ b/source/blog/2015-11-23-orm-2-5-2.md
@@ -25,40 +25,40 @@ following `composer.json` contents:
 Changes since 2.5.1
 ===================
 
-This is a list of issues resolved in `2.5.2` since `2.4.1`:
+This is a list of issues resolved in `2.5.2` since `2.5.1`:
 
 Bug Fixes
 ---------
 
--   [DDC-3677](http://www.doctrine-project.org/jira/browse/DDC-3677)
+-   [DDC-3677](https://github.com/doctrine/orm/issues/4508)
     [GH-1375](https://github.com/doctrine/doctrine2/pull/3677) DDC-3671
     prevent duplicate unique index
--   [DDC-3899](http://www.doctrine-project.org/jira/browse/DDC-3899)
+-   [DDC-3899](https://github.com/doctrine/orm/issues/4754)
     [GH-1375](https://github.com/doctrine/doctrine2/pull/3899) Fixed
     wrong property name
--   [DDC-3908](http://www.doctrine-project.org/jira/browse/DDC-3908)
+-   [DDC-3908](https://github.com/doctrine/orm/issues/4765)
     [GH-1375](https://github.com/doctrine/doctrine2/pull/3908) Fix cache
     storage related test issues (due to doctrine/cache 1.5.0 changes)
--   [DDC-3911](http://www.doctrine-project.org/jira/browse/DDC-3911)
+-   [DDC-3911](https://github.com/doctrine/orm/issues/4769)
     [GH-1375](https://github.com/doctrine/doctrine2/pull/3911) Backport
     of "LimitSubqueryOutputWalker: fix aliasing of property in OrderBy
     from MappedSuperclass"
--   [DDC-3973](http://www.doctrine-project.org/jira/browse/DDC-3973)
+-   [DDC-3973](https://github.com/doctrine/orm/issues/4832)
     [GH-1375](https://github.com/doctrine/doctrine2/pull/3973)
-    [[DDC-3711](http://www.doctrine-project.org/jira/browse/DDC-3711)]
+    [[DDC-3711](https://github.com/doctrine/orm/issues/4547)]
     Correct Error on manyToMany with composite primary key + add Tests
 
 Improvements
 ------------
 
--   [DDC-3978](http://www.doctrine-project.org/jira/browse/DDC-3978)
+-   [DDC-3978](https://github.com/doctrine/orm/issues/4837)
     [GH-1375](https://github.com/doctrine/doctrine2/pull/3978) Allow
     symfony 3.0 components on 2.5
 
 Documentation
 -------------
 
--   [DDC-3938](http://www.doctrine-project.org/jira/browse/DDC-3938)
+-   [DDC-3938](https://github.com/doctrine/orm/issues/4798)
     [GH-1375](https://github.com/doctrine/doctrine2/pull/3938) Update
     Upgrade.md after minor bc break in 2.5.1
 

--- a/source/blog/2015-12-04-common-2-5-2-and-2-6-0.md
+++ b/source/blog/2015-12-04-common-2-5-2-and-2-6-0.md
@@ -14,16 +14,16 @@ Common 2.5.2
 
 `chmod()` warnings caused by proxy generation are now silenced
 [\#383](https://github.com/doctrine/common/pull/383)
-[DCOM-299](http://www.doctrine-project.org/jira/browse/DCOM-299).
+[DCOM-299](https://github.com/doctrine/common/issues/611).
 
 `SymfonyFileLocator#getAllClassNames()` was dropping some classes: now
 fixed [\#384](https://github.com/doctrine/common/pull/384)
-[DCOM-301](http://www.doctrine-project.org/jira/browse/DCOM-301).
+[DCOM-301](https://github.com/doctrine/common/issues/615).
 
 Corrected fatal error triggered by
 `AbstractManagerRegistry#getManagerForClass()` when no parent class is
 found for a proxy [\#387](https://github.com/doctrine/common/pull/387)
-[DCOM-303](http://www.doctrine-project.org/jira/browse/DCOM-303).
+[DCOM-303](https://github.com/doctrine/common/issues/617).
 
 You can find the complete changelog for this release in the [v2.5.2
 release
@@ -37,16 +37,16 @@ as following changes:
 
 Proxy generation now supports PHP 7.0+ scalar type hints and return
 types [\#376](https://github.com/doctrine/common/pull/376)
-[DCOM-294](http://www.doctrine-project.org/jira/browse/DCOM-294).
+[DCOM-294](https://github.com/doctrine/common/issues/606).
 
 Switched autoloading to PSR-4
 [\#389](https://github.com/doctrine/common/pull/389)
-[DCOM-305](http://www.doctrine-project.org/jira/browse/DCOM-305).
+[DCOM-305](https://github.com/doctrine/common/issues/619).
 
 Added a `.gitattributes` to the repositories, reducing the size of the
 package that is installed by composer
 [\#380](https://github.com/doctrine/common/pull/380)
-[DCOM-296](http://www.doctrine-project.org/jira/browse/DCOM-296).
+[DCOM-296](https://github.com/doctrine/common/issues/608).
 
 You can find the complete changelog for this release in the [v2.6.0
 release


### PR DESCRIPTION
Mostly it was 
- jira to github issues
- symfony-project to symfony

as discussed here https://github.com/doctrine/doctrine-website/issues/166#issuecomment-451611200

also I don't know what to do with 
- "Please report any issues you may have with the update on the mailing
list or on [Jira](http://www.doctrine-project.org/jira/browse/DDC)."
- www.doctrine-project.org/change_log (for example www.doctrine-project.org/change_log/1_2_0_BETA3 ) which is dead but there is no corresponding live version
- http://www.doctrine-project.org/download same as previous one
- https://www.doctrine-project.org/2008/10/02/doctrine-1-1-development-begins.html is empty blog , what should be done here?

---
note to self:
- update all doctrine-project.org non-https to https in other PR
- update links from https://github.com/doctrine/doctrine2 to https://github.com/doctrine/orm in other PR