### PR TITLE
http to https

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
         <defaults autowire="true" autoconfigure="true" public="false">

--- a/config/team_members.yml
+++ b/config/team_members.yml
@@ -26,7 +26,7 @@ parameters:
             name: 'Steve Müller'
             github: deeky666
             avatarUrl: 'https://avatars2.githubusercontent.com/u/1411514?v=4'
-            website: 'http://dzh-online.de/'
+            website: 'https://www.dzh-online.de/'
             location: 'Hamburg, Germany'
             maintains: ["dbal", "coding-standard"]
         greg0ire:
@@ -42,7 +42,7 @@ parameters:
             twitter: guilhermeblanco
             github: guilhermeblanco
             avatarUrl: 'https://avatars1.githubusercontent.com/u/208883?v=4'
-            website: 'http://www.doctrine-project.org'
+            website: 'https://www.doctrine-project.org'
             location: 'Toronto, ON, Canada'
             maintains: ["orm", "dbal", "annotations", "doctrine1", "common", "cache", "event-manager", "lexer", "doctrine-cache-bundle"]
         jmikola:
@@ -106,7 +106,7 @@ parameters:
             twitter: srgmrzv
             github: morozov
             avatarUrl: 'https://avatars1.githubusercontent.com/u/59683?v=4'
-            website: 'http://morozov.livejournal.com/'
+            website: 'https://morozov.livejournal.com/'
             location: 'San Jose, CA'
             maintains: ["dbal"]
         Ocramius:
@@ -121,7 +121,7 @@ parameters:
             name: 'Tom H Anderson'
             github: TomHAnderson
             avatarUrl: 'https://avatars1.githubusercontent.com/u/493920?v=4'
-            website: 'http://tomhanderson.com'
+            website: 'https://tomhanderson.com/'
             location: 'Salt Lake City, Utah'
             maintains: ["doctrine-module"]
         dbu:
@@ -135,12 +135,12 @@ parameters:
             name: 'Ryan Weaver'
             github: weaverryan
             avatarUrl: 'https://avatars1.githubusercontent.com/u/121003?v=4'
-            website: 'http://knpuniversity.com'
+            website: 'https://symfonycasts.com/'
             location: 'Grand Rapids MI'
             maintains: ["rst-parser", "doctrine-bundle"]
         SenseException:
             name: 'Claudio Zizza'
             github: 'SenseException'
             avatarUrl: 'https://avatars3.githubusercontent.com/u/859964?v=4'
-            website: 'http://php.budgegeria.de/'
+            website: 'https://php.budgegeria.de/'
             location: 'Karlsruhe'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<phpunit xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
          verbose="true"

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="https://www.w3.org/2005/Atom">
     <title><![CDATA[{{ site.title }}]]></title>
     <link href="{{ site.url }}/atom.xml" rel="self" />
     <link href="{{ site.url }}/" />

--- a/source/blog/2008-06-13-php-net-style-api-documentation-lookups.md
+++ b/source/blog/2008-06-13-php-net-style-api-documentation-lookups.md
@@ -8,7 +8,7 @@ permalink: /2008/06/13/php-net-style-api-documentation-lookups.html
 <p>
 
 I have been using php.net style API lookups ever since I can remember.
-It is very nice being able to simply go to http://php.net/array\_walk
+It is very nice being able to simply go to https://secure.php.net/array\_walk
 and have it pull up that function in the PHP API Documentation. So,
 tonight i have implemented this functionality in to the Doctrine
 website. Below are some examples of how you can quickly access the API

--- a/source/blog/2008-10-19-the-bleeding-edge-website-upgraded.md
+++ b/source/blog/2008-10-19-the-bleeding-edge-website-upgraded.md
@@ -44,7 +44,7 @@ releases were added thanks to my custom theme built specifically for the
 Doctrine backend.
 
 ![Doctrine Releases
-](http://www.doctrine-project.com/uploads/assets/api_release_list.png)
+](https://www.doctrine-project.com/uploads/assets/api_release_list.png)
 
 Edit User SVN Access
 ====================
@@ -54,7 +54,7 @@ widget for editing the website users svn access for all the different
 Doctrine versions.
 
 ![Edit User SVN Access
-](http://www.doctrine-project.com/uploads/assets/edit_user_svn_access.png)
+](https://www.doctrine-project.com/uploads/assets/edit_user_svn_access.png)
 
 Doctrine Release Points
 =======================
@@ -62,7 +62,7 @@ Doctrine Release Points
 List of all the Doctrine sub-release points.
 
 ![Doctrine Release Points
-](http://www.doctrine-project.com/uploads/assets/api_release_points_list.png)
+](https://www.doctrine-project.com/uploads/assets/api_release_points_list.png)
 
 Edit Doctrine Release
 =====================
@@ -71,7 +71,7 @@ Edit a Doctrine release and control its stability as well as other
 information.
 
 ![Edit Doctrine Release
-](http://www.doctrine-project.com/uploads/assets/edit_api_release.png)
+](https://www.doctrine-project.com/uploads/assets/edit_api_release.png)
 
 Edit Blog Post
 ==============
@@ -79,4 +79,4 @@ Edit Blog Post
 Edit a blog post entry using markdown syntax.
 
 ![Edit Blog
-Post](http://www.doctrine-project.com/uploads/assets/edit_blog_post.png)
+Post](https://www.doctrine-project.com/uploads/assets/edit_blog_post.png)

--- a/source/blog/2008-11-25-doctrine-1-0-4-released.md
+++ b/source/blog/2008-11-25-doctrine-1-0-4-released.md
@@ -9,5 +9,5 @@ Today we are happy to introduce the immediate availability of Doctrine
 1.0.4. This is a major bug fix release for the 1.0 branch of Doctrine.
 It contains over 75 bug fixes and it is recommended that you upgrade as
 soon as possible. As always you can view the [change
-log](http://www.doctrine-project.org/change_log/1_0_4) on the website
-and [download here](http://www.doctrine-project.org/download).
+log](https://www.doctrine-project.org/change_log/1_0_4) on the website
+and [download here](https://www.doctrine-project.org/download).

--- a/source/blog/2008-12-03-first-1-1-alpha-version-released.md
+++ b/source/blog/2008-12-03-first-1-1-alpha-version-released.md
@@ -19,6 +19,6 @@ and other [miscellaneous new
 features](https://www.doctrine-project.org/2008/10/02/doctrine-1-1-development-begins.html).
 
 You can download the package
-[here](http://www.doctrine-project.org/download) and read some
+[here](https://www.doctrine-project.org/download) and read some
 documentation on the changes and new features
 [here](http://trac.doctrine-project.org/browser/branches/1.1/UPGRADE_TO_1_1).

--- a/source/blog/2008-12-11-double-dose-of-doctrine.md
+++ b/source/blog/2008-12-11-double-dose-of-doctrine.md
@@ -7,11 +7,11 @@ permalink: /2008/12/11/double-dose-of-doctrine.html
 ---
 Today I am happy to introduce two new versions of Doctrine! We have made
 available yet another maintenance release for the 1.0 version,
-[1.0.5](http://www.doctrine-project.org/download). This release contains
+[1.0.5](https://www.doctrine-project.org/download). This release contains
 dozens of fixes that are logged
-[here](http://www.doctrine-project.org/change_log/1_0_5). In addition to
+[here](https://www.doctrine-project.org/change_log/1_0_5). In addition to
 the monthly 1.0.x maintenance release, we have made available the [first
-beta of the 1.1](http://www.doctrine-project.org/download) development
+beta of the 1.1](https://www.doctrine-project.org/download) development
 branch of Doctrine.
 
 This is exciting news because this means we are very close to releasing

--- a/source/blog/2009-01-05-doctrine-1-0-6-released.md
+++ b/source/blog/2009-01-05-doctrine-1-0-6-released.md
@@ -19,7 +19,7 @@ years. I hope everyone enjoyed the holidays as much as I did.
 Anyways, on my first day back I am happy to introduce the freshly
 packaged Doctrine 1.0.6 bug fix release. This release contains dozens of
 fixes and the change log can be read
-[here](http://www.doctrine-project.org/change_log/1_0_6). It is strongly
+[here](https://www.doctrine-project.org/change_log/1_0_6). It is strongly
 encouraged that you upgrade as soon as possible.
 
 Doctrine 1.1
@@ -29,4 +29,4 @@ On a side note, we will be releasing the 2nd beta of 1.1 later this week
 and we have a few other surprises that will be a part of the 1.1 stable
 release. So, you will have to stick around to see what we have planned.
 You can check out what is new in 1.1 by reading the
-[upgrade](http://www.doctrine-project.org/upgrade/1_1) file.
+[upgrade](https://www.doctrine-project.org/upgrade/1_1) file.

--- a/source/blog/2009-01-06-2nd-1-1-beta-released.md
+++ b/source/blog/2009-01-06-2nd-1-1-beta-released.md
@@ -30,7 +30,7 @@ Development Highlights
     with temporary generated models not being cleaned up properly
 
 You can also check out the [detailed
-documentation](http://www.doctrine-project.org/upgrade/1_1) of all the
+documentation](https://www.doctrine-project.org/upgrade/1_1) of all the
 changes that are contained in the 1.1 version of Doctrine as well as the
-[changelog](http://www.doctrine-project.org/change_log/1_1_0_BETA2) to
+[changelog](https://www.doctrine-project.org/change_log/1_1_0_BETA2) to
 help ease the upgrade process.

--- a/source/blog/2009-01-12-doctrine-1-1-is-right-around-the-corner.md
+++ b/source/blog/2009-01-12-doctrine-1-1-is-right-around-the-corner.md
@@ -22,7 +22,7 @@ having a third beta but as the amount of tickets that came in was
 practically none, we decided to move on to the release candidate stage.
 
 As always, you can [download
-here](http://www.doctrine-project.org/download) and check out the
-[change log](http://www.doctrine-project.org/change_log/1_1_0_RC1) and
-the [upgrade](http://www.doctrine-project.org/upgrade/1_1) document to
+here](https://www.doctrine-project.org/download) and check out the
+[change log](https://www.doctrine-project.org/change_log/1_1_0_RC1) and
+the [upgrade](https://www.doctrine-project.org/upgrade/1_1) document to
 find out what has changed in 1.1.

--- a/source/blog/2009-01-23-introducing-doctrine-orm-for-php.md
+++ b/source/blog/2009-01-23-introducing-doctrine-orm-for-php.md
@@ -7,7 +7,7 @@ permalink: /2009/01/23/introducing-doctrine-orm-for-php.html
 ---
 Today I am very happy to announce that we have a first draft available
 of the new main Doctrine documentation which is titled, "[Doctrine ORM
-for PHP](http://www.doctrine-project.org/documentation/manual/1_0/en)".
+for PHP](https://www.doctrine-project.org/documentation/manual/1_0/en)".
 The content of this documentation was re-organized and completely
 re-written from the "Old Manual". The order of the chapters and sections
 have been re-thought and we've tried to put them in a more logical
@@ -64,7 +64,7 @@ We have a few more bugs to fix in the 1.1 version then we will release
 the second stable version of Doctrine, 1.1. Right before we release
 Doctrine 1.1(which will hopefully also be in a week or so), we will
 branch the new documentation for 1.1 and make all the necessary updates
-based on [what's changed](http://www.doctrine-project.org/upgrade/1_0).
+based on [what's changed](https://www.doctrine-project.org/upgrade/1_0).
 Then we will release and open it to your suggestions.
 
 Printed Book: "Doctrine ORM for PHP"
@@ -80,11 +80,11 @@ appreciation for the project and support it by purchasing a copy.
 > **TIP** If you want to print a rich text version of the Book yourself
 > instead of using the PDF or ordering a copy, we have implemented a
 > print stylesheet so when you access the documentation
-> [here](http://www.doctrine-project.org/documentation/manual/1_0/en/one-page/print)
+> [here](https://www.doctrine-project.org/documentation/manual/1_0/en/one-page/print)
 > you will get the version styled for printing.
 
 * * * * *
 
 Now go ahead and check out [Doctrine ORM for PHP - Guide to Doctrine for
-PHP](http://www.doctrine-project.org/documentation/manual/1_0/en) and
+PHP](https://www.doctrine-project.org/documentation/manual/1_0/en) and
 bring me some feedback. :)

--- a/source/blog/2009-01-30-new-documentation-pdf-downloads.md
+++ b/source/blog/2009-01-30-new-documentation-pdf-downloads.md
@@ -10,9 +10,9 @@ project](http://www.symfony-project.org) , we now have a new way to
 generate the PDF version of our documentation. The new PDFs are a MAJOR
 step up from the previous style of PDF and am very pleased with it!
 Check it out by viewing the 1.0 version of [The Guide to Doctrine for
-PHP](http://www.doctrine-project.org/documentation/manual/1_0/en/pdf) or
+PHP](https://www.doctrine-project.org/documentation/manual/1_0/en/pdf) or
 [The Doctrine
-Cookbook](http://www.doctrine-project.org/documentation/cookbook/1_0/en/pdf).
+Cookbook](https://www.doctrine-project.org/documentation/cookbook/1_0/en/pdf).
 
 What is next?
 =============

--- a/source/blog/2009-02-03-doctrine-1-0-7-is-available.md
+++ b/source/blog/2009-02-03-doctrine-1-0-7-is-available.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2009/02/03/doctrine-1-0-7-is-available.html
 ---
 Today I have made available [Doctrine
-1.0.7](http://www.doctrine-project.org/download) , the latest bug fix
+1.0.7](https://www.doctrine-project.org/download) , the latest bug fix
 release for the 1.0 version of Doctrine. This release is a significant
 one with a few dozen bugs fixed. Below is a list that highlights some of
 the fixes.
@@ -27,4 +27,4 @@ Highlights
 
 Lots of other fixes have been made in this release so if you want to see
 a list of all the changes be sure to check the
-[changelog](http://www.doctrine-project.org/change_log/1_0_7).
+[changelog](https://www.doctrine-project.org/change_log/1_0_7).

--- a/source/blog/2009-03-02-doctrine-1-0-8-and-1-1-0-rc2-released.md
+++ b/source/blog/2009-03-02-doctrine-1-0-8-and-1-1-0-rc2-released.md
@@ -9,7 +9,7 @@ Today I am happy to tell you that we have two new versions of Doctrine
 available for you to use. The first is the monthly maintenance release
 for Doctrine 1.0 and the second is another release candidate for the
 newest major version of Doctrine, 1.1. As always you can grab them from
-the [downloads](http://www.doctrine-project.org/download) page.
+the [downloads](https://www.doctrine-project.org/download) page.
 
 1.0.8 Highlights
 ================
@@ -19,7 +19,7 @@ the [downloads](http://www.doctrine-project.org/download) page.
 -   Dozens and dozens of other small fixes
 
 You can read the full change log for the 1.0.8 release
-[here](http://www.doctrine-project.org/change_log/1_0_8).
+[here](https://www.doctrine-project.org/change_log/1_0_8).
 
 1.1.0-RC2 Highlights
 ====================
@@ -36,7 +36,7 @@ You can read the full change log for the 1.0.8 release
     callbacks enabled.
 
 You can read the full change log for the 1.1.0-RC2 release
-[here](http://www.doctrine-project.org/change_log/1_1_0_RC2).
+[here](https://www.doctrine-project.org/change_log/1_1_0_RC2).
 
 <hr />
 

--- a/source/blog/2009-03-12-get-trained-by-doctrine-experts.md
+++ b/source/blog/2009-03-12-get-trained-by-doctrine-experts.md
@@ -60,5 +60,5 @@ session that works for you. You can reach me via e-mail at
 <hr />
 
 You can always see the live up-to-date SensioLabs training schedule
-[here](http://www.sensiolabs.com/en/training) or on the
-[homepage](http://www.doctrine-project.org) of the Doctrine website.
+[here](https://training.sensiolabs.com/en/) or on the
+[homepage](https://www.doctrine-project.org) of the Doctrine website.

--- a/source/blog/2009-03-16-doctrine-1-1-released.md
+++ b/source/blog/2009-03-16-doctrine-1-1-released.md
@@ -30,13 +30,13 @@ Highlights
 -   Plenty of other bug fixes
 
 You can read a detailed list of all the changes made in 1.1
-[here](http://www.doctrine-project.org/upgrade/1_1) in the upgrade file.
+[here](https://www.doctrine-project.org/upgrade/1_1) in the upgrade file.
 
 Download
 ========
 
 As always you can get Doctrine on the
-[download](http://www.doctrine-project.org/download) page or via pear.
+[download](https://www.doctrine-project.org/download) page or via pear.
 
     $ pear install pear.phpdoctrine.org/Doctrine-1.1.0
 
@@ -47,4 +47,4 @@ You can also check it out via svn.
 If you find any problems with this release please report it on our
 [trac](http://trac.doctrine-project.org) or if you have any questions
 you can send it to one of our [mailing
-lists](http://www.doctrine-project.org/community).
+lists](https://www.doctrine-project.org/community).

--- a/source/blog/2009-05-11-doctrine-1-0-9-and-1-1-1-released.md
+++ b/source/blog/2009-05-11-doctrine-1-0-9-and-1-1-1-released.md
@@ -9,8 +9,8 @@ Today I am very happy to make available two new releases of Doctrine for
 the 1.0 and 1.1 code bases. These are both significant bug fix releases
 and it is recommended that you upgrade right away.
 
--   [1.1.1](http://www.doctrine-project.org/download/1_1_1/format/tgz)
--   [1.0.9](http://www.doctrine-project.org/download/1_0_9/format/tgz)
+-   [1.1.1](https://www.doctrine-project.org/download/1_1_1/format/tgz)
+-   [1.0.9](https://www.doctrine-project.org/download/1_0_9/format/tgz)
 
 You can find more information about these releases as usual on the
-[download](http://www.doctrine-project.org/download) page.
+[download](https://www.doctrine-project.org/download) page.

--- a/source/blog/2009-05-27-want-to-contribute-to-doctrine.md
+++ b/source/blog/2009-05-27-want-to-contribute-to-doctrine.md
@@ -22,7 +22,7 @@ You can see Roman made a call to the Doctrine developers mailing list
 [here](http://groups.google.com/group/doctrine-dev/browse_thread/thread/c6e4c74e1a392909)
 about the issue. We are taking all the feedback in to consideration and
 we have started by creating a
-[contribute](http://www.doctrine-project.org/contribute) page that is
+[contribute](https://www.doctrine-project.org/contribute) page that is
 linked from the primary menu of the website. We hope that this will help
 with new users finding information faster about how they can get started
 contributing.

--- a/source/blog/2009-05-29-doctrine-lazy-loading.md
+++ b/source/blog/2009-05-29-doctrine-lazy-loading.md
@@ -110,7 +110,7 @@ How?
 If you need help with keeping track of how many queries you have per
 page, frameworks like
 [Symfony](https://symfony.com/legacy/doc/gentle-introduction/1_4/en/16-Application-Management-Tools#chapter_16_sub_web_debug_toolbar)
-and [Zend Framework](http://framework.zend.com) give you debug tools to
+and [Zend Framework](https://framework.zend.com/) give you debug tools to
 show you how many queries you have per page. Or of course you can always
 use the
 [Profiling](https://www.doctrine-project.org/projects/doctrine1/en/latest/manual/component-overview.html#profiler)

--- a/source/blog/2009-06-05-doctrine-statistics.md
+++ b/source/blog/2009-06-05-doctrine-statistics.md
@@ -31,7 +31,7 @@ Downloads
 > **NOTE** **These statistics don't count downloads through other
 > sources such as symfony, Doctrine SVN, etc. They only track the
 > downloads through the Doctrine website on the
-> [Download](http://www.doctrine-project.org/download) page.**
+> [Download](https://www.doctrine-project.org/download) page.**
 
 Hopefully I can make this same post a year from now about the same thing
 and Doctrine will have grown with many new versions.

--- a/source/blog/2009-06-15-doctrine-1-0-10-and-1-1-2-released.md
+++ b/source/blog/2009-06-15-doctrine-1-0-10-and-1-1-2-released.md
@@ -8,11 +8,11 @@ permalink: /2009/06/15/doctrine-1-0-10-and-1-1-2-released.html
 Today I am happy to release two new maintenance releases for Doctrine.
 As usual we have a new version for the 1.0 branch and a new version for
 the 1.1 branch. The new versions can be gotten on the
-[Download](http://www.doctrine-project.org/download) page.
+[Download](https://www.doctrine-project.org/download) page.
 
 You can review the changelogs for
-[1.0.10](http://www.doctrine-project.org/change_log/1_0_10) and
-[1.1.2](http://www.doctrine-project.org/change_log/1_1_2) to see what
+[1.0.10](https://www.doctrine-project.org/change_log/1_0_10) and
+[1.1.2](https://www.doctrine-project.org/change_log/1_1_2) to see what
 all issues have been addressed in these releases.
 
 On a side note, development on the Doctrine 1.2 version will begin very

--- a/source/blog/2009-06-17-special-price-offer-symfony-1-2-doctrine-training-workshop.md
+++ b/source/blog/2009-06-17-special-price-offer-symfony-1-2-doctrine-training-workshop.md
@@ -5,7 +5,7 @@ authorEmail:
 categories: []
 permalink: /2009/06/17/special-price-offer-symfony-1-2-doctrine-training-workshop.html
 ---
-As you all may know, I work for [Sensio Labs](http://www.sensiolabs.com)
+As you all may know, I work for [Sensio Labs](https://sensiolabs.com)
 , the creators of the [Symfony](http://www.symfony-project.org)
 framework. Sensio offers trainings in many topics, but primarily Symfony
 and Doctrine. I will be teaching a training session June 29th to July

--- a/source/blog/2009-06-21-website-updates.md
+++ b/source/blog/2009-06-21-website-updates.md
@@ -11,7 +11,7 @@ of you.
 
 I have decided to remove the Doctrine Forum forever and consolidate the
 user discussions in to the
-[doctrine-user](http://groups.google.com/group/doctrine-user) mailing
+[doctrine-user](https://groups.google.com/forum/#!forum/doctrine-user) mailing
 list which is hosted on Google Groups. I chose to do this for a few
 reasons.
 
@@ -29,10 +29,10 @@ time...**developing Doctrine**..instead of maintaining the forum.
 Some other changes I have made/fixed.
 
 -   Change Logs are now fixed from the move
--   The [blog](http://www.doctrine-project.org/blog) has been enhanced
+-   The [blog](https://www.doctrine-project.org/blog) has been enhanced
     and tags fixed
 -   [API
-    Documentation](http://www.doctrine-project.org/Doctrine_Record/1_1)
+    Documentation](https://www.doctrine-project.org/Doctrine_Record/1_1)
     Enhanced to include browse code links so you can see the code for
     each class, function, etc.
 -   A bunch of other small little things tweaked and fixed.

--- a/source/blog/2009-06-26-what-s-new-in-doctrine-1-2.md
+++ b/source/blog/2009-06-26-what-s-new-in-doctrine-1-2.md
@@ -35,7 +35,7 @@ Doctrine Extensions
 
 All the above changes lend themselves well to creating extensions and
 behaviors for Doctrine. This has led to the creation of the Doctrine
-[extensions](http://www.doctrine-project.org/extensions) repository.
+[extensions](https://www.doctrine-project.org/extensions) repository.
 
 You can now write standalone code bundled as a Doctrine extension that
 can be dropped in to an extensions folder and loaded by Doctrine. So now
@@ -43,7 +43,7 @@ when you all write custom behaviors and custom extensions you can make
 them available for other people to use and drop in to projects.
 
 I have started the repository by committing the
-[Sortable](http://www.doctrine-project.org/extension/Sortable/1_2-1_0)
+[Sortable](https://www.doctrine-project.org/extension/Sortable/1_2-1_0)
 behavior which was contributed by a Doctrine user on our trac. So
 whoever you are, if you would like to maintain this extension please
 contact me.
@@ -52,7 +52,7 @@ Follow 1.2 Development
 ======================
 
 If you want to know more about Doctrine 1.2 you can read the [What's new
-in Doctrine 1.2](http://www.doctrine-project.org/upgrade/1_2) document
+in Doctrine 1.2](https://www.doctrine-project.org/upgrade/1_2) document
 which will be kept up to date as we develop and change things in 1.2!
 
 > **CAUTION** Some of the implemented features in 1.2 are still being

--- a/source/blog/2009-06-30-doctrine-orm-for-php-available-in-print.md
+++ b/source/blog/2009-06-30-doctrine-orm-for-php-available-in-print.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2009/06/30/doctrine-orm-for-php-available-in-print.html
 ---
 Last night the [Doctrine ORM for
-PHP](http://www.amazon.com/Doctrine-ORM-PHP-Jonathan-Wage/dp/2918390038/ref=sr_1_1?ie=UTF8&s=books&qid=1246303098&sr=8-1)
+PHP](https://www.amazon.com/Doctrine-ORM-PHP-Jonathan-Wage/dp/2918390038/ref=sr_1_1?ie=UTF8&s=books&qid=1246303098&sr=8-1)
 book became available on the Amazon website. This is our first official
 piece of published documentation and we are very excited and proud to
 see this.
@@ -15,6 +15,6 @@ If you are an existing or new Doctrine user, it is much appreciated if
 you purchase a copy. Since Doctrine is an open source project we don't
 make any money directly from it. Doctrine is all possible because of the
 contributors and the companies that fund it, like [Sensio
-Labs](http://www.sensiolabs.com). So it is a very nice gesture, even if
+Labs](https://sensiolabs.com). So it is a very nice gesture, even if
 you are already a Doctrine expert, to purchase a copy of the book to
 show your appreciation and support for the project.

--- a/source/blog/2009-07-04-major-site-enhancements.md
+++ b/source/blog/2009-07-04-major-site-enhancements.md
@@ -20,7 +20,7 @@ Login Now!
 ==========
 
 Once you have registered you can login to the
-[website](http://www.doctrine-project.org/login) and
+[website](https://www.doctrine-project.org/login) and
 [Trac](http://trac.doctrine-project.org/login). This will make some
 extra functionality available for you to manage your user information.
 
@@ -31,7 +31,7 @@ A place where you can browse, search and find out what extensions are
 available for Doctrine. It contains documentation, ability to run the
 unit tests and download the code.
 
-Check it out [here](http://www.doctrine-project.org/extensions).
+Check it out [here](https://www.doctrine-project.org/extensions).
 
 User Documentation Area
 =======================
@@ -39,14 +39,14 @@ User Documentation Area
 For a long time I have wanted to have an area of the website where users
 could manage as much user contributed documentation as they want. I have
 started the new site with a tutorial on [how to write an
-extension](http://www.doctrine-project.org/documentation/user/1_2/en/how-to-write-an-extension).
+extension](https://www.doctrine-project.org/documentation/user/1_2/en/how-to-write-an-extension).
 
 New Homepage Look
 =================
 
 I have slightly tweaked the homepage design to match the design of the
 new Doctrine
-[book](http://www.amazon.com/Doctrine-ORM-PHP-Jonathan-Wage/dp/2918390038/ref=sr_1_1?ie=UTF8&s=books&qid=1246303098&sr=8-1).
+[book](https://www.amazon.com/Doctrine-ORM-PHP-Jonathan-Wage/dp/2918390038/ref=sr_1_1?ie=UTF8&s=books&qid=1246303098&sr=8-1).
 This is our first book so if you want to support the Doctrine project or
 just want to learn about Doctrine then we suggest you purchase a copy!
 :)
@@ -58,8 +58,8 @@ Central location where you can manage all the information you control as
 a Doctrine authenticated user. You can see what extensions you've
 written, control your user contributed documentation, request SVN access
 and update your account information. Check it out
-[here](http://www.doctrine-project.org/user/account).
+[here](https://www.doctrine-project.org/user/account).
 
 These changes are primarily based around the new extensions repository
 which is available for Doctrine 1.2. You can read about what else is new
-in Doctrine 1.2 [here](http://www.doctrine-project.org/upgrade/1_2).
+in Doctrine 1.2 [here](https://www.doctrine-project.org/upgrade/1_2).

--- a/source/blog/2009-07-27-doctrine-1-0-11-and-1-1-3-released.md
+++ b/source/blog/2009-07-27-doctrine-1-0-11-and-1-1-3-released.md
@@ -11,10 +11,10 @@ contain dozens of bug fixes. Below you will find links to view the
 changelogs for both releases.
 
 -   [Doctrine 1.0.11
-    Changelog](http://www.doctrine-project.org/change_log/1_0_11)
+    Changelog](https://www.doctrine-project.org/change_log/1_0_11)
 -   [Doctrine 1.1.3
-    Changelog](http://www.doctrine-project.org/change_log/1_1_3)
+    Changelog](https://www.doctrine-project.org/change_log/1_1_3)
 
 It is recommended that you upgrade as soon as possible. You can download
 the new versions from the
-[download](http://www.doctrine-project.org/download) page.
+[download](https://www.doctrine-project.org/download) page.

--- a/source/blog/2009-08-04-help-write-tests-for-new-dql-parser.md
+++ b/source/blog/2009-08-04-help-write-tests-for-new-dql-parser.md
@@ -17,7 +17,7 @@ grammar, usually known as LL(k).
 
 We mapped the entire supported DQL into a document, which is an [EBNF
 (Extended Backus-Naur
-Form)](http://en.wikipedia.org/wiki/Extended_Backus–Naur_Form) , which
+Form)](https://en.wikipedia.org/wiki/Extended_Backus–Naur_Form) , which
 is a meta-syntax notation to express context-free grammars. This one is
 quite simple to be readable by humans. Yes, we are humans if you raise
 the question! =)
@@ -47,7 +47,7 @@ How does it do that?
 ====================
 
 Each piece of DQL is converted to a series of tokens. Some tokens are
-defined in our [Symbol Table](http://en.wikipedia.org/wiki/Symbol_table)
+defined in our [Symbol Table](https://en.wikipedia.org/wiki/Symbol_table)
 , which is then validated and correctly typed into the right token type.
 For example... when it finds the "`FROM`", it'll return for us
 internally a token in an array format of:
@@ -107,7 +107,7 @@ Running tests
 =============
 
 It is not hard to execute new test suite. Once you have
-[PHPUnit](http://phpunit.de) and [XDebug](http://xdebug.org) installed,
+[PHPUnit](https://phpunit.de) and [XDebug](https://xdebug.org) installed,
 go to tests folder of trunk, create the directory `_coverage` (CHMOD
 0777) and execute:
 

--- a/source/blog/2009-08-24-doctrine-2-0-quality-assurance.md
+++ b/source/blog/2009-08-24-doctrine-2-0-quality-assurance.md
@@ -9,10 +9,10 @@ Greetings folks!
 
 Today I'd like to talk about Quality Assurance in PHP projects.
 Currently, PHP lacks good tools for QA, but thanks to a special PHP
-user, [Sebastian Bergmann](http://sebastian-bergmann.de) , this is
+user, [Sebastian Bergmann](https://sebastian-bergmann.de/) , this is
 changing gradually. If you don't know him, you can visit his blog and
 check about projects he's on. For lazy people, he's the author of
-[PHPUnit](http://www.phpunit.de) , a de-facto Unit Test suite in PHP.
+[PHPUnit](https://www.phpunit.de) , a de-facto Unit Test suite in PHP.
 
 Doctrine 2.0 uses PHPUnit as our Unit Test suite. It relies on PEAR to
 be installed, but you can also install it via SVN.
@@ -26,7 +26,7 @@ I have applied some of these tests against [Doctrine
 2.0](http://trac.doctrine-project.org/browser/trunk) to see how complex
 it is and if it can be optimized more. The first test I run is a trace
 about how complex our code base is. The tool I used is
-[phploc](http://github.com/sebastianbergmann/phploc/tree/master). Check
+[phploc](https://github.com/sebastianbergmann/phploc/tree/master). Check
 out the results:
 
     [bash]
@@ -50,7 +50,7 @@ Of course it still misses a couple of code to implement (CLI Tasks,
 Locking strategies, ID Generators), but now we know how big Doctrine 2.0
 is. Then, I decided to check duplicated code (possible optimization
 locations). The tool
-[phpcpd](http://github.com/sebastianbergmann/phpcpd/tree/master) gave me
+[phpcpd](https://github.com/sebastianbergmann/phpcpd/tree/master) gave me
 this feedback:
 
     [bash]
@@ -102,10 +102,10 @@ Finally, some metrics are good to inspect how stable is our code. I
 applied [pdepend](http://pdepend.org) , and it gave me these results:
 
 ![jdepend chart
-](http://www.doctrine-project.org/blog-images/doctrine-2-0-qa/picture2.png)
+](https://www.doctrine-project.org/blog-images/doctrine-2-0-qa/picture2.png)
 
 ![pyramid overview
-](http://www.doctrine-project.org/blog-images/doctrine-2-0-qa/picture3.png)
+](https://www.doctrine-project.org/blog-images/doctrine-2-0-qa/picture3.png)
 
 The command I ran was:
 

--- a/source/blog/2009-09-01-doctrine2-preview-release.md
+++ b/source/blog/2009-09-01-doctrine2-preview-release.md
@@ -72,7 +72,7 @@ To get started quickly, please check out our [sandbox quickstart
 tutorial](https://www.doctrine-project.org/projects/doctrine-orm/en/current/tutorials/getting-started.html).
 You can also obtain Doctrine 2.0.0 ALPHA1 via a PEAR package like normal
 which can be found on the
-[download](http://www.doctrine-project.org/download)
+[download](https://www.doctrine-project.org/download)
 
 We want to encourage everyone to start experimenting with the new
 generation of Doctrine in order to get familiar with it and to help find

--- a/source/blog/2009-09-14-moving-to-jira.md
+++ b/source/blog/2009-09-14-moving-to-jira.md
@@ -8,14 +8,14 @@ permalink: /2009/09/14/moving-to-jira.html
 While we really like Trac, especially its subversion integration, it has
 a lot of shortcomings for bigger projects in the area of project &
 issue/ticket management. Hence we decided to evaluate alternatives and
-ended up with choosing [JIRA](http://www.atlassian.com/software/jira/).
+ended up with choosing [JIRA](https://www.atlassian.com/software/jira).
 Its normally not free software but the generous guys from Atlassian
 granted us a free open source license. A big thanks from all of us to
 Atlassian for their support of open source projects.
 
 From now on all the project management, release management and
 issue/ticket management will happen in our [new JIRA
-instance](http://doctrine-project.org/jira). While it is open for
+instance](https://www.doctrine-project.org/jira). While it is open for
 everyone in read-only mode, we strongly encourage you to create an
 account soon so that you can create/modify/comment issues and content in
 JIRA.
@@ -51,5 +51,5 @@ improvement for all users. We hope you enjoy all the new functionality
 provided by JIRA, like voting for issues that are important to you,
 tracking issues and much more.
 
-So, head over to our [JIRA instance](http://doctrine-project.org/jira) ,
+So, head over to our [JIRA instance](https://www.doctrine-project.org/jira) ,
 create an account and start creating issues and explore the features.

--- a/source/blog/2009-09-18-doctrine-1-2-0-alpha-released.md
+++ b/source/blog/2009-09-18-doctrine-1-2-0-alpha-released.md
@@ -11,7 +11,7 @@ last 1.x version and is a LTS(long term support) release. We will post
 the official support schedule once 1.2 is stable and released.
 
 You can download Doctrine 1.2.0-ALPHA1 on the
-[download](http://www.doctrine-project.org/download) page just like
+[download](https://www.doctrine-project.org/download) page just like
 normal.
 
 This release contains many changes, bug fixes and enhancements. Some of
@@ -29,5 +29,5 @@ them are highlighted below.
     performance improvements
 
 You can view the full details of all the changes in the [upgrade
-file](http://www.doctrine-project.org/upgrade/1_2). We use this to
+file](https://www.doctrine-project.org/upgrade/1_2). We use this to
 document all major changes so that upgrading is easier for you.

--- a/source/blog/2009-09-25-doctrine-1-0-12-and-1-1-4-released.md
+++ b/source/blog/2009-09-25-doctrine-1-0-12-and-1-1-4-released.md
@@ -17,4 +17,4 @@ releases and only contain bug fixes.
 > will have **18** months of support from the date it is released.
 
 You can view the change logs and download these releases on the
-[download](http://www.doctrine-project.org) page.
+[download](https://www.doctrine-project.org) page.

--- a/source/blog/2009-10-05-second-alpha-release-of-doctrine-2.md
+++ b/source/blog/2009-10-05-second-alpha-release-of-doctrine-2.md
@@ -22,6 +22,6 @@ Below are some highlights for the release.
 
 If you're curious about what all was committed in this release you can
 check the [change
-log](http://www.doctrine-project.org/change_log/2_0_0_ALPHA2) page and
+log](https://www.doctrine-project.org/change_log/2_0_0_ALPHA2) page and
 you can snag the packages from the
-[download](http://www.doctrine-project.org/download) page.
+[download](https://www.doctrine-project.org/download) page.

--- a/source/blog/2009-10-06-doctrine-1-2-nearing-stable-release.md
+++ b/source/blog/2009-10-06-doctrine-1-2-nearing-stable-release.md
@@ -11,9 +11,9 @@ with the new things in Doctrine 1.2 and we know lots of people have
 upgraded and using it so we feel it is a pretty stable release already.
 
 You can view what all changed in this release by checking the
-[changelog](http://www.doctrine-project.org/change_log/1_2_0_ALPHA2) and
+[changelog](https://www.doctrine-project.org/change_log/1_2_0_ALPHA2) and
 you can snag it from the
-[download](http://www.doctrine-project.org/download) page.
+[download](https://www.doctrine-project.org/download) page.
 
 We hope that everything goes fine from here and the next release will be
 BETA1 followed by an RC and stable release. Please give 1.2 a try and

--- a/source/blog/2009-10-21-doctrine-1-2-alpha3-released.md
+++ b/source/blog/2009-10-21-doctrine-1-2-alpha3-released.md
@@ -10,17 +10,17 @@ Doctrine 1.2. We decided to have one more alpha due to some interesting
 issues and improvements brought to our attention related to PEAR
 model/file naming standards, result set caching improvements and a few
 other things. You can of course check out what all is new in Doctrine in
-the [upgrade](http://www.doctrine-project.org/upgrade/1_2) file. Below
+the [upgrade](https://www.doctrine-project.org/upgrade/1_2) file. Below
 are some quick links to some of the most recent changes.
 
 -   [PEAR Style Model Loading and
-    Generation](http://www.doctrine-project.org/upgrade/1_2#PEAR%20Style%20Model%20Loading%20and%20Generation)
+    Generation](https://www.doctrine-project.org/upgrade/1_2#PEAR%20Style%20Model%20Loading%20and%20Generation)
 -   [Ordering
-    Relationships](http://www.doctrine-project.org/upgrade/1_2#Ordering%20Relationships)
+    Relationships](https://www.doctrine-project.org/upgrade/1_2#Ordering%20Relationships)
 -   [Result Cache
-    Improvements](http://www.doctrine-project.org/upgrade/1_2#Result%20Cache%20Improvements)
+    Improvements](https://www.doctrine-project.org/upgrade/1_2#Result%20Cache%20Improvements)
 
-Go ahead and [download](http://www.doctrine-project.org/download)
+Go ahead and [download](https://www.doctrine-project.org/download)
 Doctrine 1.2 ALPHA3 and give it a try. Let us know if you have any
 issues by raising a new issue in
-[JIRA](http://www.doctrine-project.org/jira).
+[JIRA](https://www.doctrine-project.org/jira).

--- a/source/blog/2009-11-03-a-doctrine-triple-play.md
+++ b/source/blog/2009-11-03-a-doctrine-triple-play.md
@@ -12,7 +12,7 @@ Doctrine 1.0.13
 
 This is a regular maintenance release for the Doctrine 1.0 branch and
 contains several bug fixes. Check out the [change
-log](http://www.doctrine-project.org/change_log/1_0_13) for the changes
+log](https://www.doctrine-project.org/change_log/1_0_13) for the changes
 contained in this release.
 
 Doctrine 1.1.5
@@ -24,7 +24,7 @@ branch as the scheduled support for this version has technically ended
 on November 1st. We will have a few more maintenance releases for 1.1
 since Doctrine 1.2 is not out yet. We'll give a few months of overlap to
 give people some time to upgrade to Doctrine 1.2. Check out the [change
-log](http://www.doctrine-project.org/change_log/1_1_5) for the changes
+log](https://www.doctrine-project.org/change_log/1_1_5) for the changes
 contained in this release.
 
 Doctrine 1.2.0-BETA1
@@ -33,10 +33,10 @@ Doctrine 1.2.0-BETA1
 This is the first BETA of the Doctrine 1.2 branch. This release is a
 very exciting one as it will be a LTS(long term support) version and it
 contains lots of new features and bug fixes. Check out the [change
-log](http://www.doctrine-project.org/change_log/1_2_0_BETA1) for the
+log](https://www.doctrine-project.org/change_log/1_2_0_BETA1) for the
 changes contained in this release. You can also see documentation for
 everything that has changed or is new in Doctrine 1.2 on the [What's
-New](http://www.doctrine-project.org/upgrade/1_2) page.
+New](https://www.doctrine-project.org/upgrade/1_2) page.
 
 Like always, you can grab the package for these new versions on the
-[download](http://www.doctrine-project.org/download) page.
+[download](https://www.doctrine-project.org/download) page.

--- a/source/blog/2009-11-04-doctrine-1-2-documentation-available.md
+++ b/source/blog/2009-11-04-doctrine-1-2-documentation-available.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2009/11/04/doctrine-1-2-documentation-available.html
 ---
 I am happy to announce that [Doctrine 1.2
-documentation](http://www.doctrine-project.org/documentation/manual/1_2/en)
+documentation](https://www.doctrine-project.org/documentation/manual/1_2/en)
 is now available and up to date. It might still need some work but for
 the most part it is updated with all the new features and changes in
 1.2.
@@ -19,5 +19,5 @@ New Chapters
 -   [Extensions](https://www.doctrine-project.org/projects/doctrine1/en/latest/manual/extensions.html)
 
 Please read over it and create
-[Jira](http://www.doctrine-project.org/jira) issues for any problems or
+[Jira](https://www.doctrine-project.org/jira) issues for any problems or
 corrections you find.

--- a/source/blog/2009-11-10-doctrine-1-2-0-beta2-released.md
+++ b/source/blog/2009-11-10-doctrine-1-2-0-beta2-released.md
@@ -8,10 +8,10 @@ permalink: /2009/11/10/doctrine-1-2-0-beta2-released.html
 Today I am happy to bring you the second beta of the latest Doctrine 1.2
 version. This is a solid bug fix release and we're getting very close to
 a stable 1.2 version of Doctrine! It is recommended that you upgrade and
-[report](http://www.doctrine-project.org/jira) any issues in
-[Jira](http://www.doctrine-project.org/jira) to help us test for
+[report](https://www.doctrine-project.org/jira) any issues in
+[Jira](https://www.doctrine-project.org/jira) to help us test for
 regressions between 1.1 and 1.2.
 
 Take a look at the
-[changelog](http://www.doctrine-project.org/change_log/1_2_0_BETA2) and
-try it out by [downloading](http://www.doctrine-project.org) it.
+[changelog](https://www.doctrine-project.org/change_log/1_2_0_BETA2) and
+try it out by [downloading](https://www.doctrine-project.org) it.

--- a/source/blog/2009-11-11-doctrine-2-0-0-alpha3-released.md
+++ b/source/blog/2009-11-11-doctrine-2-0-0-alpha3-released.md
@@ -23,11 +23,11 @@ Highlights
     clear-cache task.
 
 View the complete [change
-log](http://www.doctrine-project.org/change_log/2_0_0_ALPHA3) to see a
+log](https://www.doctrine-project.org/change_log/2_0_0_ALPHA3) to see a
 detailed list of every change contained in this release. You can
-[download](http://www.doctrine-project.org/download#2_0) this release
+[download](https://www.doctrine-project.org/download#2_0) this release
 and report any issues you find in
-[Jira](http://www.doctrine-project.org/jira).
+[Jira](https://www.doctrine-project.org/jira).
 
 What is Next?
 =============

--- a/source/blog/2009-11-16-doctrine-1-2-0-beta3-released.md
+++ b/source/blog/2009-11-16-doctrine-1-2-0-beta3-released.md
@@ -12,7 +12,7 @@ planned we will have a stable release hopefully a little before the end
 of November.
 
 You can view the [change
-log](http://www.doctrine-project.org/change_log/1_2_0_BETA3) or
-[download](http://www.doctrine-project.org/download#1_2) this release
+log](https://www.doctrine-project.org/change_log/1_2_0_BETA3) or
+[download](https://www.doctrine-project.org/download#1_2) this release
 now. If you find any issues please open tickets in
-[Jira](http://www.doctrine-project.org/jira).
+[Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2009-11-18-php-benchmarking-mythbusters.md
+++ b/source/blog/2009-11-18-php-benchmarking-mythbusters.md
@@ -248,6 +248,6 @@ around easily. That just shows how meaningless these comparisons are.
 
 > **NOTE** All the code used to run these benchmarks can be downloaded
 > from
-> [here](http://www.doctrine-project.org/downloads/doctrine2outletbenchmark.zip).
+> [here](https://www.doctrine-project.org/downloads/doctrine2outletbenchmark.zip).
 > It is a zip archive containing all the code you need to run the
 > benchmarks yourself.

--- a/source/blog/2009-11-23-doctrine-1-2-0-rc1-released.md
+++ b/source/blog/2009-11-23-doctrine-1-2-0-rc1-released.md
@@ -6,14 +6,14 @@ categories: [release]
 permalink: /2009/11/23/doctrine-1-2-0-rc1-released.html
 ---
 Today the first release candidate for the 1.2 version of Doctrine is
-available for [download](http://www.doctrine-project.org/download#1_2).
+available for [download](https://www.doctrine-project.org/download#1_2).
 We addressed around 20 or so issues in
-[Jira](http://www.doctrine-project.org/jira) for this release and we
+[Jira](https://www.doctrine-project.org/jira) for this release and we
 hope to have a stable release by the end of November. Please test this
 latest release and report any issues you discover in
-[Jira](http://www.doctrine-project.org/jira).
+[Jira](https://www.doctrine-project.org/jira).
 
 View the full [change
-log](http://www.doctrine-project.org/change_log/1_2_0_RC1) for this
-release and [download RC1](http://www.doctrine-project.org/download#1_2)
+log](https://www.doctrine-project.org/change_log/1_2_0_RC1) for this
+release and [download RC1](https://www.doctrine-project.org/download#1_2)
 now!

--- a/source/blog/2009-11-23-new-doctrine-core-team-member.md
+++ b/source/blog/2009-11-23-new-doctrine-core-team-member.md
@@ -14,4 +14,4 @@ to the team.
 Benjamin is a contributor to the Zend Framework as well so he will be
 responsible for leading the integration between the projects. You can
 read a little more about Benjamin on his [about
-page](http://www.doctrine-project.org/contributor/beberlei).
+page](https://www.doctrine-project.org/contributor/beberlei).

--- a/source/blog/2009-11-30-doctrine-1-2-0-stable-released.md
+++ b/source/blog/2009-11-30-doctrine-1-2-0-stable-released.md
@@ -27,21 +27,21 @@ Release Highlights
 
 Below you will find some of the highlights from this release. Of course
 you can view the full
-[upgrade](http://www.doctrine-project.org/upgrade/1_2) page to see all
+[upgrade](https://www.doctrine-project.org/upgrade/1_2) page to see all
 the new things in Doctrine 1.2.
 
 -   [Custom
-    Hydrators](http://www.doctrine-project.org/upgrade/1_2#Custom%20Hydrators)
+    Hydrators](https://www.doctrine-project.org/upgrade/1_2#Custom%20Hydrators)
 -   [Improved Magic
-    Finders](http://www.doctrine-project.org/upgrade/1_2#Expanded%20Magic%20Finders%20to%20Multiple%20Fields)
+    Finders](https://www.doctrine-project.org/upgrade/1_2#Expanded%20Magic%20Finders%20to%20Multiple%20Fields)
 -   [On-Demand
-    Hydration](http://www.doctrine-project.org/upgrade/1_2#On%20Demand%20Hydration)
+    Hydration](https://www.doctrine-project.org/upgrade/1_2#On%20Demand%20Hydration)
 -   [Nested Set
-    Hierarchy](http://www.doctrine-project.org/upgrade/1_2#Doctrine%20Nested%20Set%20Hierarchy%20Structure)
+    Hierarchy](https://www.doctrine-project.org/upgrade/1_2#Doctrine%20Nested%20Set%20Hierarchy%20Structure)
 -   [Result Cache
-    Improvements](http://www.doctrine-project.org/upgrade/1_2#Result%20Cache%20Improvements)
+    Improvements](https://www.doctrine-project.org/upgrade/1_2#Result%20Cache%20Improvements)
 
-Please, [download](http://www.doctrine-project.org/download#1_2)
+Please, [download](https://www.doctrine-project.org/download#1_2)
 Doctrine 1.2 today and give it a try. Let us know any problems you have
 by reporting a new issue in
-[Jira](http://www.doctrine-project.org/jira).
+[Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2009-12-01-more-doctrine-releases.md
+++ b/source/blog/2009-12-01-more-doctrine-releases.md
@@ -9,6 +9,6 @@ Only a few hours ago we released the stable version of Doctrine 1.2! Now
 we bring you two maintenance releases for the 1.0 and 1.1 versions of
 Doctrine. The number of changes in these releases are small, but they
 are important bug fixes. It is recommended that you upgrade. Download
-[1.0.14](http://www.doctrine-project.org/download#1_0) and
-[1.1.6](http://www.doctrine-project.org/download#1_1) now and report any
-issues you discover in [Jira](http://www.doctrine-project.org/jira).
+[1.0.14](https://www.doctrine-project.org/download#1_0) and
+[1.1.6](https://www.doctrine-project.org/download#1_1) now and report any
+issues you discover in [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2009-12-07-doctrine-1-2-1-released.md
+++ b/source/blog/2009-12-07-doctrine-1-2-1-released.md
@@ -71,7 +71,7 @@ directory is clean
 </ul>
 
 You can view the full [change
-log](http://www.doctrine-project.org/change_log/1_2_1) and
-[download](http://www.doctrine-project.org/download#1_2) now! If you
+log](https://www.doctrine-project.org/change_log/1_2_1) and
+[download](https://www.doctrine-project.org/download#1_2) now! If you
 encounter any issues please report them in
-[Jira](http://www.doctrine-project.org/jira).
+[Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2010-01-22-doctrine-2-0-0-alpha4-released.md
+++ b/source/blog/2010-01-22-doctrine-2-0-0-alpha4-released.md
@@ -18,11 +18,11 @@ Highlights
 -   XML Mapping Driver Improvements: [DDC-243], [DDC-242], [DDC-159]
 
 View the complete [change
-log](http://www.doctrine-project.org/change_log/2_0_0_ALPHA4) to see a
+log](https://www.doctrine-project.org/change_log/2_0_0_ALPHA4) to see a
 detailed list of every change contained in this release. You can
-[download](http://www.doctrine-project.org/download#2_0) this release
+[download](https://www.doctrine-project.org/download#2_0) this release
 and report any issues you find in
-[Jira](http://www.doctrine-project.org/jira).
+[Jira](https://www.doctrine-project.org/jira).
 
 We would like to thank everyone who participated in this release through
 bug reports, patches and suggestions.

--- a/source/blog/2010-02-18-symfony-live-2010.md
+++ b/source/blog/2010-02-18-symfony-live-2010.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2010/02/18/symfony-live-2010.html
 ---
 This past week I had the pleasure of spending time in Paris, France for
-the [2010 Symfony Live](http://www.symfony-live.com) conference. My
+the [2010 Symfony Live](https://live.symfony.com/) conference. My
 first Symfony event was [Symfony Camp](http://www.symfonycamp.com) in
 2008 which was a great success. I also attended the first Symfony Live
 last year where I spoke about [Sympal](http://www.sympalphp.org) and
@@ -27,7 +27,7 @@ You can find the presentations given at the conference related to
 Doctrine below:
 
 -   [Using Doctrine
-    Migrations](http://www.slideshare.net/denderello/symfony-live-2010-using-doctrine-migrations)
+    Migrations](https://www.slideshare.net/denderello/symfony-live-2010-using-doctrine-migrations)
 -   [Doctrine 2: Not the same Old PHP
-    ORM](http://www.slideshare.net/jwage/doctrine-2-not-the-same-old-php-orm)
+    ORM](https://www.slideshare.net/jwage/doctrine-2-not-the-same-old-php-orm)
 

--- a/source/blog/2010-03-15-doctrine-2-at-confoo-2010.md
+++ b/source/blog/2010-03-15-doctrine-2-at-confoo-2010.md
@@ -9,7 +9,7 @@ This past week I was lucky enough to get to travel to Montreal for the
 annual ConFoo conference, previously known as PHP Quebec. I presented on
 the latest and greatest version of Doctrine, 2.0 for the PHP Trac. You
 can find the slides on SlideShare.com
-[here](http://www.slideshare.net/jwage/doctrine-2-enterprise-persistence-layer-for-php-3402070)
+[here](https://www.slideshare.net/jwage/doctrine-2-enterprise-persistence-layer-for-php-3402070)
 or view the presentation embedded below:
 
 <div style="margin-left: 30px; width:425px" id="__ss_3402070">

--- a/source/blog/2010-03-29-doctrine-1-2-2-released.md
+++ b/source/blog/2010-03-29-doctrine-1-2-2-released.md
@@ -7,11 +7,11 @@ permalink: /2010/03/29/doctrine-1-2-2-released.html
 ---
 Today I am happy to bring you the second maintenance release for the 1.2
 version of Doctrine. This release contains around 100 fixed issues from
-[Jira](http://www.doctrine-project.org/jira/browse/DC/fixforversion/10047).
+[Jira](https://www.doctrine-project.org/jira/browse/DC/fixforversion/10047).
 We will continue regularly creating maintenance releases for the
 Doctrine 1.2 version so if you have any problems, please create a issue
 on Jira, include a patch with tests and we'll try and include it in the
 next version.
 
 As always you can find information about this new version on the
-[download](http://www.doctrine-project.org/download) page.
+[download](https://www.doctrine-project.org/download) page.

--- a/source/blog/2010-03-29-doctrine2-custom-dql-udfs.md
+++ b/source/blog/2010-03-29-doctrine2-custom-dql-udfs.md
@@ -120,7 +120,7 @@ FunctionNode somewhere in the AST of the dql statement.
 
 The `ArithmeticPrimary` method call is the most common denominator of
 valid EBNF tokens taken from the [DQL EBNF
-grammer](http://www.doctrine-project.org/documentation/manual/2_0/en/dql-doctrine-query-language#ebnf)
+grammer](https://www.doctrine-project.org/documentation/manual/2_0/en/dql-doctrine-query-language#ebnf)
 that matches our requirements for valid input into the DateDiff Dql
 function. Picking the right tokens for your methods is a tricky
 business, but the EBNF grammer is pretty helpful finding it, as is
@@ -229,4 +229,4 @@ sql functions and extend the DQL languages scope.
 
 Code for this Extension to DQL and other Doctrine Extensions can be
 found [in my Github DoctrineExtensions
-repository](http://github.com/beberlei/DoctrineExtensions).
+repository](https://github.com/beberlei/DoctrineExtensions).

--- a/source/blog/2010-04-20-orm-is-not-a-choice.md
+++ b/source/blog/2010-04-20-orm-is-not-a-choice.md
@@ -7,7 +7,7 @@ permalink: /2010/04/20/orm-is-not-a-choice.html
 ---
 **NOTE** When speaking of "ORM" or "object-relational mapping" in
 :   this post I am referring to the act of mapping an [object-oriented
-    domain model](http://martinfowler.com/eaaCatalog/domainModel.html)
+    domain model](https://martinfowler.com/eaaCatalog/domainModel.html)
     to a relational database. There are other, alternative forms of
     object-relational mapping.
 
@@ -17,9 +17,9 @@ either use or not. The choices are elsewhere. Furthermore, if there is a
 dislike for ORM tools it helps to clarify what exactly is the cause. The
 cause can be a dislike of object-oriented domain models. For example, if
 you prefer to separate data from behavior/logic, as [I've read recently
-on Twitter](http://twitter.com/elazar/status/12492601691) , then it is a
+on Twitter](https://twitter.com/elazar/status/12492601691) , then it is a
 sign that you don't like domain models, at least not rich ones, maybe
-[anemic ones](http://martinfowler.com/bliki/AnemicDomainModel.html) ,
+[anemic ones](https://martinfowler.com/bliki/AnemicDomainModel.html) ,
 and you probably don't like OOP much at all then, because bundling data
 with behavior is what OO is about, usually.
 

--- a/source/blog/2010-04-27-doctrine-2-0-0-beta1-released.md
+++ b/source/blog/2010-04-27-doctrine-2-0-0-beta1-released.md
@@ -15,17 +15,17 @@ incompatible changes to be much lower.
 
 Since the ALPHA4 release over 160 issues have been resolved. You can
 find the full changelog
-[here](http://www.doctrine-project.org/jira/secure/ReleaseNote.jspa?projectId=10032&styleName=Html&version=10030).
+[here](https://www.doctrine-project.org/jira/secure/ReleaseNote.jspa?projectId=10032&styleName=Html&version=10030).
 
 Some of the most important changes were the shift towards the Symfony
 (2) Console component for the CLI as well as the introduction of the
 inversedBy attribute for bidirectional associations, among others. For
 some help with upgrading from ALPHA4 to BETA1, please consult [the
-upgrade page](http://www.doctrine-project.org/upgrade/2_0).
+upgrade page](https://www.doctrine-project.org/upgrade/2_0).
 
 You can get the new release as usual from our [download
-page](http://www.doctrine-project.org/download) or [directly from
-github](http://github.com/doctrine/doctrine2).
+page](https://www.doctrine-project.org/download) or [directly from
+github](https://github.com/doctrine/doctrine2).
 
 We would like to thank all the adopters of the early alpha releases. All
 your issue reports, feature and enhancement requests and general

--- a/source/blog/2010-05-12-a-few-website-changes.md
+++ b/source/blog/2010-05-12-a-few-website-changes.md
@@ -15,16 +15,16 @@ well!
 You can now find dedicated sections of the website for both the Object
 Relational Mapper and Database Abstraction Layer projects:
 
--   [ORM Project](http://www.doctrine-project.org/projects/orm)
--   [DBAL Project](http://www.doctrine-project.org/projects/dbal)
+-   [ORM Project](https://www.doctrine-project.org/projects/orm)
+-   [DBAL Project](https://www.doctrine-project.org/projects/dbal)
 
 The new website also introduces a new API Documentation thanks to [PHP
 Doctor](http://peej.github.com/phpdoctor/)!
 
 -   [Doctrine 2 ORM API
-    Documentation](http://www.doctrine-project.org/projects/orm/2.0/api)
+    Documentation](https://www.doctrine-project.org/projects/orm/2.0/api)
 -   [Doctrine 2 DBAL API
-    Documentation](http://www.doctrine-project.org/projects/dbal/2.0/api)
+    Documentation](https://www.doctrine-project.org/projects/dbal/2.0/api)
 
 If you have any problems with the website please let me know by e-mail
 at jonwage [at] gmail.com.

--- a/source/blog/2010-05-13-doctrine-mongodb-object-document-mapper.md
+++ b/source/blog/2010-05-13-doctrine-mongodb-object-document-mapper.md
@@ -15,7 +15,7 @@ A few weekends ago I decided to install MongoDB and give it a try. It
 was pretty fun and interesting. I quickly learned that it being a
 document based storage system lends itself well to a object mapper so
 the experimental [Doctrine MongoDB Object Document
-Mapper](http://github.com/jwage/odm) was born.
+Mapper](https://github.com/jwage/odm) was born.
 
 Introducing Doctrine MongoDB Object Document Mapper (ODM)
 =========================================================
@@ -85,7 +85,7 @@ Below you can find an overview list of the features available:
 -   Create references between documents in different databases.
 -   Map documents with Annotations, XML, YAML or plain old PHP code.
 -   Documents can be stored on the
-    [MongoGridFS](http://www.php.net/MongoGridFS).
+    [MongoGridFS](https://secure.php.net/MongoGridFS).
 -   Collection per class(concrete) and single collection inheritance
     supported.
 -   Map your Doctrine 2 ORM Entities to the ODM and use mixed data
@@ -102,20 +102,20 @@ We've put together a little documentation to help you get familiar with
 the ODM quickly.
 
 -   [Reference
-    Documentation](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/en)
+    Documentation](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/en)
 -   [Getting Started Cookbook
-    Article](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/cookbook/getting-started/en)
+    Article](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/cookbook/getting-started/en)
 -   [API
-    Documentation](http://www.doctrine-project.org/projects/mongodb_odm/1.0/api)
+    Documentation](https://www.doctrine-project.org/projects/mongodb_odm/1.0/api)
 
 How can I contribute?
 =====================
 
 Get your fork on! All you need to do is fork a Doctrine
-[repository](http://github.com/doctrine) on github.com and [submit your
-modifications](http://github.com/guides/fork-a-project-and-submit-your-modifications/7)
+[repository](https://github.com/doctrine) on github.com and [submit your
+modifications](https://github.com/guides/fork-a-project-and-submit-your-modifications/7)
 to us by sending a pull request.
 
 You can also take part in discussions on our [mailing
-list](http://groups.google.com/group/doctrine-user) or join \#doctrine
+list](https://groups.google.com/forum/#!forum/doctrine-user) or join \#doctrine
 on irc.freenode.net for live support from the community.

--- a/source/blog/2010-05-13-the-switch-to-git.md
+++ b/source/blog/2010-05-13-the-switch-to-git.md
@@ -7,9 +7,9 @@ permalink: /2010/05/13/the-switch-to-git.html
 ---
 Now that the dust has settled from the move to git I suppose it is time
 for a blog post. About a month ago, we made the decision to switch the
-Doctrine projects source control to [git](http://git-scm.com). Like many
+Doctrine projects source control to [git](https://git-scm.com). Like many
 other [open source projects](http://www.symfony-project.org) , we also
-chose [github.com](http://www.github.com) to host our repositories.
+chose [github.com](https://www.github.com) to host our repositories.
 Github brings a whole new level of collaborative coding to the Doctrine
 community and I can already see more people getting involved because of
 it.
@@ -26,7 +26,7 @@ do so by using the read-only SVN features of github.com:
     [http://svn.github.com/doctrine/doctrine2.git](http://svn.github.com/doctrine/doctrine2.git)
 
 You can read about this feature on the github
-[blog](http://github.com/blog/626-announcing-svn-support).
+[blog](https://github.com/blog/626-announcing-svn-support).
 
 Need to learn git?
 ==================
@@ -43,8 +43,8 @@ Want to contribute to Doctrine?
 
 If you are interested in contributing to the Doctrine project, you will
 need to fork one of the Doctrine
-[repositories](http://github.com/doctrine) and submit your
+[repositories](https://github.com/doctrine) and submit your
 modifications. You can read more about how to ["Fork a project and
 submit your
-modifications"](http://github.com/guides/fork-a-project-and-submit-your-modifications/7)
+modifications"](https://github.com/guides/fork-a-project-and-submit-your-modifications/7)
 on the github website.

--- a/source/blog/2010-05-27-bringing-it-all-together.md
+++ b/source/blog/2010-05-27-bringing-it-all-together.md
@@ -13,7 +13,7 @@ Website Changes
 ===============
 
 A few weeks ago I made some
-[updates](http://www.doctrine-project.org/blog/a-few-website-changes) to
+[updates](https://www.doctrine-project.org/blog/a-few-website-changes) to
 the Doctrine website. Some said it looked like we took a step backwards.
 Well, we kind of did. I had to rip apart the website, remove old legacy
 code and reorganize things so that it can be integrated with the changes
@@ -25,7 +25,7 @@ The Switch to git
 =================
 
 The next big change we wanted to make was to switch to
-[github.com](http://www.doctrine-project.org) for our source control.
+[github.com](https://www.doctrine-project.org) for our source control.
 This has a lot of impact on the project since everything is built around
 the source control, including the website. That is why the previous
 change was necessary in order to make this move complete.
@@ -37,14 +37,14 @@ The next step for us was to split the Doctrine 2 sources into separate
 repositories on github. So now the source code of the Common, DBAL, and
 ORM packages are truly separated.
 
--   [Common](http://github.com/doctrine/common)
--   [DBAL](http://github.com/doctrine/dbal)
--   [ORM](http://github.com/doctrine/doctrine2)
+-   [Common](https://github.com/doctrine/common)
+-   [DBAL](https://github.com/doctrine/dbal)
+-   [ORM](https://github.com/doctrine/doctrine2)
 
 This means the packages can evolve independently and will be maintained
 separately from now on. The website also has dedicated project pages for
-the [DBAL](http://www.doctrine-project.org/projects/dbal) and
-[ORM](http://www.doctrine-project.org/projects/orm) with plenty of
+the [DBAL](https://www.doctrine-project.org/projects/dbal) and
+[ORM](https://www.doctrine-project.org/projects/orm) with plenty of
 documentation.
 
 Bringing it all together
@@ -52,10 +52,10 @@ Bringing it all together
 
 The last piece that brings it all together is the new [Guide for
 Doctrine Contributors and
-Collaborators](http://www.doctrine-project.org/contribute). Now that
+Collaborators](https://www.doctrine-project.org/contribute). Now that
 we've moved to git we had to reinvent a lot of stuff we had already
 learned for SVN. Thanks to our git mentor David Abdemoulaie
-([hobodave](http://www.twitter.com/hobodave)) we have figured out a
+([hobodave](https://www.twitter.com/hobodave)) we have figured out a
 workable solution for dealing with the project dependencies via git
 submodules that does most of what we want. Through this process we all
 worked on some new documentation that detailed how contributors and

--- a/source/blog/2010-06-09-doctrine-mongodb-odm-1-0-0alpha1-released.md
+++ b/source/blog/2010-06-09-doctrine-mongodb-odm-1-0-0alpha1-released.md
@@ -6,7 +6,7 @@ categories: [release]
 permalink: /2010/06/09/doctrine-mongodb-odm-1-0-0alpha1-released.html
 ---
 Today I am very happy to announce the release of the first alpha version
-of the Doctrine [MongoDB](http://www.mongodb.org) Object Document
+of the Doctrine [MongoDB](https://www.mongodb.com/) Object Document
 Mapper. This is exciting as it is the beginning of a whole new chapter
 in the life of the Doctrine Project. We hope to continue adding packages
 to allow you to transparently persist your domain objects to a variety
@@ -20,23 +20,23 @@ Doctrine MongoDB Object Document Mapper:
 
 -   Transparent persistence.
 -   Map one or many
-    [embedded](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/embedded-mapping/en)
+    [embedded](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/embedded-mapping/en)
     documents.
 -   Map one or many
-    [referenced](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/reference-mapping/en)
+    [referenced](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/reference-mapping/en)
     documents.
 -   Create references between documents in different databases.
 -   Map documents with
-    [Annotations](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/annotations-reference/en)
+    [Annotations](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/annotations-reference/en)
     ,
-    [XML](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/xml-mapping/en#xml-mapping)
+    [XML](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/xml-mapping/en#xml-mapping)
     ,
-    [YAML](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/yml-mapping/en#yml-mapping)
+    [YAML](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/yml-mapping/en#yml-mapping)
     or plain old PHP code.
 -   Documents can be stored on the
-    [MongoGridFS](http://www.php.net/MongoGridFS).
+    [MongoGridFS](https://secure.php.net/MongoGridFS).
 -   Collection per class(concrete) and single collection
-    [inheritance](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/inheritance-mapping/en)
+    [inheritance](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/inheritance-mapping/en)
     supported.
 -   Map your Doctrine 2 ORM Entities to the ODM and use mixed data
     stores.
@@ -44,17 +44,17 @@ Doctrine MongoDB Object Document Mapper:
     [MongoCollection::batchInsert()](http://us.php.net/manual/en/mongocollection.batchinsert.php)
 -   Updates are performed using the atomic operators \$set, \$pullAll,
     \$pushAll and \$increment instead of saving the entire document.
--   [Migrate](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/migrating-schemas/en)
+-   [Migrate](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/migrating-schemas/en)
     your schema as your domain model evolves and changes.
 -   [Fluent Object Oriented
-    Interface](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/query-api/en)
+    Interface](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/query-api/en)
     for building and executing queries.
 -   [Map
-    Reduce](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/map-reduce/en)
+    Reduce](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/map-reduce/en)
     integration.
 
 You can continue reading the
-[Introduction](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/introduction/en)
+[Introduction](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/introduction/en)
 chapter in the reference documentation to get a grasp of what exactly
 the Doctrine MongoDB Object Document Mapper does by looking at some
 examples!
@@ -66,14 +66,14 @@ Want documentation? You got it! Check out the links below to get started
 learning about the Doctrine MongoDB Object Document Mapper:
 
 -   [Reference
-    Documentation](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/en)
+    Documentation](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/en)
 -   [Getting Started Cookbook
-    Article](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/cookbook/getting-started/en)
+    Article](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/cookbook/getting-started/en)
 -   [API
-    Documentation](http://www.doctrine-project.org/projects/mongodb_odm/1.0/api)
+    Documentation](https://www.doctrine-project.org/projects/mongodb_odm/1.0/api)
 
 We'll be adding more
-[Cookbook](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/cookbook)
+[Cookbook](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/cookbook)
 articles in the coming weeks so check back for more documentation!
 
 Download
@@ -81,7 +81,7 @@ Download
 
 You can see all the download information for the Doctrine MongoDB ODM on
 the projects
-[download](http://www.doctrine-project.org/projects/mongodb_odm/download)
+[download](https://www.doctrine-project.org/projects/mongodb_odm/download)
 page. You have several ways to get the code which are described below as
 well:
 
@@ -96,7 +96,7 @@ Download PEAR Package
 ---------------------
 
 You can manually download the PEAR package
-[here](http://www.doctrine-project.org/downloads/DoctrineMongoDBODM-1.0.0ALPHA1.tgz).
+[here](https://www.doctrine-project.org/downloads/DoctrineMongoDBODM-1.0.0ALPHA1.tgz).
 If you want you can manually unarchive the code or you can
 `pear install` the downloaded package:
 
@@ -115,7 +115,7 @@ Reporting Issues
 
 If you encounter any problems with the Doctrine MongoDB Object Document
 Mapper you can report new issues to the
-[Jira](http://www.doctrine-project.org/jira/browse/MODM) project. For
+[Jira](https://www.doctrine-project.org/jira/browse/MODM) project. For
 more information about contributing to Doctrine you can checkout the
 documentation for our [Contributor
-Workflow](http://www.doctrine-project.org/contribute).
+Workflow](https://www.doctrine-project.org/contribute).

--- a/source/blog/2010-06-15-doctrine2-beta2-released.md
+++ b/source/blog/2010-06-15-doctrine2-beta2-released.md
@@ -49,9 +49,9 @@ Download
 --------
 
 You can get the code a few different ways which are described in detail
-[here](http://www.doctrine-project.org/projects/orm/2.0/download/2.0.0BETA2).
+[here](https://www.doctrine-project.org/projects/orm/2.0/download/2.0.0BETA2).
 If you have any issues with Doctrine you can report them on
-[Jira](http://www.doctrine-project.org/jira).
+[Jira](https://www.doctrine-project.org/jira).
 
 Contributions
 -------------
@@ -59,6 +59,6 @@ Contributions
 We thank all the contributors and early adopters for their extensive
 feedback and reports. If you are interesting in contributing to the
 Doctrine project too, check out our new [contributors
-guide](http://www.doctrine-project.org/contribute) and
-[community](http://www.doctrine-project.org/community) page for
+guide](https://www.doctrine-project.org/contribute) and
+[community](https://www.doctrine-project.org/community) page for
 information about how you can get involved!

--- a/source/blog/2010-07-12-doctrine2-large-collections.md
+++ b/source/blog/2010-07-12-doctrine2-large-collections.md
@@ -31,7 +31,7 @@ following data for any given `PersistentCollection`:
     alternative)
 
 You can get this extension from the [DoctrineExtensions Github
-repository](http://github.com/beberlei/DoctrineExtensions).
+repository](https://github.com/beberlei/DoctrineExtensions).
 
 Working with a LargeCollection
 ==============================

--- a/source/blog/2010-07-19-your-own-orm-doctrine2.md
+++ b/source/blog/2010-07-19-your-own-orm-doctrine2.md
@@ -47,7 +47,7 @@ dependent library.
 This article will describe some possible extensions and show where you
 can hook into the Doctrine2 core to implement your own ORM. The article
 will be very code focused and also comes with a [Github
-project](http://github.com/beberlei/Doctrine-ActiveEntity) where all the
+project](https://github.com/beberlei/Doctrine-ActiveEntity) where all the
 code and some tests are hosted.
 
 Doctrine2 and ActiveRecord
@@ -66,7 +66,7 @@ Some while ago Jonathan already released his approach, called the
 entities have to implement, the code is still [in our SVN
 repository](http://trac.doctrine-project.org/browser/extensions/ActiveEntity/branches/2.0-1.0/DoctrineExtensions/ActiveEntity.php).
 However a more recent version of this code is available as [a project on
-Github](http://github.com/beberlei/Doctrine-ActiveEntity). I won't
+Github](https://github.com/beberlei/Doctrine-ActiveEntity). I won't
 support this experiment any further, I hope somebody picks it up and
 starts maintaining it.
 
@@ -362,7 +362,7 @@ Using Traits for Behaviours
 
 We want to add a simple "Timestampable" behaviour now, hooking into the
 `loadClassMetadata` event [as described in the
-documentation](http://www.doctrine-project.org/projects/orm/2.0/docs/reference/events/en#load-classmetadata-event):
+documentation](https://www.doctrine-project.org/projects/orm/2.0/docs/reference/events/en#load-classmetadata-event):
 
 Now this is untested code, as i don't have a PHP-5.3.99-DEV version
 compiled at this machine.
@@ -456,4 +456,4 @@ required some understanding of the inner workings of Doctrine2, however
 not many changes were required in the end.
 
 [See the code on
-GitHub!](http://github.com/beberlei/Doctrine-ActiveEntity)
+GitHub!](https://github.com/beberlei/Doctrine-ActiveEntity)

--- a/source/blog/2010-07-21-mongodb-odm-query-builder-api.md
+++ b/source/blog/2010-07-21-mongodb-odm-query-builder-api.md
@@ -162,4 +162,4 @@ to right. We hope to enhance and improve this API even more before we
 release the stable 1.0 version.
 
 You can read more about the Query Builder API in the
-[documentation](http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/query-builder-api/en#query-builder-api).
+[documentation](https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/query-builder-api/en#query-builder-api).

--- a/source/blog/2010-07-22-mongodb-for-ecommerce.md
+++ b/source/blog/2010-07-22-mongodb-for-ecommerce.md
@@ -33,10 +33,10 @@ requirements. Something as obvious as the "item you add to cart" could
 be overly complicated when it comes to data.
 
 There is a good example of how to model the database for handling
-variable product attributes; [Magento](http://www.magentocommerce.com)
+variable product attributes; [Magento](https://magento.com/)
 is one of the most advanced open source eCommerce solutions available
 today. It uses [EAV (Entity Attribute
-Value)](http://en.wikipedia.org/wiki/Entity-attribute-value_model) ,
+Value)](https://en.wikipedia.org/wiki/Entity-attribute-value_model) ,
 which solves the problem of variable attributes by sacrificing database
 level integrity and application performance. The amount of queries you
 need to perform to select one entity will grow with every attribute data
@@ -48,16 +48,16 @@ structure it is also possible to add or remove a document's properties
 after saving - it's a database that adapts to your data structure on the
 fly.
 
-At [OpenSky](http://www.theopenskyproject.com/) , we decided to use
-[MongoDB](http://www.mongodb.org/) for storage of products and use
+At [OpenSky](https://www.theopenskyproject.com/) , we decided to use
+[MongoDB](https://www.mongodb.com/) for storage of products and use
 relational databases for order-related data since
-[MongoDB](http://www.mongodb.org/) doesn't support transactions.
+[MongoDB](https://www.mongodb.com/) doesn't support transactions.
 
-So what is the benefit of using [MongoDB](http://www.mongodb.org/) over
+So what is the benefit of using [MongoDB](https://www.mongodb.com/) over
 MySQL, or any other RDBMS, for storing variable attribute data.
 Performance. This is the pseudo-query we would have to write to select
 one product, with id 1, and all of its attributes in a typical [EAV
-model](http://en.wikipedia.org/wiki/Entity-attribute-value_model):
+model](https://en.wikipedia.org/wiki/Entity-attribute-value_model):
 
 <div class="right">
 
@@ -74,9 +74,9 @@ model](http://en.wikipedia.org/wiki/Entity-attribute-value_model):
 
 After the above queries are run, there would be a huge step of data
 hydration into the product object, which
-[Magento](http://www.magentocommerce.com) handles quite well, albeit
+[Magento](https://magento.com/) handles quite well, albeit
 slowly. Contrast this with what we would do in
-[MongoDB](http://www.mongodb.org/):
+[MongoDB](https://www.mongodb.com/):
 
     [javascript]
     db.products.find({'_id': '1'});
@@ -84,7 +84,7 @@ slowly. Contrast this with what we would do in
 Not only is the selection simpler, but it also returns a JSON object,
 which can easily be hydrated into a native PHP object. And here is how a
 configurable product could be represented in
-[MongoDB](http://www.mongodb.org/):
+[MongoDB](https://www.mongodb.com/):
 
     [javascript]
     {
@@ -115,27 +115,27 @@ configurable product could be represented in
     and reference them from the product document.
 
 Of course, there are [plenty of ORM
-libraries](http://www.mongodb.org/display/DOCS/PHP+Language+Center#PHPLanguageCenter-LibraryandFrameworkTools)
-for [MongoDB](http://www.mongodb.org/) , which were either
+libraries](https://docs.mongodb.com/ecosystem/drivers/php/#PHPLanguageCenter-LibraryandFrameworkTools)
+for [MongoDB](https://www.mongodb.com/) , which were either
 hard-to-extract parts of frameworks, not quite ORMs or used the
 [ActiveRecord
-pattern](http://martinfowler.com/eaaCatalog/activeRecord.html) (which
+pattern](https://martinfowler.com/eaaCatalog/activeRecord.html) (which
 after using
-[DataMapper](http://martinfowler.com/eaaCatalog/dataMapper.html) for
+[DataMapper](https://martinfowler.com/eaaCatalog/dataMapper.html) for
 quite some time, I wouldn't want to go back to). The very same day I
 started writing an object document mapper (ODM) to use at
-[OpenSky](http://www.theopenskyproject.com/) , [Jon
-Wage](http://www.twitter.com/jwage) (developer for the Doctrine project)
+[OpenSky](https://www.theopenskyproject.com/) , [Jon
+Wage](https://www.twitter.com/jwage) (developer for the Doctrine project)
 released a proof-of-concept [MongoDB
-ODM](http://www.doctrine-project.org/projects/mongodb_odm) , which you
-can [find on github](http://github.com/doctrine/mongodb-odm). After
+ODM](https://www.doctrine-project.org/projects/mongodb_odm) , which you
+can [find on github](https://github.com/doctrine/mongodb-odm). After
 contacting Jon and giving his library a couple of tries and
-[tests](http://www.phpunit.de/) , I decided to use it for
-[OpenSky](http://www.theopenskyproject.com/)'s products domain layer.
+[tests](https://www.phpunit.de/) , I decided to use it for
+[OpenSky](https://www.theopenskyproject.com/)'s products domain layer.
 
-I started to submit patches and [unit tests](http://www.phpunit.de/) to
+I started to submit patches and [unit tests](https://www.phpunit.de/) to
 the project and soon joined the core team for [MongoDB
-ODM](http://www.doctrine-project.org/projects/mongodb_odm). Today, we
+ODM](https://www.doctrine-project.org/projects/mongodb_odm). Today, we
 are past first alpha release of the project, and this is my first post
 on the Doctrine blog (yay!).
 
@@ -263,21 +263,21 @@ $documentManager->persist($product);
 $documentManager->flush();
 
 **NOTE** MongoDB ODM intelligently uses
-`atomic operators <http://www.mongodb.org/display/DOCS/Atomic+Operations>`_
+`atomic operators <https://docs.mongodb.com/manual/core/write-operations-atomicity/>`_
 to update data, which makes it really fast. It also supports
 inheritance (collection-per-class and single-collection
 inheritances), which is similar to table inheritance design
 patterns for ORMs. Check out the official Mongo ODM
-`project documentation <http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/en>`_
+`project documentation <https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/en>`_
 for more information and examples. Complete instructions on how to
 setup your DocumentManager instance
-`can be found here <http://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/introduction/en>`_.
+`can be found here <https://www.doctrine-project.org/projects/mongodb_odm/1.0/docs/reference/introduction/en>`_.
 ~~~~
 
 The above code would store the product object as a document in
-[MongoDB](http://www.mongodb.org/).
+[MongoDB](https://www.mongodb.com/).
 
 There is much more to talk about in terms or technologies, techniques
 and practices we adopt and use at
-[OpenSky](http://www.theopenskyproject.com/) , so this post is
+[OpenSky](https://www.theopenskyproject.com/) , so this post is
 definitely not the last one.

--- a/source/blog/2010-07-27-dbal2-beta3-released.md
+++ b/source/blog/2010-07-27-dbal2-beta3-released.md
@@ -23,8 +23,8 @@ A total of 13 issues on DBAL has been fixed.
 
 Links:
 
--   [Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10066)
--   [Installation](http://www.doctrine-project.org/projects/dbal/2.0/download/2.0.0BETA3)
+-   [Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10066)
+-   [Installation](https://www.doctrine-project.org/projects/dbal/2.0/download/2.0.0BETA3)
 
     > **NOTE** DBAL BETA 3 is not currently compatible with the ORM
     > master, we still have to make some changes. Please wait to use

--- a/source/blog/2010-07-27-document-oriented-databases-vs-relational-databases.md
+++ b/source/blog/2010-07-27-document-oriented-databases-vs-relational-databases.md
@@ -13,7 +13,7 @@ and approaches and gotchas one should remember when dealing with either.
 I had some thoughts on the subject, but they didn't feel complete, so I
 decided to do some research. I started out by googling ["document
 -oriented databases vs relational
-databases"](http://www.google.com/search?q=document+-oriented+databases+vs+relational+databases)
+databases"](https://www.google.com/search?q=document+-oriented+databases+vs+relational+databases)
 , which brought a number of interesting results. After some intense
 reading and analyzing, I think I have a good enough understanding of the
 concepts, strengths and weaknesses of different data stores to write and
@@ -25,8 +25,8 @@ internet user-base, the number of reads and writes a typical application
 needed to perform grew rapidly. This led to the need for scaling.
 Traditional RDBMSs were hard to scale (SQL operation or Transaction
 spanning multiple nodes doesn't scale well). With solutions like [MySQL
-Cluster](http://www.mysql.com/products/database/cluster/) and [Oracle
-RAC](http://www.oracle.com/technology/products/database/clustering/index.html)
+Cluster](https://www.mysql.com/products/cluster/) and [Oracle
+RAC](https://www.oracle.com/database/technologies/rac.html)
 , this is much less of a problem now, but it wasn't the case for a
 while, which led to many companies abandoning traditional RDBMSs for
 "noSQL" data stores.

--- a/source/blog/2010-07-30-doctrine-mongodb-odm-1-0-0alpha2-released.md
+++ b/source/blog/2010-07-30-doctrine-mongodb-odm-1-0-0alpha2-released.md
@@ -101,7 +101,7 @@ Download
 ========
 
 You can directly download the PEAR package file
-[here](http://www.doctrine-project.org/downloads/DoctrineMongoDBODM-1.0.0ALPHA2.tgz).
+[here](https://www.doctrine-project.org/downloads/DoctrineMongoDBODM-1.0.0ALPHA2.tgz).
 You can manually extract the code or you can install the PEAR package
 file locally.
 

--- a/source/blog/2010-08-06-doctrine2-orm-beta3.md
+++ b/source/blog/2010-08-06-doctrine2-orm-beta3.md
@@ -7,8 +7,8 @@ permalink: /2010/08/06/doctrine2-orm-beta3.html
 ---
 We would like to announce the immediate release of Doctrine ORM BETA 3:
 
--   [Installation](http://www.doctrine-project.org/projects/orm/2.0/download/2.0.0BETA3)
--   [Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10060)
+-   [Installation](https://www.doctrine-project.org/projects/orm/2.0/download/2.0.0BETA3)
+-   [Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10060)
 
 We fixed 45 issues, most of them bugs reported by our users. The ORM
 package is now in a state where no new features will be added and we
@@ -36,7 +36,7 @@ The DBAL Type "datetime" included the Timezone Offset in both Postgres
 and Oracle. As of this version they are now generated without Timezone
 (TIMESTAMP WITHOUT TIME ZONE instead of TIMESTAMP WITH TIME ZONE). See
 [this comment to Ticket
-DBAL-22](http://www.doctrine-project.org/jira/browse/DBAL-22?focusedCommentId=13396&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#action_13396)
+DBAL-22](https://www.doctrine-project.org/jira/browse/DBAL-22?focusedCommentId=13396&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#action_13396)
 for more details as well as migration issues for PostgreSQL and Oracle.
 
 Both Postgres and Oracle will throw Exceptions during hydration of

--- a/source/blog/2010-08-07-dc2-experimental-associations-id-fields.md
+++ b/source/blog/2010-08-07-dc2-experimental-associations-id-fields.md
@@ -33,10 +33,10 @@ sure that it works correctly and does not have to many problematic
 edge-cases. Therefore we need your feedback.
 
 -   Go to
-    [[http://github.com/doctrine/doctrine2/commits/DDC-117](http://github.com/doctrine/doctrine2/commits/DDC-117)](http://github.com/doctrine/doctrine2/commits/DDC-117)
+    [[https://github.com/doctrine/doctrine2/commits/DDC-117](https://github.com/doctrine/doctrine2/commits/DDC-117)](https://github.com/doctrine/doctrine2/commits/DDC-117)
     to see the code
 -   [Have a look at the functional
-    tests](http://github.com/doctrine/doctrine2/blob/DDC-117/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php)
+    tests](https://github.com/doctrine/doctrine2/blob/DDC-117/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php)
     to see the synatx
 -   Checkout the Git Repository and switch to the experimental branch
     `git checkout DDC-117`

--- a/source/blog/2010-08-18-mongodb-odm-1-0-0beta1-released.md
+++ b/source/blog/2010-08-18-mongodb-odm-1-0-0beta1-released.md
@@ -114,7 +114,7 @@ Download
 ========
 
 You can directly download the PEAR package file
-[here](http://www.doctrine-project.org/downloads/DoctrineMongoDBODM-1.0.0BETA1.tgz).
+[here](https://www.doctrine-project.org/downloads/DoctrineMongoDBODM-1.0.0BETA1.tgz).
 You can manually extract the code or you can install the PEAR package
 file locally.
 

--- a/source/blog/2010-09-01-birthday-release-party.md
+++ b/source/blog/2010-09-01-birthday-release-party.md
@@ -13,24 +13,24 @@ Doctrine Common RC1
 
 The first release candidate of the Doctrine Common project.
 
--   [Installation](http://www.doctrine-project.org/projects/common/2.0/download/2.0.0RC1)
--   [Changelog](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10081)
+-   [Installation](https://www.doctrine-project.org/projects/common/2.0/download/2.0.0RC1)
+-   [Changelog](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10081)
 
 Doctrine DBAL BETA4
 ===================
 
 The last beta release of the Doctrine DBAL project.
 
--   [Installation](http://www.doctrine-project.org/projects/dbal/2.0/download/2.0.0BETA4)
--   [Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10071)
+-   [Installation](https://www.doctrine-project.org/projects/dbal/2.0/download/2.0.0BETA4)
+-   [Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10071)
 
 Doctrine ORM BETA4
 ==================
 
 The last beta release of the Doctrine ORM project.
 
--   [Installation](http://www.doctrine-project.org/projects/orm/2.0/download/2.0.0BETA4)
--   [Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10072)
+-   [Installation](https://www.doctrine-project.org/projects/orm/2.0/download/2.0.0BETA4)
+-   [Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10072)
 
 Again we want to thank everyone who participated in the ongoing
 development efforts, whether it was through bug reports, comments,

--- a/source/blog/2010-11-18-common-rc2-dbal-rc2-release.md
+++ b/source/blog/2010-11-18-common-rc2-dbal-rc2-release.md
@@ -13,9 +13,9 @@ In the Common package 3 bugs have been fixed, in the DBAL package 9 bugs
 have been fixed. See the changelogs for details:
 
 -   [Common RC1
-    Changelog](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10093)
+    Changelog](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10093)
 -   [DBAL RC3
-    Changelogt](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10094)
+    Changelogt](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10094)
 
 We are especially thankful for the support Microsoft has been giving us
 to integrate PDO Sqlsrv. Juozas was invited to [Jumpin

--- a/source/blog/2010-12-04-doctrine2-rc1.md
+++ b/source/blog/2010-12-04-doctrine2-rc1.md
@@ -14,6 +14,6 @@ will serve as basis for the final release.
 For this release candidate over 70 tickets were closed. See the
 changelog for a detailed overview:
 
--   [Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10091)
+-   [Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10091)
 
 We want to thank everybody for their contributions and help.

--- a/source/blog/2010-12-12-doctrine2-orm-rc2-released.md
+++ b/source/blog/2010-12-12-doctrine2-orm-rc2-released.md
@@ -18,9 +18,9 @@ Just make sure to call flush explicitly whenever you need it.
 See the changelogs for both projects:
 
 -   [DBAL RC5
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10113)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10113)
 -   [ORM RC2
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10112)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10112)
 
 Both DBAL and ORM are essentially bug-free. All the still open bug
 reports are either:
@@ -36,7 +36,7 @@ Expect these Release Candidates to be tagged as final if no critical or
 major issues are discovered in the next week.
 
 You can grab the code from our [downloads
-section](http://www.doctrine-project.org/projects) or [directly from
+section](https://www.doctrine-project.org/projects) or [directly from
 Github](https://github.com/doctrine/doctrine2/commits/2.0.0RC2).
 
 In these last days before the final release we will focus on the

--- a/source/blog/2010-12-21-doctrine2-released.md
+++ b/source/blog/2010-12-21-doctrine2-released.md
@@ -161,22 +161,22 @@ Where do I start?
 =================
 
 You can download Doctrine 2 [from our downloads
-section](http://www.doctrine-project.org/projects/orm/download) ,
+section](https://www.doctrine-project.org/projects/orm/download) ,
 [install it via PEAR](http://pear.doctrine-project.org/) or find it in
-the [Github repository](http://github.com/doctrine/doctrine2). Symfony 2
+the [Github repository](https://github.com/doctrine/doctrine2). Symfony 2
 also ships with a current version of Doctrine 2. After you installed
 Doctrine 2 you can [go to the
-documentation](http://www.doctrine-project.org/docs/orm/2.0/en/) and
+documentation](https://www.doctrine-project.org/docs/orm/2.0/en/) and
 start reading the reference guide or [the
-tutorial](http://www.doctrine-project.org/docs/orm/2.0/en/tutorials/getting-started-xml-edition.html).
+tutorial](https://www.doctrine-project.org/docs/orm/2.0/en/tutorials/getting-started-xml-edition.html).
 
 If you find any bugs or have feature requests you should check our
 [Bug-Tracker and report bugs or feature
-requests](http://www.doctrine-project.org/jira). If you want to discuss
+requests](https://www.doctrine-project.org/jira). If you want to discuss
 about Doctrine 2 you can either [use the Google Group or join the
 \#doctrine channel on the Freenode IRC
-Network](http://www.doctrine-project.org/community). Also make sure to
+Network](https://www.doctrine-project.org/community). Also make sure to
 check the current [Limitations and Known Issues
-section](http://www.doctrine-project.org/docs/orm/2.0/en/reference/limitations-and-known-issues.html)
+section](https://www.doctrine-project.org/docs/orm/2.0/en/reference/limitations-and-known-issues.html)
 in the docs. We are trying to be honest about what Doctrine 2 can and
 can't do but might do in the future.

--- a/source/blog/2011-01-13-roadmap-doctrine2.md
+++ b/source/blog/2011-01-13-roadmap-doctrine2.md
@@ -23,7 +23,7 @@ for June 30th 2011.
 You can follow the Tracker with all the features that are planned for
 2.1:
 
-[[http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022)](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022)
+[[https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022)](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022)
 
 You can already start testing 2.1 development with two new features as
 of last week:

--- a/source/blog/2011-01-30-doctrine-maintenance-jan2011.md
+++ b/source/blog/2011-01-30-doctrine-maintenance-jan2011.md
@@ -9,14 +9,14 @@ We released the first maintenance versions of Common, DBAL and ORM
 today. See the changelogs for more information:
 
 -   [ORM, 26 Bugs
-    fixed](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10114)
+    fixed](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10114)
 -   [DBAL, 1 Bug
-    fixed](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10115)
+    fixed](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10115)
 -   Common, no known bugs
 
 We also optimized the build process, so that the Version Classes in the
 Git Tags do not contain the "-DEV" suffix anymore.
 
-You can get the code from [Git](http://github.com/doctrine) , [our PEAR
+You can get the code from [Git](https://github.com/doctrine) , [our PEAR
 channel](http://pear.doctrine-project.org) or from the [download
-section](http://www.doctrine-project.org/projects) of the website.
+section](https://www.doctrine-project.org/projects) of the website.

--- a/source/blog/2011-02-19-doctrine-mongodb-odm-beta2-released.md
+++ b/source/blog/2011-02-19-doctrine-mongodb-odm-beta2-released.md
@@ -6,7 +6,7 @@ categories: [release]
 permalink: /2011/02/19/doctrine-mongodb-odm-beta2-released.html
 ---
 After a long wait, I am happy to bring you the second beta release of
-the new Doctrine persistence layer for [MongoDB](http://mongodb.org).
+the new Doctrine persistence layer for [MongoDB](https://www.mongodb.com).
 This release includes dozens of bug fixes and improvements and it is
 recommended that you upgrade as soon as possible. You can learn about
 how to get the code here.
@@ -20,27 +20,27 @@ been doing there. The changelog is very large as the development spanned
 almost 5 months with commits from over 15 developers all over the world.
 Here are some of the people who've contributed this release:
 
--   [avalanche123](http://github.com/avalanche123)
--   [bobthecow](http://github.com/bobthecow)
--   [kriswallsmith](http://github.com/kriswallsmith)
--   [jmikola](http://github.com/jmikola)
--   [ornicar](http://github.com/ornicar)
--   [jseverson](http://github.com/jseverson)
--   [pgodel](http://github.com/pgodel)
--   [weaverryan](http://github.com/weaverryan)
--   [docteurklein](http://github.com/docteurklein)
+-   [avalanche123](https://github.com/avalanche123)
+-   [bobthecow](https://github.com/bobthecow)
+-   [kriswallsmith](https://github.com/kriswallsmith)
+-   [jmikola](https://github.com/jmikola)
+-   [ornicar](https://github.com/ornicar)
+-   [jseverson](https://github.com/jseverson)
+-   [pgodel](https://github.com/pgodel)
+-   [weaverryan](https://github.com/weaverryan)
+-   [docteurklein](https://github.com/docteurklein)
 -   [ThomasAdam](https://github.com/ThomasAdam)
--   [dan](http://github.com/dan)
--   [fabpot](http://github.com/fabpot)
--   [IamPersistent](http://github.com/IamPersistent)
--   [igorw](http://github.com/igorw)
--   [Vrtak-CZ](http://github.com/Vrtak-CZ)
+-   [dan](https://github.com/dan)
+-   [fabpot](https://github.com/fabpot)
+-   [IamPersistent](https://github.com/IamPersistent)
+-   [igorw](https://github.com/igorw)
+-   [Vrtak-CZ](https://github.com/Vrtak-CZ)
 
 Documentation
 =============
 
 Check out the
-[documentation](http://www.doctrine-project.org/docs/mongodb_odm/1.0/en)
+[documentation](https://www.doctrine-project.org/docs/mongodb_odm/1.0/en)
 as it is has been completely updated and improved for this release. We
 fully migrated the docs to use reST and Sphinx to generate our
 documentation so it is much improved over the previous versions.

--- a/source/blog/2011-03-05-doctrine-maintenance-mar05.md
+++ b/source/blog/2011-03-05-doctrine-maintenance-mar05.md
@@ -9,9 +9,9 @@ Slightly delayed but here are the releases of DBAL and ORM versions
 2.0.2:
 
 -   [ORM 2.0.2
-    Changeset](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10116)
+    Changeset](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10116)
 -   [DBAL 2.0.2
-    Changeset](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10118)
+    Changeset](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10118)
 
 A total of 22 issues was fixed.
 

--- a/source/blog/2011-03-06-doctrine-oxm-intro.md
+++ b/source/blog/2011-03-06-doctrine-oxm-intro.md
@@ -8,7 +8,7 @@ permalink: /2011/03/06/doctrine-oxm-intro.html
 Greetings programmers!
 
 Some of you may have noticed a new project being hosted by Doctrine's
-[github](http://github.com/doctrine) named [Object XML
+[github](https://github.com/doctrine) named [Object XML
 Mapper(OXM)](https://github.com/doctrine/oxm). The OXM is the newest
 member of the Doctrine family, and serves as persistence and marshalling
 framework for PHP objects to XML, and back again. I'd like to take a
@@ -33,7 +33,7 @@ XML.
 
 As a PHP enthusiest and fan of Doctrine, I created a small project that
 was capable of marshalling, unmarshalling, and persisting PHP objects to
-XML using [Doctrine Common](http://github.com/doctrine/common) package
+XML using [Doctrine Common](https://github.com/doctrine/common) package
 as a base, and many ideas from the ORM, and ODM projects. The Java
 [Castor](http://www.castor.org) project also brought a lot of ideas to
 give a high degree of control to the developer during the

--- a/source/blog/2011-03-20-doctrine-security-fix.md
+++ b/source/blog/2011-03-20-doctrine-security-fix.md
@@ -28,8 +28,8 @@ hole.
 You can grab the packages from PEAR, Archive or Github, see the
 respective links more details:
 
--   [ORM](http://www.doctrine-project.org/projects/orm/download)
--   [DBAL](http://www.doctrine-project.org/projects/dbal/download)
+-   [ORM](https://www.doctrine-project.org/projects/orm/download)
+-   [DBAL](https://www.doctrine-project.org/projects/dbal/download)
 
 The fix for this security hole breaks backwards compatibility for
 developers that extend the

--- a/source/blog/2011-04-07-doctrine2-april-2011-maintenance.md
+++ b/source/blog/2011-04-07-doctrine2-april-2011-maintenance.md
@@ -9,13 +9,13 @@ Slightly behind schedule, but we released the next round of maintenance
 versions of Doctrine Common (2.0.2), DBAL (2.0.4) and ORM (2.0.4) today.
 
 -   [Common Changelog (4 Tickets
-    closed)](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10121)
+    closed)](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10121)
 -   [DBAL Changelog (3 Tickets
-    closed)](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10131)
+    closed)](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10131)
 -   [ORM Changelog (13 Tickets
-    closed)](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10130)
+    closed)](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10130)
 
 You can grab the packages from the download page or our [Github
-repository](http://github.com/doctrine).
+repository](https://github.com/doctrine).
 
 Please report any problems to the Jira Bugtracker.

--- a/source/blog/2011-05-14-doctrine-maintenance-may11.md
+++ b/source/blog/2011-05-14-doctrine-maintenance-may11.md
@@ -13,11 +13,11 @@ should now use the "charset" option in DriverManager::getConnection()
 instead of the MysqlSessionInit listener.
 
 -   [DBAL Changelog (4 Tickets
-    closed)](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10132)
+    closed)](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10132)
 -   [ORM Changelog (15 Tickets
-    closed)](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10133)
+    closed)](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10133)
 
 You can grab the packages from the download page or our [Github
-repository](http://github.com/doctrine).
+repository](https://github.com/doctrine).
 
 Please report any problems to the Jira Bugtracker.

--- a/source/blog/2011-05-16-doctrine-2-1-beta-release.md
+++ b/source/blog/2011-05-16-doctrine-2-1-beta-release.md
@@ -11,7 +11,7 @@ packed with new features that will make your life easier:
 -   **Indexed associations:** You can force Doctrine to hydrate
     collection elements by using a field of the target entity as key,
     for example the ID or any unique field. See the [tutorial for this
-    feature](http://www.doctrine-project.org/docs/orm/2.0/en/tutorials/working-with-indexed-associations.html).
+    feature](https://www.doctrine-project.org/docs/orm/2.0/en/tutorials/working-with-indexed-associations.html).
 -   **Extra Lazy Collections:** Instead of always initializing the
     complete collection in memory you can now mark a collection as extra
     lazy, leading to special SQL executed for Collection\#count(),
@@ -19,12 +19,12 @@ packed with new features that will make your life easier:
     implement efficient pagination on collections without having to use
     DQL. It also allows to save some memory for common use-cases with
     very large collections. See the [tutorial for this
-    feature](http://www.doctrine-project.org/docs/orm/2.0/en/tutorials/extra-lazy-associations.html).
+    feature](https://www.doctrine-project.org/docs/orm/2.0/en/tutorials/extra-lazy-associations.html).
 -   **Identity through Foreign Entities or derived entities:** You can
     now use a foreign key as identifier of an entity. This translates to
     using @Id on a @ManyToOne or @OneToOne association. You can read up
     on this [feature in the
-    tutorial](http://www.doctrine-project.org/docs/orm/2.0/en/tutorials/composite-primary-keys.html#identity-through-foreign-entities).
+    tutorial](https://www.doctrine-project.org/docs/orm/2.0/en/tutorials/composite-primary-keys.html#identity-through-foreign-entities).
 -   **Persister Refactoring:** Instead of reimplementing hydration in
     the persisters we now use the hydration mechanism that is used by
     DQL aswell. Sadly performance for hydration in the persisters drops

--- a/source/blog/2011-06-17-doctrine-2-0-6.md
+++ b/source/blog/2011-06-17-doctrine-2-0-6.md
@@ -11,8 +11,8 @@ with cascade remove, inheritance and the XML driver for the ORM.
 
 See the changelogs for more details:
 
--   [ORM](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10140)
--   [DBAL](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10141)
+-   [ORM](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10140)
+-   [DBAL](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10141)
 
 Grab the download from our [PEAR
 Channel](http://pear.doctrine-project.org) or from the download section

--- a/source/blog/2011-06-18-doctrine-2-1-rc1.md
+++ b/source/blog/2011-06-18-doctrine-2-1-rc1.md
@@ -10,7 +10,7 @@ candidate to celebrate this day. So far we got exactly one backwards
 compability complaint that was immediately fixed. You only have about 10
 days to verify that this release candidate is working with your existing
 2.0 code-bases. If you find some problems please report a bug on
-[Jira](http://www.doctrine-project.org). We will provide everyone with
+[Jira](https://www.doctrine-project.org). We will provide everyone with
 mugs/tshirts who is finding incompatible changes.
 
 We plan to release only 1-2 bugfix releases of the 2.0.x branch, which

--- a/source/blog/2011-07-04-doctrine-2-1.md
+++ b/source/blog/2011-07-04-doctrine-2-1.md
@@ -16,7 +16,7 @@ This release is packed with new features and optimizations:
 -   **Indexed associations:** You can force Doctrine to hydrate
     collection elements by using a field of the target entity as key,
     for example the ID or any unique field. See the [tutorial for this
-    feature](http://www.doctrine-project.org/docs/orm/2.0/en/tutorials/working-with-indexed-associations.html).
+    feature](https://www.doctrine-project.org/docs/orm/2.0/en/tutorials/working-with-indexed-associations.html).
 -   **Extra Lazy Collections:** Instead of always initializing the
     complete collection in memory you can now mark a collection as extra
     lazy, leading to special SQL executed for Collection\#count(),
@@ -24,12 +24,12 @@ This release is packed with new features and optimizations:
     implement efficient pagination on collections without having to use
     DQL. It also allows to save some memory for common use-cases with
     very large collections. See the [tutorial for this
-    feature](http://www.doctrine-project.org/docs/orm/2.0/en/tutorials/extra-lazy-associations.html).
+    feature](https://www.doctrine-project.org/docs/orm/2.0/en/tutorials/extra-lazy-associations.html).
 -   **Identity through Foreign Entities or derived entities:** You can
     now use a foreign key as identifier of an entity. This translates to
     using @Id on a @ManyToOne or @OneToOne association. You can read up
     on this [feature in the
-    tutorial](http://www.doctrine-project.org/docs/orm/2.0/en/tutorials/composite-primary-keys.html#identity-through-foreign-entities).
+    tutorial](https://www.doctrine-project.org/docs/orm/2.0/en/tutorials/composite-primary-keys.html#identity-through-foreign-entities).
 -   **Persister Refactoring:** Instead of reimplementing hydration in
     the persisters we now use the hydration mechanism that is used by
     DQL aswell. Sadly this drops performance for hydration in the
@@ -85,22 +85,22 @@ This release is packed with new features and optimizations:
 -   **AnnotationReader Refactoring** - The annotation reader is now much
     more powerful and also allows for giving you error advices if you
     configure it this way. See the
-    [documentation](http://www.doctrine-project.org/docs/common/2.1/en/reference/annotations.html)
+    [documentation](https://www.doctrine-project.org/docs/common/2.1/en/reference/annotations.html)
     on all the changes and how Annotations work in 2.1.
 
 See the changelogs for a list of all changes:
 
 -   [Doctrine ORM 2.1
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10022)
 -   [Doctrine DBAL 2.1
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10068)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10068)
 -   [Doctrine Common 2.1
-    Changelog](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10123)
+    Changelog](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10123)
 
 You can grab the code from our [downloads
-section](http://www.doctrine-project.org/projects) , from
+section](https://www.doctrine-project.org/projects) , from
 [PEAR](http://pear.doctrine-project.org) or directly from
-[Github](http://github.com/doctrine).
+[Github](https://github.com/doctrine).
 
 I will announce winners of the backwards compatibility competition in
 the next weeks and send out gifts. The team thanks all contributors and

--- a/source/blog/2011-08-17-doctrine-2-0-7-and-eol.md
+++ b/source/blog/2011-08-17-doctrine-2-0-7-and-eol.md
@@ -10,9 +10,9 @@ We released the last maintenance version of the 2.0.x branch Doctrine
 master branches. You can find the list of fixes in the Changelog:
 
 -   [ORM Changelog
-    2.0.7](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10150)
+    2.0.7](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10150)
 -   [DBAL Changelog
-    2.0.7](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10151)
+    2.0.7](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10151)
 
 This release marks the end of line of the 2.0.x branch. We will not port
 bugs for this branch anymore only security issues will get applied.

--- a/source/blog/2011-08-26-doctrine2-1-1.md
+++ b/source/blog/2011-08-26-doctrine2-1-1.md
@@ -10,9 +10,9 @@ several issues with both packages. You can see the changelog of both
 packages on Jira:
 
 -   [ORM Changelog (22 issues
-    fixed)](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10153)
+    fixed)](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10153)
 -   [DBAL Changelog (4 issues
-    fixed)](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10156)
+    fixed)](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10156)
 
 Please report any problems with these packages to the Jira tracker or
 the mailing list.

--- a/source/blog/2011-08-29-dbal-security-2011-1.md
+++ b/source/blog/2011-08-29-dbal-security-2011-1.md
@@ -14,8 +14,8 @@ error.
 We released versions 2.1.2 and 2.0.8 of DBAL that both contain a fix for
 the problem. You can grab the code from
 [PEAR](http://pear.doctrine-project.org) ,
-[Github](http://github.com/doctrine/dbal) or the [Downloads
-section](http://www.doctrine-project.org/projects/dbal/download).
+[Github](https://github.com/doctrine/dbal) or the [Downloads
+section](https://www.doctrine-project.org/projects/dbal/download).
 
 If you make use of AbstractPlatform::quoteIdentifier() or
 Doctrine::quoteIdentifier() please upgrade immediately. The ORM itself

--- a/source/blog/2011-09-25-doctrine-maintenance-sep2011.md
+++ b/source/blog/2011-09-25-doctrine-maintenance-sep2011.md
@@ -9,11 +9,11 @@ We have released the maintenance versions Common 2.1.2, DBAL 2.1.3 and
 ORM 2.1.2.
 
 -   [Common 2.1.2
-    Changelog](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10161)
+    Changelog](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10161)
 -   [DBAL 2.1.3
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10162)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10162)
 -   [ORM 2.1.2
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10154)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10154)
 
 A total of 20 bugs have been fixed in all 3 components. The DBAL release
 contains a security fix for the Oracle driver fixing [a possible SQL

--- a/source/blog/2011-11-21-doctrine-maintenance-nov2011.md
+++ b/source/blog/2011-11-21-doctrine-maintenance-nov2011.md
@@ -8,18 +8,18 @@ permalink: /2011/11/21/doctrine-maintenance-nov2011.html
 The bugfix release is three weeks overdue, here is it now:
 
 -   [ORM 2.1.3 with 24 bugfixes and 1 security
-    fix](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10164)
+    fix](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10164)
 -   [DBAL 2.1.5 with 6
-    bugfixes](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10167)
+    bugfixes](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10167)
 -   [Common 2.1.3 with 1
-    bugfix](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10166)
+    bugfix](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10166)
 
 The security fix concerns usage of the ASC/DESC orientation parameters
 in `$repository->findBy($criteria, $orderBy)`, which is subject to SQL
 injection when user-input is allowed into this method.
 
 You can grab the downloads from the [project
-page](http://www.doctrine-project.org/projects) , via
+page](https://www.doctrine-project.org/projects) , via
 [PEAR](http://pear.doctrine-project.org) or
 [Git](https://github.com/doctrine)
 

--- a/source/blog/2011-11-23-doctrine-orm-2-1-4-released.md
+++ b/source/blog/2011-11-23-doctrine-orm-2-1-4-released.md
@@ -8,8 +8,8 @@ permalink: /2011/11/23/doctrine-orm-2-1-4-released.html
 I just released Doctrine ORM 2.1.4. The Doctrine ORM 2.1.3 release has a
 regression in the EntityManager\#merge() method, which is fixed in this
 release. See the
-[changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10165).
+[changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10165).
 
 Get the package from [PEAR](http://pear.doctrine-project.org) ,
-[Downloads](http://www.doctrine-project.org/projects) or from
+[Downloads](https://www.doctrine-project.org/projects) or from
 [Github](https://github.com/doctrine/doctrine2).

--- a/source/blog/2011-12-15-symfony-bundles-move.md
+++ b/source/blog/2011-12-15-symfony-bundles-move.md
@@ -33,7 +33,7 @@ DoctrineBundle for example the following:
 
     >     [empty]
     >     [DoctrineBundle]
-    >         git=http://github.com/doctrine/DoctrineBundle.git
+    >         git=https://github.com/doctrine/DoctrineBundle.git
     >         target=/bundles/Doctrine/Bundle/DoctrineBundle
 
 -   Change the Bundle class
@@ -48,21 +48,21 @@ A full deps file for all Doctrine bundles now looks like:
 
     [empty]
     [data-fixtures]
-        git=http://github.com/doctrine/data-fixtures.git
+        git=https://github.com/doctrine/data-fixtures.git
 
     [migrations]
-        git=http://github.com/doctrine/migrations.git
+        git=https://github.com/doctrine/migrations.git
 
     [DoctrineBundle]
-        git=http://github.com/doctrine/DoctrineBundle.git
+        git=https://github.com/doctrine/DoctrineBundle.git
         target=/bundles/Doctrine/Bundle/DoctrineBundle
 
     [DoctrineMigrationsBundle]
-        git=http://github.com/doctrine/DoctrineMigrationsBundle.git
+        git=https://github.com/doctrine/DoctrineMigrationsBundle.git
         target=/bundles/Doctrine/Bundle/MigrationsBundle
 
     [DoctrineFixturesBundle]
-        git=http://github.com/doctrine/DoctrineFixturesBundle.git
+        git=https://github.com/doctrine/DoctrineFixturesBundle.git
         target=/bundles/Doctrine/Bundle/FixturesBundle
 
 And the autoload.php:

--- a/source/blog/2011-12-19-doctrine-2-1-5.md
+++ b/source/blog/2011-12-19-doctrine-2-1-5.md
@@ -8,7 +8,7 @@ permalink: /2011/12/19/doctrine-2-1-5.html
 We released another Doctrine ORM bugfix release, version 2.1.5. It fixes
 5 critical regressions that were introduced in 2.1.0, 2.1.2 and 2.1.3
 and a total of 10 issues. See the
-[changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10170)
+[changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10170)
 for details.
 
 You can get the code from [PEAR](http://pear.doctrine-project.org) , the

--- a/source/blog/2011-12-20-doctrine2-2-beta.md
+++ b/source/blog/2011-12-20-doctrine2-2-beta.md
@@ -26,9 +26,9 @@ A top list of the changes includes:
 
 See the changelogs of all three projects Common, DBAL, ORM:
 
--   [ORM](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10157)
--   [DBAL](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10142)
--   [Common](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10152)
+-   [ORM](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10157)
+-   [DBAL](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10142)
+-   [Common](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10152)
 
 In the next weeks will stabilize this code and add documentation for all
 the new features. Additionally we try to drive the bug count down in the
@@ -42,7 +42,7 @@ file to see backwards incompatible changes.
 You can install the Beta through
 [Github](https://github.com/doctrine/doctrine2) , \`PEAR
 [http://pear.doctrine-project.org](http://pear.doctrine-project.org)\>\`\_
-or through [Composer](http://www.packagist.org):
+or through [Composer](https://packagist.org):
 
 > {
 > :   "require": { "doctrine/orm": "2.2.0-BETA1" }

--- a/source/blog/2012-01-03-doctrine2-2-beta2.md
+++ b/source/blog/2012-01-03-doctrine2-2-beta2.md
@@ -11,13 +11,13 @@ are releasing another Beta of Doctrine DBAL and ORM. The final release
 is rescheduled to 19th January.
 
 -   DBAL Changelog
-    \<[http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10189](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10189)\>\`\_
+    \<[https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10189](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10189)\>\`\_
 -   ORM Changelog
-    \<[http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10188](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10188)\>\`\_
+    \<[https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10188](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10188)\>\`\_
 
 Please try and test this code with your production applications and
 report any backwards compatibility breaks to the [Bug
-Tracker](http://www.doctrine-project.org/jira) or the Mailing List. See
+Tracker](https://www.doctrine-project.org/jira) or the Mailing List. See
 the
 [UPGRADE\_2\_2](https://github.com/doctrine/doctrine2/blob/master/UPGRADE_TO_2_2)
 file to see backwards incompatible changes.
@@ -25,7 +25,7 @@ file to see backwards incompatible changes.
 You can install the Beta through
 [Github](https://github.com/doctrine/doctrine2) ,
 [PEAR](http://pear.doctrine-project.org) by download or through
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
 > {
 > :   "require": { "doctrine/orm": "2.2.0-BETA2" }

--- a/source/blog/2012-01-22-dbal-orm-22rc1.md
+++ b/source/blog/2012-01-22-dbal-orm-22rc1.md
@@ -19,10 +19,10 @@ made the delay necessary:
 
 As usual you can grab the code from:
 
--   [Packagist](http://packagist.org/packages/doctrine/)
+-   [Packagist](https://packagist.org/packages/doctrine/)
 -   [PEAR](http://pear.doctrine-project.org)
--   [Downloads](http://www.doctrine-project.org/projects)
--   [Github](http://github.com/doctrine)
+-   [Downloads](https://www.doctrine-project.org/projects)
+-   [Github](https://github.com/doctrine)
 
 Please test this code with your applications. If no bugs or
 backwards-compatible breaks are reported in the next days we will

--- a/source/blog/2012-01-29-doctrine-2-2-final.md
+++ b/source/blog/2012-01-29-doctrine-2-2-final.md
@@ -24,9 +24,9 @@ A top list of the new features includes:
 
 See the changelogs of all three projects Common, DBAL, ORM:
 
--   [ORM](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10157)
--   [DBAL](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10142)
--   [Common](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10152)
+-   [ORM](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10157)
+-   [DBAL](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10142)
+-   [Common](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10152)
 
 See the
 [UPGRADE\_2\_2](https://github.com/doctrine/doctrine2/blob/master/UPGRADE_TO_2_2)
@@ -35,7 +35,7 @@ file to see backwards incompatible changes.
 You can install the release through
 [Github](https://github.com/doctrine/doctrine2) ,
 [PEAR](http://pear.doctrine-project.org) or through
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
 > {
 > :   "require": { "doctrine/orm": "2.2.0" }

--- a/source/blog/2012-01-30-doctrine-2-1-6.md
+++ b/source/blog/2012-01-30-doctrine-2-1-6.md
@@ -10,9 +10,9 @@ and ORM are now in version 2.1.6 of their lifecycle. There have been 8
 bug fixes in ORM and 8 in DBAL. See the changelogs:
 
 -   [ORM
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10182)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10182)
 -   [DBAL
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10181)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10181)
 
 As usual code is available via Download, PEAR, Packagist/Composer or
 from Github.

--- a/source/blog/2012-03-04-doctrine-2-2-1-released.md
+++ b/source/blog/2012-03-04-doctrine-2-2-1-released.md
@@ -9,12 +9,12 @@ We released version 2.2.1 of the Doctrine ORM today, fixing a total of
 16 bugs.
 
 -   [ORM
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10194)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10194)
 
 You can install the release through
 [Github](https://github.com/doctrine/doctrine2) ,
 [PEAR](http://pear.doctrine-project.org) , download from the website or
-through [Composer](http://www.packagist.org):
+through [Composer](https://packagist.org):
 
 > {
 > :   "require": { "doctrine/orm": "2.2.1" }

--- a/source/blog/2012-04-13-doctrine-2-2-2-released.md
+++ b/source/blog/2012-04-13-doctrine-2-2-2-released.md
@@ -9,16 +9,16 @@ We released version 2.2.2 of the Doctrine ORM, Common and DBAL today,
 fixing a total of 20 bugs.
 
 -   [ORM
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10195)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10195)
 -   [DBAL
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10197)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10197)
 -   [Common
-    Changelog](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10199)
+    Changelog](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10199)
 
 You can install the release through
 [Github](https://github.com/doctrine/doctrine2) ,
 [PEAR](http://pear.doctrine-project.org) , download from the website or
-through [Composer](http://www.packagist.org):
+through [Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2012-05-28-doctrine-2-1-7-released.md
+++ b/source/blog/2012-05-28-doctrine-2-1-7-released.md
@@ -9,14 +9,14 @@ We released version 2.1.7 of the Doctrine ORM and DBAL today, fixing a
 total of 18 bugs.
 
 -   [ORM
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10198)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10198)
 -   [DBAL
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10200)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10200)
 
 You can install the release through
 [Github](https://github.com/doctrine/doctrine2) ,
 [PEAR](http://pear.doctrine-project.org) , download from the website or
-through [Composer](http://www.packagist.org):
+through [Composer](https://packagist.org):
 
 ~~~~ {.sourceCode .yaml}
 {

--- a/source/blog/2012-05-29-symfony-live-2012-hackday.md
+++ b/source/blog/2012-05-29-symfony-live-2012-hackday.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2012/05/29/symfony-live-2012-hackday.html
 ---
 Next week will be [Symfony Live
-2012](http://paris2012.live.symfony.com/) in Paris and the Doctrine
+2012](https://paris2012.live.symfony.com/) in Paris and the Doctrine
 DBAL/ORM Team will be represented by Guilherme, Alexander, Marco and me.
 Jeremy is also there and knows the MongoDB ODM inside out.
 

--- a/source/blog/2012-07-16-doctrine-2-3-beta.md
+++ b/source/blog/2012-07-16-doctrine-2-3-beta.md
@@ -39,7 +39,7 @@ feedback about issues that you find.
 
 You can install the Beta through
 [Github](https://github.com/doctrine/doctrine2) or
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2012-08-29-doctrine-2-3-rc2.md
+++ b/source/blog/2012-08-29-doctrine-2-3-rc2.md
@@ -24,7 +24,7 @@ some information about changes in 2.3.
 
 You can install the release candidate through
 [Github](https://github.com/doctrine/doctrine2) or
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {
@@ -34,7 +34,7 @@ You can install the release candidate through
     }
 
 If you find any problems with your applications please report them on
-our [bugtracker](http://www.doctrine-project.org/jira).
+our [bugtracker](https://www.doctrine-project.org/jira).
 
 When no blocking issues occur we will release the 2.3.0 final on next
 Monday.

--- a/source/blog/2012-09-05-doctrine-2-3-rc3.md
+++ b/source/blog/2012-09-05-doctrine-2-3-rc3.md
@@ -24,7 +24,7 @@ some information about changes in 2.3.
 
 You can install the release candidate through
 [Github](https://github.com/doctrine/doctrine2) or
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {
@@ -34,7 +34,7 @@ You can install the release candidate through
     }
 
 If you find any problems with your applications please report them on
-our [bugtracker](http://www.doctrine-project.org/jira).
+our [bugtracker](https://www.doctrine-project.org/jira).
 
 When no blocking issues occur we will release the 2.3.0 final on the
 weekend.

--- a/source/blog/2012-09-17-doctrine-2-3-rc4.md
+++ b/source/blog/2012-09-17-doctrine-2-3-rc4.md
@@ -24,7 +24,7 @@ some information about changes in 2.3.
 
 You can install the release candidate through
 [Github](https://github.com/doctrine/doctrine2) or
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {
@@ -34,7 +34,7 @@ You can install the release candidate through
     }
 
 If you find any problems with your applications please report them on
-our [bugtracker](http://www.doctrine-project.org/jira).
+our [bugtracker](https://www.doctrine-project.org/jira).
 
 We hope to release the final version of Doctrine 2.3 after this release
 candidate. Please test your applications with this.

--- a/source/blog/2012-09-20-doctrine-2-3-final.md
+++ b/source/blog/2012-09-20-doctrine-2-3-final.md
@@ -34,11 +34,11 @@ many little optimizations:
 The complete changelogs are listed on JIRA:
 
 -   [Common
-    Changelog](http://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10183)
+    Changelog](https://www.doctrine-project.org/jira/browse/DCOM/fixforversion/10183)
 -   [DBAL
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10184)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10184)
 -   [ORM
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10185)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10185)
 
 We will flesh out the documentation and information about all new
 features in the coming month. If you want to contribute to the
@@ -49,7 +49,7 @@ on Github.
 
 You can install the final release through
 [Github](https://github.com/doctrine/doctrine2) or
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2012-12-05-doctrine-2-3-1.md
+++ b/source/blog/2012-12-05-doctrine-2-3-1.md
@@ -12,13 +12,13 @@ workload of all the participating developers we couldn't release this
 earlier. We hope to release 2.3.2 in a much shorter period from now.
 
 -   [DBAL
-    Changelog](http://doctrine-project.org/jira/browse/DBAL/fixforversion/10325)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10325)
 -   [ORM
-    Changelog](http://doctrine-project.org/jira/browse/DDC/fixforversion/10323)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10323)
 
 You can install the release through
 [Github](https://github.com/doctrine/doctrine2) , download, PEAR or
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2012-12-28-doctrine-orientdb-odm.md
+++ b/source/blog/2012-12-28-doctrine-orientdb-odm.md
@@ -10,7 +10,7 @@ people were hearing at the end of 2011, especially after the explosion
 of Big Data associated with social networks.
 
 At the beginning of this year, a really promising GraphDB,
-[OrientDB](http://orientdb.org) , saw its first stable release (1.0.0)
+[OrientDB](https://orientdb.org) , saw its first stable release (1.0.0)
 which finally gave to the world a stable toy pretty different from the
 traditional RDBMS that we're used to see and from the document-based DBs
 like MongoDB or CouchDB: OrientDB integrates document capabilities with
@@ -19,7 +19,7 @@ a graph layer, thus it sounded very, very interesting.
 Even before going stable, there were some companies already using
 OrientDB, thanks to the language-specific drivers created by the
 community surrounding this GraphDB: one of them, for PHP, was
-[Orient](http://github.com/congow/Orient) , a bunch of classes that
+[Orient](https://github.com/congow/Orient) , a bunch of classes that
 wrapped PHP's native cURL functions to make queries against OrientDB's
 via the HTTP protocol.
 

--- a/source/blog/2013-01-08-doctrine-2-3-2.md
+++ b/source/blog/2013-01-08-doctrine-2-3-2.md
@@ -10,13 +10,13 @@ permalink: /2013/01/08/doctrine-2-3-2.html
 We have released the second mini release in the 2.3 cycle.
 
 -   [DBAL
-    Changelog](http://doctrine-project.org/jira/browse/DBAL/fixforversion/10326)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10326)
 -   [ORM
-    Changelog](http://doctrine-project.org/jira/browse/DDC/fixforversion/10324)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10324)
 
 You can install the release through
 [Github](https://github.com/doctrine/doctrine2) , download, PEAR or
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2013-03-24-doctrine-2-3-3.md
+++ b/source/blog/2013-03-24-doctrine-2-3-3.md
@@ -9,10 +9,10 @@ permalink: /2013/03/24/doctrine-2-3-3.html
 
 We have released a mini version 2.3.3 of ORM and DBAL. See the list of
 [18
-tickets](http://www.doctrine-project.org/jira/issues/?jql=project%20in%20(DDC%2C%20DBAL%2C%20DCOM)%20AND%20fixVersion%20%3D%20%222.3.3%22%20AND%20status%20%3D%20Resolved%20ORDER%20BY%20priority%20DESC)
+tickets](https://www.doctrine-project.org/jira/issues/?jql=project%20in%20(DDC%2C%20DBAL%2C%20DCOM)%20AND%20fixVersion%20%3D%20%222.3.3%22%20AND%20status%20%3D%20Resolved%20ORDER%20BY%20priority%20DESC)
 we fixed.
 
-You can install the release with [Composer](http://www.packagist.org):
+You can install the release with [Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2013-03-24-doctrine-2-4-beta.md
+++ b/source/blog/2013-03-24-doctrine-2-4-beta.md
@@ -13,9 +13,9 @@ talk](https://speakerdeck.com/asm89/what-is-new-in-doctrine) by
 Alexander and me from Symfony Live Berlin last year.
 
 You can find a list of changes on
-[Jira](http://www.doctrine-project.org/jira/issues/?jql=project%20in%20(DDC%2C%20DBAL%2C%20DCOM)%20AND%20fixVersion%20%3D%20%222.4%22%20AND%20status%20%3D%20Resolved%20ORDER%20BY%20priority%20DESC).
+[Jira](https://www.doctrine-project.org/jira/issues/?jql=project%20in%20(DDC%2C%20DBAL%2C%20DCOM)%20AND%20fixVersion%20%3D%20%222.4%22%20AND%20status%20%3D%20Resolved%20ORDER%20BY%20priority%20DESC).
 
-You can install the release with [Composer](http://www.packagist.org):
+You can install the release with [Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2013-05-11-doctrine-2-3-4.md
+++ b/source/blog/2013-05-11-doctrine-2-3-4.md
@@ -12,12 +12,12 @@ much as 18 DBAL tickets and 12 ORM tickets.
 
 See a Changelog of both components:
 
--   [DBAL](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10421)
--   [ORM](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10420)
+-   [DBAL](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10421)
+-   [ORM](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10420)
 
 You can install the release with
 [PEAR](http://pear.doctrine-project.org) or with
-[Composer](http://www.packagist.org):
+[Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2013-05-11-doctrine-2-4-beta2.md
+++ b/source/blog/2013-05-11-doctrine-2-4-beta2.md
@@ -17,9 +17,9 @@ Most of the new functionality is already documented and marked with
 all the new functionality in one place.
 
 You can find a list of changes on
-[Jira](http://www.doctrine-project.org/jira/issues/?jql=project%20in%20(DDC%2C%20DBAL%2C%20DCOM)%20AND%20fixVersion%20%3D%20%222.4%22%20AND%20status%20%3D%20Resolved%20ORDER%20BY%20priority%20DESC).
+[Jira](https://www.doctrine-project.org/jira/issues/?jql=project%20in%20(DDC%2C%20DBAL%2C%20DCOM)%20AND%20fixVersion%20%3D%20%222.4%22%20AND%20status%20%3D%20Resolved%20ORDER%20BY%20priority%20DESC).
 
-You can install the release with [Composer](http://www.packagist.org):
+You can install the release with [Composer](https://packagist.org):
 
     {
         "require": {

--- a/source/blog/2013-09-11-doctrine-2-4-released.md
+++ b/source/blog/2013-09-11-doctrine-2-4-released.md
@@ -15,7 +15,7 @@ features.
 Starting with version 2.4 Doctrine will not be available over PEAR
 anymore. The maintenance of this deployment channel is too complicated,
 compared to the small number of people using it. We focus on shipping
-Doctrine with [Composer](http://getcomposer.org) , which is a superior
+Doctrine with [Composer](https://getcomposer.org) , which is a superior
 packaging tool in our opinion. We will continue to make Doctrine
 available as standalone download through the Github releases pages.
 

--- a/source/blog/2013-11-12-doctrine-2-4-1.md
+++ b/source/blog/2013-11-12-doctrine-2-4-1.md
@@ -12,9 +12,9 @@ total 6 tickets have been closed in both releases.
 See all the changes:
 
 -   [Doctrine ORM v2.4.1
-    Changelog](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10528)
+    Changelog](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10528)
 -   [Doctrine DBAL v2.4.1
-    Changelog](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10527)
+    Changelog](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10527)
 
 Installation
 ============

--- a/source/blog/2013-12-23-our-hhvm-roadmap.md
+++ b/source/blog/2013-12-23-our-hhvm-roadmap.md
@@ -6,7 +6,7 @@ categories: []
 permalink: /2013/12/23/our-hhvm-roadmap.html
 ---
 Facebook has been [pushing HHVM alot
-lately](http://www.hhvm.com/blog/2813/we-are-the-98-5-and-the-16) ,
+lately](https://hhvm.com/blog/2813/we-are-the-98-5-and-the-16) ,
 helping open source projects to get their test-suite running 100%. For
 Doctrine HHVM is particularly interesting, because of the performance
 gains that the complex PHP algorithms inside ORM would probably get.
@@ -17,7 +17,7 @@ improvement will be.
 
 One roadblock for us to investigate HHVM in more detail was missing CI
 support. But then Travis CI [announced support for
-HHVM](http://about.travis-ci.org/blog/2013-12-16-test-php-code-with-the-hiphop-vm)
+HHVM](https://blog.travis-ci.com/2013-12-16-test-php-code-with-the-hiphop-vm)
 last week. With automated testing support available we think it is time
 to announce our official HHVM roadmap.
 

--- a/source/blog/2014-01-01-dbal-242-252beta1.md
+++ b/source/blog/2014-01-01-dbal-242-252beta1.md
@@ -61,7 +61,7 @@ There is also a nice list of new features:
 See all the changes for the 2.5.0 BETA1 on Jira:
 
 -   [DBAL 2.5.0
-    BETA1](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523)
+    BETA1](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523)
 
 You can install the BETA using Composer and the following
 `composer.json` contents:

--- a/source/blog/2014-02-08-orm-235-234.md
+++ b/source/blog/2014-02-08-orm-235-234.md
@@ -13,10 +13,10 @@ We are happy to announce the immediate availability of Doctrine ORM
 You can find all the changes on JIRA:
 
 -   [ORM
-    2.3.5](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10521)
+    2.3.5](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10521)
     - 17 issues fixed
 -   [ORM
-    2.4.2](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10621)
+    2.4.2](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10621)
     12 issues fixed
 
 You can install the ORM using Composer and the following `composer.json`
@@ -39,4 +39,4 @@ contents:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-02-21-doctrine_2_5_beta3.md
+++ b/source/blog/2014-02-21-doctrine_2_5_beta3.md
@@ -14,9 +14,9 @@ final release in March as well.
 
 For details about all the new features in DBAL 2.5, see the [previous
 release blog
-post](http://www.doctrine-project.org/2014/01/01/dbal-242-252beta1.html)
+post](https://www.doctrine-project.org/2014/01/01/dbal-242-252beta1.html)
 and the [Jira
-Release](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523).
+Release](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523).
 
 You can install the BETA through Composer with the following version
 constraint::
@@ -32,4 +32,4 @@ small details (See UPGRADE.md). You can even test Doctrine DBAL 2.5 with
 a stable DBAL 2.4 version.
 
 If you find any problems with this beta, please report a bug [on
-Jira](http://www.doctrine-project.org/jira).
+Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-02-21-security_in_doctrine.md
+++ b/source/blog/2014-02-21-security_in_doctrine.md
@@ -87,7 +87,7 @@ Read all the information about Security in Doctrine in the
 documentation.
 
 -   [DBAL
-    Security](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/security.html)
+    Security](https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/security.html)
 -   [ORM
-    Security](http://docs.doctrine-project.org/en/latest/reference/security.html)
+    Security](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/security.html)
 

--- a/source/blog/2014-09-11-instantiator-1-0-0.md
+++ b/source/blog/2014-09-11-instantiator-1-0-0.md
@@ -24,7 +24,7 @@ bug for this problem is \`DDC-3120\`\_.
 [Doctrine Instantiator](https://github.com/doctrine/instantiator)
 provides a simple API to build objects without directly relying on the
 [serialization
-hack](http://www.doctrine-project.org/2010/03/21/doctrine-2-give-me-my-constructor-back.html)
+hack](https://www.doctrine-project.org/2010/03/21/doctrine-2-give-me-my-constructor-back.html)
 that has been explicitly used by all of our data mappers for quite some
 time.
 

--- a/source/blog/2014-09-11-orm-244.md
+++ b/source/blog/2014-09-11-orm-244.md
@@ -12,7 +12,7 @@ We are happy to announce the immediate availability of Doctrine ORM
 You can find all the changes on JIRA:
 
 -   [ORM
-    2.4.4](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10720)
+    2.4.4](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10720)
     - 1 issue fixed
 
 You can install the ORM using Composer and the following `composer.json`
@@ -27,4 +27,4 @@ contents:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-09-12-dbal-250rc2.md
+++ b/source/blog/2014-09-12-dbal-250rc2.md
@@ -28,9 +28,9 @@ you should expect to see the finished DBAL 2.5 very soon.
 
 For details about all the new features in DBAL 2.5, see the [previous
 release blog
-post](http://www.doctrine-project.org/2014/02/21/doctrine_2_5_beta3.html)
+post](https://www.doctrine-project.org/2014/02/21/doctrine_2_5_beta3.html)
 and the [Jira
-Release](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523).
+Release](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523).
 
 You can install the Release Candidate through Composer with the
 following version constraint:
@@ -48,4 +48,4 @@ for small details (See `UPGRADE.md`). You can even test Doctrine DBAL
 2.5 with a stable ORM 2.4 version.
 
 If you find any problems with this beta, please report a bug [on
-Jira](http://www.doctrine-project.org/jira).
+Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-09-15-dbal-235.md
+++ b/source/blog/2014-09-15-dbal-235.md
@@ -13,7 +13,7 @@ to an error.
 You can find all the changes on JIRA:
 
 -   [DBAL
-    2.3.5](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10721)
+    2.3.5](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10721)
     - 8 issues fixed
 
 You can install the DBAL using Composer and the following
@@ -28,4 +28,4 @@ You can install the DBAL using Composer and the following
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-09-23-orm-245.md
+++ b/source/blog/2014-09-23-orm-245.md
@@ -7,12 +7,12 @@ permalink: /2014/09/23/orm-245.html
 ---
 We are happy to announce the immediate availability of Doctrine ORM
 2.4.5, which fixes [an HHVM/PHP7 issue related with
-func\_get\_args()](http://3v4l.org/NIqRh).
+func\_get\_args()](https://3v4l.org/NIqRh).
 
 You can find all the changes on JIRA:
 
 -   [ORM
-    2.4.5](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10722)
+    2.4.5](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10722)
     - 1 issue fixed
 
 You can install the ORM using Composer and the following `composer.json`
@@ -27,4 +27,4 @@ contents:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-10-06-orm-246.md
+++ b/source/blog/2014-10-06-orm-246.md
@@ -16,7 +16,7 @@ interface with the ORM:
 You can find all the changes on JIRA:
 
 -   [ORM
-    2.4.6](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10723)
+    2.4.6](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10723)
     - 2 issues fixed
 
 You can install the ORM using Composer and the following `composer.json`
@@ -31,4 +31,4 @@ contents:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-10-16-dbal-243.md
+++ b/source/blog/2014-10-16-dbal-243.md
@@ -12,7 +12,7 @@ development.
 You can find all the changes on JIRA:
 
 -   [DBAL
-    2.4.3](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10622)
+    2.4.3](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10622)
     - 10 issues fixed
 
 You can install the DBAL using Composer and the following
@@ -27,4 +27,4 @@ You can install the DBAL using Composer and the following
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2014-12-04-doctrine_dbal_2_5_release.md
+++ b/source/blog/2014-12-04-doctrine_dbal_2_5_release.md
@@ -49,7 +49,7 @@ See all the changes for the 2.5.0 Release on Jira, an amazing total of
 316 issues:
 
 -   [DBAL
-    2.5.0](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523/)
+    2.5.0](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10523/)
 
 If you find any problems or backwards compatibility breaks with this
 release please report them on JIRA or open up Pull Requests on Github.

--- a/source/blog/2014-12-16-orm-247.md
+++ b/source/blog/2014-12-16-orm-247.md
@@ -21,7 +21,7 @@ allowing DQL queries that have `SELECT` clauses containing parameters:
 You can find all the changes on JIRA:
 
 -   [ORM
-    2.4.7](http://www.doctrine-project.org/jira/browse/DDC/fixforversion/10724)
+    2.4.7](https://www.doctrine-project.org/jira/browse/DDC/fixforversion/10724)
     - 2 issues fixed
 
 You can install the ORM using Composer and the following `composer.json`
@@ -36,4 +36,4 @@ contents:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-01-12-dbal-244-251.md
+++ b/source/blog/2015-01-12-dbal-244-251.md
@@ -28,16 +28,16 @@ DBAL 2.5.0 when retrieving the underlying platform. Unfortunately we did
 not find a good solution for this issue yet. Until the issue is fixed
 please directly set the platform version as a workaround by using the
 `serverVersion` configuration option described in the
-[documentation](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#automatic-platform-version-detection)
+[documentation](https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/configuration.html#automatic-platform-version-detection)
 if you are encountering any problems.
 
 You can find all the changes on JIRA:
 
 -   [DBAL
-    2.4.4](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10725)
+    2.4.4](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10725)
     - 9 issues fixed
 -   [DBAL
-    2.5.1](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10727)
+    2.5.1](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10727)
     - 24 issues fixed
 
 You can install the DBAL using Composer and the following
@@ -60,4 +60,4 @@ You can install the DBAL using Composer and the following
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-01-15-cache-1-4-0.md
+++ b/source/blog/2015-01-15-cache-1-4-0.md
@@ -48,4 +48,4 @@ You can install the Cache component using Composer and the following
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-01-25-orm-2-5-0-alpha-2.md
+++ b/source/blog/2015-01-25-orm-2-5-0-alpha-2.md
@@ -127,4 +127,4 @@ This is a list of issues solved in `2.5.0-alpha2` since `2.5.0-alpha1`:
     test suite performance
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DDC).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DDC).

--- a/source/blog/2015-03-18-orm-2-5-0-beta-1.md
+++ b/source/blog/2015-03-18-orm-2-5-0-beta-1.md
@@ -107,4 +107,4 @@ This is a list of issues solved in `2.5.0-beta1` since `2.5.0-alpha2`:
     Allow access to all aliases for a QueryBuilder.
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DDC).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DDC).

--- a/source/blog/2015-03-22-data-fixtures-1-0-1.md
+++ b/source/blog/2015-03-22-data-fixtures-1-0-1.md
@@ -8,7 +8,7 @@ permalink: /2015/03/22/data-fixtures-1-0-1.html
 We are happy to announce the immediate availability Doctrine Data
 Fixtures `1.0.1`.
 
-In all [semver](http://semver.org/) fashion, this is a bug fix release.
+In all [semver](https://semver.org/) fashion, this is a bug fix release.
 
 What is new in 1.0.x?
 =====================

--- a/source/blog/2015-03-25-common-2-5-0-beta-1.md
+++ b/source/blog/2015-03-25-common-2-5-0-beta-1.md
@@ -128,4 +128,4 @@ New Feature
     namespace separators for SymfonyFileLocator
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DDC).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DDC).

--- a/source/blog/2015-03-25-orm-2-5-0-rc-1.md
+++ b/source/blog/2015-03-25-orm-2-5-0-rc-1.md
@@ -75,4 +75,4 @@ This is a list of issues solved in `2.5.0-RC1` since `2.5.0-beta1`:
 :   parameters and caches
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DDC).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DDC).

--- a/source/blog/2015-03-31-orm-2-5-0-rc-2.md
+++ b/source/blog/2015-03-31-orm-2-5-0-rc-2.md
@@ -69,4 +69,4 @@ This is a list of issues solved in `2.5.0-RC2` since `2.5.0-RC1`:
     parameters and caches
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DDC).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DDC).

--- a/source/blog/2015-04-01-indoctrinator-0-0-1-alpha-1.md
+++ b/source/blog/2015-04-01-indoctrinator-0-0-1-alpha-1.md
@@ -60,10 +60,10 @@ How to get Indoctrinator?
 
 Indoctrinator has its own dedicated [documentation section in the
 doctrine
-website](http://www.doctrine-project.org/projects/indoctrinator.html).
+website](https://www.doctrine-project.org/projects/indoctrinator.html).
 
 Reporting Issues
 ================
 
 Please report any issues you may have with the project on the mailing
-list or on [JIRA](http://www.doctrine-project.org/jira/browse/).
+list or on [JIRA](https://www.doctrine-project.org/jira/browse/).

--- a/source/blog/2015-04-02-common-2-5-0.md
+++ b/source/blog/2015-04-02-common-2-5-0.md
@@ -107,4 +107,4 @@ New Feature
     namespace separators for SymfonyFileLocator
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DCOM).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DCOM).

--- a/source/blog/2015-04-02-orm-2-5-0.md
+++ b/source/blog/2015-04-02-orm-2-5-0.md
@@ -1467,4 +1467,4 @@ Documentation
     docs for clear-cache commands
 
 Please report any issues you may have with the update on the mailing
-list or on [JIRA](http://www.doctrine-project.org/jira/browse/DDC).
+list or on [JIRA](https://www.doctrine-project.org/jira/browse/DDC).

--- a/source/blog/2015-04-14-annotations-1-2-4.md
+++ b/source/blog/2015-04-14-annotations-1-2-4.md
@@ -27,4 +27,4 @@ and the following `composer.json` contents:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DCOM).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DCOM).

--- a/source/blog/2015-04-14-collections-1-3-0.md
+++ b/source/blog/2015-04-14-collections-1-3-0.md
@@ -46,4 +46,4 @@ This is a list of issues solved in `1.3.0` since `1.2.0`:
     7.0 nightly added + few improvements
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira/browse/DCOM).
+list or on [Jira](https://www.doctrine-project.org/jira/browse/DCOM).

--- a/source/blog/2015-04-15-cache-1-4-1.md
+++ b/source/blog/2015-04-15-cache-1-4-1.md
@@ -43,4 +43,4 @@ You can install the Cache component using Composer and the following
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-08-31-doctrine_orm_2_5_1_and_2_4_8_released.md
+++ b/source/blog/2015-08-31-doctrine_orm_2_5_1_and_2_4_8_released.md
@@ -9,7 +9,7 @@ We are happy to announce the immediate availability of Doctrine ORM
 2.5.1 and 2.4.8.
 
 This versions include a fix for the [Security Misconfiguration
-Vulnerability](http://www.doctrine-project.org/2015/08/31/security_misconfiguration_vulnerability_in_various_doctrine_projects.html)
+Vulnerability](https://www.doctrine-project.org/2015/08/31/security_misconfiguration_vulnerability_in_various_doctrine_projects.html)
 described in an earlier blog post today.
 
 Here are the changelogs:

--- a/source/blog/2015-09-16-doctrine_dbal_2_5_2_released.md
+++ b/source/blog/2015-09-16-doctrine_dbal_2_5_2_released.md
@@ -14,7 +14,7 @@ didn't work properly anymore as well as several other issues.
 You can find all the changes on JIRA:
 
 -   [DBAL
-    2.5.2](http://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10731)
+    2.5.2](https://www.doctrine-project.org/jira/browse/DBAL/fixforversion/10731)
     - 24 issues fixed
 
 You can install the DBAL using Composer and the following
@@ -29,4 +29,4 @@ You can install the DBAL using Composer and the following
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-10-28-cache-1-4-3_and-1-5-0.md
+++ b/source/blog/2015-10-28-cache-1-4-3_and-1-5-0.md
@@ -83,4 +83,4 @@ following `composer.json` definitions:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-11-02-cache-1-4-4_and-1-5-1.md
+++ b/source/blog/2015-11-02-cache-1-4-4_and-1-5-1.md
@@ -55,4 +55,4 @@ following `composer.json` definitions:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-11-23-orm-2-5-2.md
+++ b/source/blog/2015-11-23-orm-2-5-2.md
@@ -63,4 +63,4 @@ Documentation
     Upgrade.md after minor bc break in 2.5.1
 
 Please report any issues you may have with the update on the mailing
-list or on [JIRA](http://www.doctrine-project.org/jira/browse/DDC).
+list or on [JIRA](https://www.doctrine-project.org/jira/browse/DDC).

--- a/source/blog/2015-12-03-cache-1-5-2.md
+++ b/source/blog/2015-12-03-cache-1-5-2.md
@@ -26,4 +26,4 @@ definitions:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-12-04-common-2-5-2-and-2-6-0.md
+++ b/source/blog/2015-12-04-common-2-5-2-and-2-6-0.md
@@ -27,7 +27,7 @@ found for a proxy [\#387](https://github.com/doctrine/common/pull/387)
 
 You can find the complete changelog for this release in the [v2.5.2
 release
-notes](http://www.doctrine-project.org/jira/projects/DCOM/versions/10820).
+notes](https://www.doctrine-project.org/jira/projects/DCOM/versions/10820).
 
 Common 2.6.0
 ============
@@ -50,7 +50,7 @@ package that is installed by composer
 
 You can find the complete changelog for this release in the [v2.6.0
 release
-notes](http://www.doctrine-project.org/jira/projects/DCOM/versions/10735).
+notes](https://www.doctrine-project.org/jira/projects/DCOM/versions/10735).
 
 Installation
 ============
@@ -75,4 +75,4 @@ following `composer.json` definitions:
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-12-31-cache-1-6-0.md
+++ b/source/blog/2015-12-31-cache-1-6-0.md
@@ -14,7 +14,7 @@ Cache 1.6.0
 Support for PHP versions below 5.5.0 was removed: please remember that
 if you are still using PHP 5.4.x or lower, the PHP project [does not
 provide support for those versions
-anymore](http://php.net/supported-versions.php).
+anymore](https://secure.php.net/supported-versions.php).
 [\#109](https://github.com/doctrine/cache/pull/109)
 
 Native [APCu](https://github.com/krakjoe/apcu) support was introduced:
@@ -48,4 +48,4 @@ composer require doctrine/cache:^1.6
 ~~~~
 
 Please report any issues you may have with the update on the mailing
-list or on [Jira](http://www.doctrine-project.org/jira).
+list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2016-02-16-doctrine-mongodb-odm-release-1.0.5.md
+++ b/source/blog/2016-02-16-doctrine-mongodb-odm-release-1.0.5.md
@@ -39,7 +39,7 @@ While ODM still relies on legacy MongoDB driver ([i.e.
 ext-mongo](https://pecl.php.net/package/mongo)) and no dates are
 scheduled for the 2.0 release, it is possible to run ODM's development
 branch with the new MongoDB driver (i.e.
-[ext-mongodb](http://php.net/manual/en/mongodb.installation.php)) on
+[ext-mongodb](https://secure.php.net/manual/en/mongodb.installation.php)) on
 PHP 7 and HHVM! [(see: this
 tweet)](https://twitter.com/alcaeus/status/697659616172359680) The new
 driver should be properly supported once we release versions 1.1 and 1.3

--- a/source/blog/2016-06-19-data-fixtures-1-2-0.md
+++ b/source/blog/2016-06-19-data-fixtures-1-2-0.md
@@ -23,7 +23,7 @@ from tables with quoted names.
 
 Please also be aware that this release drops support for PHP 5.5 and
 below. Given that PHP 5.5 is going to exit its official [security
-support schedule](http://php.net/supported-versions.php) very soon, we
+support schedule](https://secure.php.net/supported-versions.php) very soon, we
 strongly recommend that all users upgrade their PHP installations as
 well.
 

--- a/source/blog/2017-07-25-php-7.1-requirement-and-composer.md
+++ b/source/blog/2017-07-25-php-7.1-requirement-and-composer.md
@@ -36,7 +36,7 @@ like this:
 
 The `^2.5` constraint resolves to: `>= 2.5.0 && <= 2.999999.999999`.
 This is intended: our projects all follow [Semantic
-Versioning](http://semver.org/), so you can safely install a new minor
+Versioning](https://semver.org/), so you can safely install a new minor
 version without having to fear BC breaks.
 
 When determining what version to install, composer employs a SAT solver

--- a/source/community.html
+++ b/source/community.html
@@ -54,7 +54,7 @@ permalink: /community/index.html
                 to communicate with other Doctrine developers.
             </p>
 
-            <a href="http://groups.google.com/group/doctrine-user" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Go to Mailing List</a>
+            <a href="https://groups.google.com/forum/#!forum/doctrine-user" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Go to Mailing List</a>
         </div>
     </div>
 

--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -41,8 +41,8 @@ back to a Doctrine project.
 Initial Setup
 -------------
 
--  Setup a `github <http://github.com>`_ account.
--  Fork the `repository <http://github.com/doctrine/doctrine2>`_ of the
+-  Setup a `github <https://github.com>`_ account.
+-  Fork the `repository <https://github.com/doctrine/doctrine2>`_ of the
    project you want to contribute to.
 -  Clone your fork locally
 

--- a/source/contribute/maintainer.rst
+++ b/source/contribute/maintainer.rst
@@ -7,7 +7,7 @@ Maintainer Workflow
 
 Who is a maintainer? Maintainers are those who have been granted write
 access to the main repository of a project. In the example of the ORM,
-it would be this `repository <http://github.com/doctrine/doctrine2>`_.
+it would be this `repository <https://github.com/doctrine/doctrine2>`_.
 This repository will be referred to as **doctrine** in this document.
 
 You might want want to know how a maintainer is different from a
@@ -23,7 +23,7 @@ Setup
 -----
 
 First you must Fork the
-`repository <http://github.com/doctrine/doctrine2>`_ and clone your fork
+`repository <https://github.com/doctrine/doctrine2>`_ and clone your fork
 locally:
 
 .. code-block:: console

--- a/source/images/doctrine-logo.svg
+++ b/source/images/doctrine-logo.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- Created with Inkscape (https://inkscape.org/) -->
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   xmlns:cc="https://creativecommons.org/ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="https://www.w3.org/2000/svg"
+   xmlns="https://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:inkscape="https://inkscape.org/namespaces/inkscape/"
    width="172.231"
    height="225.83495"
    id="svg2"

--- a/source/policies/deprecation.rst
+++ b/source/policies/deprecation.rst
@@ -154,5 +154,5 @@ The `PHPUnit Bridge`_ provides utilities to report legacy tests and usage of dep
 .. _PHPStan: https://github.com/phpstan/phpstan
 .. _PHP Parser: https://github.com/nikic/php-parser
 .. _PHPUnit Bridge: https://github.com/symfony/phpunit-bridge
-.. _error_reporting: http://php.net/manual/en/function.error-reporting.php
-.. _set_error_handler: http://php.net/manual/en/function.set-error-handler.php
+.. _error_reporting: https://secure.php.net/manual/en/function.error-reporting.php
+.. _set_error_handler: https://secure.php.net/manual/en/function.set-error-handler.php

--- a/source/projects.html
+++ b/source/projects.html
@@ -1,7 +1,7 @@
 <h1>Projects</h1>
 
 <p class="lead">
-    Doctrine is a collection of projects built for <a href="https://php.net" target="_blank" rel="noopener noreferrer">PHP</a>. Each project can be used standalone and installed with <a href="https://getcomposer.org/" target="_blank" rel="noopener noreferrer">Composer</a>.
+    Doctrine is a collection of projects built for <a href="https://secure.php.net" target="_blank" rel="noopener noreferrer">PHP</a>. Each project can be used standalone and installed with <a href="https://getcomposer.org/" target="_blank" rel="noopener noreferrer">Composer</a>.
 </p>
 
 <ul class="nav nav-tabs" id="projects" role="tablist">

--- a/source/schemas/odm/doctrine-mongo-mapping.xsd
+++ b/source/schemas/odm/doctrine-mongo-mapping.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema"
     targetNamespace="https://www.doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd"
     xmlns:odm="https://www.doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd"
     elementFormDefault="qualified">

--- a/source/schemas/odm/doctrine-phpcr-mapping.xsd
+++ b/source/schemas/odm/doctrine-phpcr-mapping.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema"
            targetNamespace="https://www.doctrine-project.org/schemas/odm/doctrine-phpcr-mapping.xsd"
            xmlns:phpcr="https://www.doctrine-project.org/schemas/odm/doctrine-phpcr-mapping.xsd"
            elementFormDefault="qualified">
@@ -108,7 +108,7 @@
     </xs:complexType>
 
     <!--
-    TODO:  http://www.doctrine-project.org/jira/browse/PHPCR-108
+    TODO:  https://www.doctrine-project.org/jira/browse/PHPCR-108
     <xs:complexType name="document-listener">
         <xs:choice>
             <xs:element name="lifecycle-callback" type="phpcr:lifecycle-callback" minOccurs="0" maxOccurs="unbounded"/>
@@ -138,7 +138,7 @@
             <xs:element name="options" type="phpcr:options" minOccurs="0" />
             <xs:element name="lifecycle-callbacks" type="phpcr:lifecycle-callbacks" minOccurs="0" maxOccurs="1" />
             <!--
-            TODO:  http://www.doctrine-project.org/jira/browse/PHPCR-108
+            TODO:  https://www.doctrine-project.org/jira/browse/PHPCR-108
             <xs:element name="document-listeners" type="phpcr:document-listeners" minOccurs="0" maxOccurs="1" />
             -->
             <xs:element name="id" type="phpcr:id" minOccurs="0" maxOccurs="1" />
@@ -192,7 +192,7 @@
             <xs:enumeration value="ASSIGNED"/>
             <xs:enumeration value="PARENT"/>
             <!--
-            TODO: http://www.doctrine-project.org/jira/browse/PHPCR-73
+            TODO: https://www.doctrine-project.org/jira/browse/PHPCR-73
             <xs:enumeration value="CUSTOM"/>
              -->
         </xs:restriction>
@@ -210,7 +210,7 @@
         <xs:choice>
             <xs:element name="generator" type="phpcr:generator" minOccurs="0" />
             <!--
-                TODO: http://www.doctrine-project.org/jira/browse/PHPCR-73
+                TODO: https://www.doctrine-project.org/jira/browse/PHPCR-73
             <xs:element name="custom-id-generator" type="phpcr:custom-id-generator" minOccurs="0" maxOccurs="1" />
              -->
             <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
@@ -224,7 +224,7 @@
     </xs:complexType>
 
     <!--
-        TODO: http://www.doctrine-project.org/jira/browse/PHPCR-73
+        TODO: https://www.doctrine-project.org/jira/browse/PHPCR-73
     <xs:complexType name="custom-id-generator">
         <xs:choice>
             <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>

--- a/source/schemas/orm/doctrine-mapping.xsd
+++ b/source/schemas/orm/doctrine-mapping.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema"
     targetNamespace="https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
     xmlns:orm="https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
     elementFormDefault="qualified">

--- a/source/sitemap.xml
+++ b/source/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9/">
     {% for page in pages %}
         <url>
             <loc>{{ site.url }}{{ page.url }}</loc>

--- a/templates/layouts/blog-post.html.twig
+++ b/templates/layouts/blog-post.html.twig
@@ -7,7 +7,7 @@
 {% block head_meta %}
     <script type="application/ld+json">
     {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "@type": "NewsArticle",
         "mainEntityOfPage": {
             "@type": "WebPage",

--- a/templates/layouts/documentation.html.twig
+++ b/templates/layouts/documentation.html.twig
@@ -20,7 +20,7 @@
     {% if project is defined and project %}
         <script type="application/ld+json">
         {
-            "@context": "http://schema.org",
+            "@context": "https://schema.org",
             "@type": "Course",
             "name": "Doctrine {{ project.name }}",
             "description": "{{ page.title }}",

--- a/templates/layouts/layout.html.twig
+++ b/templates/layouts/layout.html.twig
@@ -69,7 +69,7 @@
 
         <script type="application/ld+json">
         {
-            "@context": "http://schema.org",
+            "@context": "https://schema.org",
             "@type": "Organization",
             "url": "{{ site.url }}",
             "logo": "{{ site.url }}/images/doctrine-logo.svg"
@@ -78,7 +78,7 @@
 
         <script type="application/ld+json">
         {
-            "@context": "http://schema.org",
+            "@context": "https://schema.org",
             "@type": "WebSite",
             "url": "{{ site.url }}",
             "potentialAction": {
@@ -91,7 +91,7 @@
 
         <script type="application/ld+json">
         {
-            "@context": "http://schema.org",
+            "@context": "https://schema.org",
             "@type": "Organization",
             "name": "Doctrine",
             "url": "{{ site.url }}",


### PR DESCRIPTION
Websites that where moved

- github.com
- php.net to secure.php.net
- www.doctrine-project.org
- orientdb.org
- packagist.org
- twitter.com
- martinfowler.com
- sensiolabs.com
- en.wikipedia.org
- www.mongodb.org to www.mongodb.com
- amazon.com
- 3v4l.org
- php.budgegeria.de
- framework.zend.com
- www.sitemaps.org
- schema.org
- www.w3.org
- www.atlassian.com
- magentocommerce.com to magento.com
- mysql.com
- slideshare.net
- groups.google.com

moved non-www doctrine-project.org to version with www