### PR TITLE
Use exception instead of assert

### DIFF
--- a/lib/Repositories/ContributorRepository.php
+++ b/lib/Repositories/ContributorRepository.php
@@ -6,7 +6,8 @@ namespace Doctrine\Website\Repositories;
 
 use Doctrine\SkeletonMapper\ObjectRepository\BasicObjectRepository;
 use Doctrine\Website\Model\Contributor;
-use function assert;
+use UnexpectedValueException;
+use function sprintf;
 
 class ContributorRepository extends BasicObjectRepository
 {
@@ -14,7 +15,9 @@ class ContributorRepository extends BasicObjectRepository
     {
         $contributor = $this->findOneBy(['github' => $github]);
 
-        assert($contributor instanceof Contributor || $contributor !== null);
+        if (! $contributor instanceof Contributor) {
+            throw new UnexpectedValueException(sprintf('No contributor was found by "%s"', $github));
+        }
 
         return $contributor;
     }


### PR DESCRIPTION
This is a small follow up PR to #270, that fixes a last step suggested by @lcobucci to use an exception instead of `assert`.