### PR TITLE
Fix bug with major release zero versions that do not have an associated branch.

### DIFF
--- a/lib/Projects/ProjectVersionsReader.php
+++ b/lib/Projects/ProjectVersionsReader.php
@@ -50,18 +50,17 @@ class ProjectVersionsReader
                 continue;
             }
 
+            // if 0.x release doesn't have an associated branch, assume master
+            if ($tag->isMajorReleaseZero() && $branchName === null) {
+                $branchName = 'master';
+            }
+
             $versions[$branchSlug] = [
                 'name' => $branchSlug,
                 'slug' => $branchSlug,
                 'branchName' => $branchName,
                 'tags' => [$tag],
             ];
-
-            if (! $tag->isMajorReleaseZero()) {
-                continue;
-            }
-
-            $versions[$branchSlug]['branchName'] = 'master';
         }
 
         return array_values($versions);

--- a/tests/Projects/ProjectVersionsReaderTest.php
+++ b/tests/Projects/ProjectVersionsReaderTest.php
@@ -23,7 +23,6 @@ class ProjectVersionsReaderTest extends TestCase
     /** @var ProjectVersionsReader */
     private $projectVersionsReader;
 
-
     public function testReadProjectVersions() : void
     {
         $repositoryPath = '/repository/path';
@@ -32,9 +31,10 @@ class ProjectVersionsReaderTest extends TestCase
         $tag2 = new Tag('v2.0.1', new DateTimeImmutable());
         $tag3 = new Tag('v3.0.0', new DateTimeImmutable());
         $tag4 = new Tag('dev-test', new DateTimeImmutable());
-        $tag5 = new Tag('0.0.1', new DateTimeImmutable());
+        $tag5 = new Tag('0.1.0', new DateTimeImmutable());
+        $tag6 = new Tag('0.0.1', new DateTimeImmutable());
 
-        $tags = [$tag1, $tag2, $tag3, $tag4, $tag5];
+        $tags = [$tag1, $tag2, $tag3, $tag4, $tag5, $tag6];
 
         $this->tagReader->expects(self::once())
             ->method('getRepositoryTags')
@@ -78,18 +78,29 @@ class ProjectVersionsReaderTest extends TestCase
         $this->tagBranchGuesser->expects(self::at(6))
             ->method('generateTagBranchSlug')
             ->with($tag5)
-            ->willReturn('0.0');
+            ->willReturn('0.1');
 
         $this->tagBranchGuesser->expects(self::at(7))
             ->method('guessTagBranchName')
             ->with($repositoryPath, $tag5)
+            ->willReturn('0.1');
+
+        // tag6
+        $this->tagBranchGuesser->expects(self::at(8))
+            ->method('generateTagBranchSlug')
+            ->with($tag6)
+            ->willReturn('0.0');
+
+        $this->tagBranchGuesser->expects(self::at(9))
+            ->method('guessTagBranchName')
+            ->with($repositoryPath, $tag6)
             ->willReturn(null);
 
         $versions = $this->projectVersionsReader->readProjectVersions(
             $repositoryPath
         );
 
-        self::assertCount(3, $versions);
+        self::assertCount(4, $versions);
 
         self::assertCount(2, $versions[0]['tags']);
         self::assertSame('v2.0.0', $versions[0]['tags'][0]->getName());
@@ -99,8 +110,12 @@ class ProjectVersionsReaderTest extends TestCase
         self::assertSame('v3.0.0', $versions[1]['tags'][0]->getName());
 
         self::assertCount(1, $versions[2]['tags']);
-        self::assertSame('0.0.1', $versions[2]['tags'][0]->getName());
-        self::assertSame('master', $versions[2]['branchName']);
+        self::assertSame('0.1.0', $versions[2]['tags'][0]->getName());
+        self::assertSame('0.1', $versions[2]['branchName']);
+
+        self::assertCount(1, $versions[3]['tags']);
+        self::assertSame('0.0.1', $versions[3]['tags'][0]->getName());
+        self::assertSame('master', $versions[3]['branchName']);
     }
 
     protected function setUp() : void


### PR DESCRIPTION
I made an incorrect assumption for major release zero versions where it assumed `0.x` releases would always be master but this is not the case. We should only assume master if the TagBranchGuesser did not find a branch for the tag.