### PR TITLE
Remove memory-limit in build-website-data command

### DIFF
--- a/lib/Commands/BuildWebsiteDataCommand.php
+++ b/lib/Commands/BuildWebsiteDataCommand.php
@@ -12,7 +12,6 @@ use Doctrine\Website\DataBuilder\WebsiteDataWriter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use function ini_set;
 use function sprintf;
 
 class BuildWebsiteDataCommand extends Command
@@ -57,8 +56,6 @@ class BuildWebsiteDataCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        ini_set('memory_limit', '1024M');
-
         $output->writeln('Building website data.');
 
         $dataBuilders = [


### PR DESCRIPTION
The build/deployment for the website is exiting with the error message

```
PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried   
  to allocate 307200 bytes) in vendor/doctrine/static-website-generator/lib/SourceFile/SourceFile.php on line 131
```

This occurs because of a limitation of memory added with `ini_set` in the past. Without the limit, the build proceeds.