### PR TITLE
Remove caution about rebase

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -207,11 +207,6 @@ fixed with ``add``, and then continue rebasing with
 ``rebase --abort`` unlike nasty merges which will leave files strewn
 everywhere.
 
-    **caution**
-
-    Please note that once you have pushed your branch remotely you MUST
-    NOT rebase!
-
 .. code-block:: console
 
     $ git fetch doctrine


### PR DESCRIPTION
It is inconsistent with other parts of the contributing guide.
Closes #334 