### PR TITLE
Update Tidelift marketing language

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -132,15 +132,25 @@
             <div class="card">
                 <h5 class="card-header">Get professional support for Doctrine ORM</h5>
                 <div class="card-body">
-                    Available as part of the <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank" rel="noopener noreferrer">Tidelift Subscription</a>. It includes support for Doctrine ORM and many of the other open source packages you depend on. Here’s how it provides the professional assurances you need.
+                    <h6>Available as part of the <a href="https://tidelift.com/subscription/request-a-demo?utm_source=packagist-doctrine-orm&utm_medium=referral&utm_campaign=enterprise" target="_blank" rel="noopener noreferrer">Tidelift Subscription</a>.</h6>
 
-                    <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=website" target="_blank" rel="noopener noreferrer"><img src="{{ get_asset_url('/images/tidelift-logo.png', site.url) }}" class="w-100" /></a>
+                    <p>Tidelift is working with the maintainers of Doctrine ORM and thousands of other open source projects to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use.</p>
 
+                    <a href="https://tidelift.com/subscription/pkg/packagist-doctrine-orm?utm_source=packagist-doctrine-orm&utm_medium=referral&utm_campaign=enterprise" target="_blank" rel="noopener noreferrer"><img src="{{ get_asset_url('/images/tidelift-logo.png', site.url) }}" class="w-100" /></a>
+
+                    <h6>Enterprise-ready open source software—managed for you.</h6>
+                    
+                    <p>The Tidelift Subscription is a managed open source subscription for application dependencies covering millions of open source projects across JavaScript, Python, Java, PHP, Ruby, .NET, and more.</p>
+
+                    <p>Your subscription includes:</p>
+                    
                     <ul>
-                        <li><strong>Security:</strong> Timely notifications and help addressing vulnerabilities</li>
-                        <li><strong>Maintenance:</strong> Assurance of ongoing high-quality maintenance into the future</li>
-                        <li><strong>Licensing:</strong> Legal assurances documenting license status and whether current usage is compatible</li>
-                        <li><strong>Comprehensive view:</strong> A clear way to understand all of your organization’s open source dependencies and better manage risk</li>
+                        <li><strong>Security updates:</strong> Tidelift’s security response team coordinates patches for new breaking security vulnerabilities and alerts immediately through a private channel, so your software supply chain is always secure.</li>
+                        <li><strong>Licensing verification and indemnification:</strong> Tidelift verifies license information to enable easy policy enforcement and adds intellectual property indemnification to cover creators and users in case something goes wrong. You always have a 100% up-to-date bill of materials for your dependencies to share with your legal team, customers, or partners.</li>
+                        <li><strong>Maintenance and code improvement:</strong> Tidelift ensures the software you rely on keeps working as long as you need it to work. Your managed dependencies are actively maintained and we recruit additional maintainers where required.</li>
+                        <li><strong>Package selection and version guidance:</strong> We help you choose the best open source packages from the start—and then guide you through updates to stay on the best releases as new issues arise.</li>
+                        <li><strong>Roadmap input:</strong> Take a seat at the table with the creators behind the software you use. Tidelift’s participating maintainers earn more income as their software is used by more subscribers, so they’re interested in knowing what you need.</li>
+                        <li><strong>Tooling and cloud integration:</strong> Tidelift works with GitHub, GitLab, BitBucket, and more. We support every cloud platform (and other deployment targets, too).</li>
                     </ul>
                 </div>
             </div>

--- a/source/index.html
+++ b/source/index.html
@@ -130,7 +130,7 @@
     <div class="row mb-4">
         <div class="col-12">
             <div class="card">
-                <h5 class="card-header">Get professional support for Doctrine ORM</h5>
+                <h5 class="card-header">Doctrine ORM for enterprise</h5>
                 <div class="card-body">
                     <h6>Available as part of the <a href="https://tidelift.com/subscription/request-a-demo?utm_source=packagist-doctrine-orm&utm_medium=referral&utm_campaign=enterprise" target="_blank" rel="noopener noreferrer">Tidelift Subscription</a>.</h6>
 


### PR DESCRIPTION
This updates the Tidelift marketing language to make Doctrine ORM eligible for our marketing lead referral bonus.

I'm not sure if the layout is perfect, so feel free to adjust it.