### PR TITLE
Fix the name of the orm clone

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -50,11 +50,11 @@ Initial Setup
 
     $ git clone git@github.com:username/orm.git
 
--  Enter the doctrine2 directory and add the **doctrine** remote
+-  Enter the orm directory and add the **doctrine** remote
 
 .. code-block:: console
 
-    $ cd doctrine2
+    $ cd orm
     $ git remote add doctrine git://github.com/doctrine/orm.git
 
 -  Adjust your branch to track the doctrine master remote branch, by


### PR DESCRIPTION
The repository will be cloned into a directory named “orm”, not “doctrine2”.

Missed in 03e3b92dfabfeeff06c7cb07d739770d71989f35.