### PR TITLE
Regular builds to make broken .doctrine-project.json visible

### DIFF
--- a/.github/workflows/website-configs.yml
+++ b/.github/workflows/website-configs.yml
@@ -1,0 +1,46 @@
+name: "website-configs"
+
+on:
+  schedule:
+    - cron:  "0 23 * * *"
+
+jobs:
+  build:
+
+    runs-on: "ubuntu-18.04"
+
+    services:
+      mysql:
+        image: "mysql:5.7"
+        env:
+          MYSQL_DATABASE: "doctrine_website_test"
+          MYSQL_ROOT_PASSWORD: "VdtLtifRh4gt37T"
+        ports:
+          - "3306:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+    - uses: "actions/checkout@v2"
+
+    - name: "Cache Composer packages"
+      id: "composer-cache"
+      uses: "actions/cache@v2"
+      with:
+        path: "vendor"
+        key: "${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}"
+        restore-keys: |
+          ${{ runner.os }}-php-
+    - name: "Setup PHP Action"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: "7.2"
+
+    - name: "Install dependencies"
+      if: "steps.composer-cache.outputs.cache-hit != 'true'"
+      run: "composer install --prefer-dist --no-progress --no-suggest"
+
+    - name: "Prepare Webite files"
+      run: "bin/console --env=test sync-repositories && bin/console --env=test sync && bin/console --env=test clear-build-cache  && bin/console --env=test build-website-data"
+
+    - name: "Build docs based on .doctrine-project.json files"
+      run: "bin/console --env=test build-docs"


### PR DESCRIPTION
A misconfigured .doctrine-project.json file in Doctrine projects tend to break builds which prevents all project documentations to be released in case of new changes. As a current first step this action was created to regularly run the `build-docs` command to make broken website configs in the different projects visible.