### PR TITLE
Use default branch instead of master for .doctrine-project.json

### DIFF
--- a/.github/workflows/php7.2.yml
+++ b/.github/workflows/php7.2.yml
@@ -3,6 +3,7 @@ name: "Website build"
 on: ["push", "pull_request"]
 
 env:
+  doctrine_website_github_http_token: "${{ secrets.doctrine_website_github_http_token }}"
   PHP_VERSION: "7.2"
   doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"
 

--- a/.github/workflows/website-configs.yml
+++ b/.github/workflows/website-configs.yml
@@ -11,6 +11,7 @@ on:
     - '.github/workflows/website-configs.yml'
 
 env:
+  doctrine_website_github_http_token: "${{ secrets.doctrine_website_github_http_token }}"
   doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"
 
 jobs:

--- a/lib/DataBuilder/ProjectDataBuilder.php
+++ b/lib/DataBuilder/ProjectDataBuilder.php
@@ -91,7 +91,7 @@ class ProjectDataBuilder implements DataBuilder
     private function buildProjectData(string $repositoryName): array
     {
         // checkout master branch
-        $this->projectGitSyncer->checkoutMaster($repositoryName);
+        $this->projectGitSyncer->checkoutDefaultBranch($repositoryName);
 
         $projectData = array_replace(
             self::DEFAULTS,
@@ -245,7 +245,7 @@ class ProjectDataBuilder implements DataBuilder
         }
 
         // switch back to master
-        $this->projectGitSyncer->checkoutMaster($repositoryName);
+        $this->projectGitSyncer->checkoutDefaultBranch($repositoryName);
 
         return $projectVersions;
     }

--- a/lib/Docs/BuildDocs.php
+++ b/lib/Docs/BuildDocs.php
@@ -108,7 +108,7 @@ class BuildDocs
                 $this->searchIndexer->buildSearchIndexes($project, $version, $searchDocuments);
             }
 
-            $this->projectGitSyncer->checkoutMaster($project->getRepositoryName());
+            $this->projectGitSyncer->checkoutDefaultBranch($project->getRepositoryName());
         }
     }
 

--- a/lib/Projects/ProjectGitSyncer.php
+++ b/lib/Projects/ProjectGitSyncer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Website\Projects;
 
 use Doctrine\Website\ProcessFactory;
-
+use Github\Client;
 use function is_dir;
 use function sprintf;
 
@@ -17,10 +17,14 @@ class ProjectGitSyncer
     /** @var string */
     private $projectsDir;
 
-    public function __construct(ProcessFactory $processFactory, string $projectsDir)
+    /** @var \Github\Api\Repo */
+    private $githubRepo;
+
+    public function __construct(ProcessFactory $processFactory, Client $githubClient, string $projectsDir)
     {
         $this->processFactory = $processFactory;
         $this->projectsDir    = $projectsDir;
+        $this->githubRepo     = $githubClient->repo();
     }
 
     public function isRepositoryInitialized(string $repositoryName): bool
@@ -47,7 +51,9 @@ class ProjectGitSyncer
 
     public function checkoutMaster(string $repositoryName): void
     {
-        $this->checkoutBranch($repositoryName, 'master');
+        $repoMetaData = $this->githubRepo->show('doctrine', $repositoryName);
+
+        $this->checkoutBranch($repositoryName, $repoMetaData['default_branch']);
     }
 
     public function checkoutBranch(string $repositoryName, string $branchName): void

--- a/lib/Projects/ProjectGitSyncer.php
+++ b/lib/Projects/ProjectGitSyncer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Projects;
 
+use Doctrine\Website\Github\GithubClientProvider;
 use Doctrine\Website\ProcessFactory;
-use Github\Client;
 use function is_dir;
 use function sprintf;
 
@@ -20,11 +20,12 @@ class ProjectGitSyncer
     /** @var \Github\Api\Repo */
     private $githubRepo;
 
-    public function __construct(ProcessFactory $processFactory, Client $githubClient, string $projectsDir)
+    public function __construct(ProcessFactory $processFactory, GithubClientProvider $githubClientProvider, string $projectsDir)
     {
         $this->processFactory = $processFactory;
         $this->projectsDir    = $projectsDir;
-        $this->githubRepo     = $githubClient->repo();
+        // TODO Inject Repo instead of GithubClientProvider
+        $this->githubRepo     = $githubClientProvider->getGithubClient()->repo();
     }
 
     public function isRepositoryInitialized(string $repositoryName): bool

--- a/lib/Projects/ProjectGitSyncer.php
+++ b/lib/Projects/ProjectGitSyncer.php
@@ -49,7 +49,7 @@ class ProjectGitSyncer
         $this->processFactory->run($command);
     }
 
-    public function checkoutMaster(string $repositoryName): void
+    public function checkoutDefaultBranch(string $repositoryName): void
     {
         $repoMetaData = $this->githubRepo->show('doctrine', $repositoryName);
 

--- a/lib/Projects/ProjectGitSyncer.php
+++ b/lib/Projects/ProjectGitSyncer.php
@@ -6,6 +6,8 @@ namespace Doctrine\Website\Projects;
 
 use Doctrine\Website\Github\GithubClientProvider;
 use Doctrine\Website\ProcessFactory;
+use Github\Api\Repo;
+
 use function is_dir;
 use function sprintf;
 
@@ -17,7 +19,7 @@ class ProjectGitSyncer
     /** @var string */
     private $projectsDir;
 
-    /** @var \Github\Api\Repo */
+    /** @var Repo */
     private $githubRepo;
 
     public function __construct(ProcessFactory $processFactory, GithubClientProvider $githubClientProvider, string $projectsDir)
@@ -25,7 +27,7 @@ class ProjectGitSyncer
         $this->processFactory = $processFactory;
         $this->projectsDir    = $projectsDir;
         // TODO Inject Repo instead of GithubClientProvider
-        $this->githubRepo     = $githubClientProvider->getGithubClient()->repo();
+        $this->githubRepo = $githubClientProvider->getGithubClient()->repo();
     }
 
     public function isRepositoryInitialized(string $repositoryName): bool

--- a/tests/DataBuilder/ProjectDataBuilderTest.php
+++ b/tests/DataBuilder/ProjectDataBuilderTest.php
@@ -50,7 +50,7 @@ class ProjectDataBuilderTest extends TestCase
             ->willReturn(['orm']);
 
         $this->projectGitSyncer->expects(self::at(0))
-            ->method('checkoutMaster')
+            ->method('checkoutDefaultBranch')
             ->with('orm');
 
         $this->projectDataReader->expects(self::once())

--- a/tests/Projects/ProjectGitSyncerTest.php
+++ b/tests/Projects/ProjectGitSyncerTest.php
@@ -7,6 +7,9 @@ namespace Doctrine\Website\Tests\Projects;
 use Doctrine\Website\ProcessFactory;
 use Doctrine\Website\Projects\ProjectGitSyncer;
 use Doctrine\Website\Tests\TestCase;
+use Github\Api\Repo;
+use Github\Client;
+use Github\HttpClient\Builder;
 use PHPUnit\Framework\MockObject\MockObject;
 
 use function sprintf;
@@ -19,16 +22,25 @@ class ProjectGitSyncerTest extends TestCase
     /** @var string */
     private $projectsDir;
 
-    /** @var ProjectGitSyncer */
+    /** @var ProjectGitSyncer&MockObject */
     private $projectGitSyncer;
 
     protected function setUp(): void
     {
         $this->processFactory = $this->createMock(ProcessFactory::class);
         $this->projectsDir    = __DIR__;
+        $this->githubRepo     = $this->createMock(Repo::class);
+        $githubClient         = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['repo'])
+            ->getMock();
+
+        $githubClient->method('repo')
+            ->willReturn($this->githubRepo);
 
         $this->projectGitSyncer = new ProjectGitSyncer(
             $this->processFactory,
+            $githubClient,
             $this->projectsDir
         );
     }
@@ -63,14 +75,19 @@ class ProjectGitSyncerTest extends TestCase
         $this->projectGitSyncer->syncRepository($repositoryName);
     }
 
-    public function testCheckoutMaster(): void
+    public function testCheckoutDefaultBranch(): void
     {
         $repositoryName = 'example-project';
+
+        $this->githubRepo->expects(self::once())
+            ->method('show')
+            ->with('doctrine', $repositoryName)
+            ->willReturn(['default_branch' => '1.0']);
 
         $this->processFactory->expects(self::at(0))
             ->method('run')
             ->with(sprintf(
-                'cd %s/example-project && git clean -xdf && git checkout origin/master',
+                'cd %s/example-project && git clean -xdf && git checkout origin/1.0',
                 $this->projectsDir
             ));
 

--- a/tests/Projects/ProjectGitSyncerTest.php
+++ b/tests/Projects/ProjectGitSyncerTest.php
@@ -10,21 +10,23 @@ use Doctrine\Website\Projects\ProjectGitSyncer;
 use Doctrine\Website\Tests\TestCase;
 use Github\Api\Repo;
 use Github\Client;
-use Github\HttpClient\Builder;
 use PHPUnit\Framework\MockObject\MockObject;
 
 use function sprintf;
 
 class ProjectGitSyncerTest extends TestCase
 {
-    /** @var ProcessFactory|MockObject */
+    /** @var ProcessFactory&MockObject */
     private $processFactory;
 
     /** @var string */
     private $projectsDir;
 
-    /** @var ProjectGitSyncer&MockObject */
+    /** @var ProjectGitSyncer */
     private $projectGitSyncer;
+
+    /** @var Repo&MockObject */
+    private $githubRepo;
 
     protected function setUp(): void
     {

--- a/tests/Projects/ProjectGitSyncerTest.php
+++ b/tests/Projects/ProjectGitSyncerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Tests\Projects;
 
+use Doctrine\Website\Github\GithubClientProvider;
 use Doctrine\Website\ProcessFactory;
 use Doctrine\Website\Projects\ProjectGitSyncer;
 use Doctrine\Website\Tests\TestCase;
@@ -30,6 +31,7 @@ class ProjectGitSyncerTest extends TestCase
         $this->processFactory = $this->createMock(ProcessFactory::class);
         $this->projectsDir    = __DIR__;
         $this->githubRepo     = $this->createMock(Repo::class);
+        $githubClientProvider = $this->createMock(GithubClientProvider::class);
         $githubClient         = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->addMethods(['repo'])
@@ -38,9 +40,12 @@ class ProjectGitSyncerTest extends TestCase
         $githubClient->method('repo')
             ->willReturn($this->githubRepo);
 
+        $githubClientProvider->method('getGithubClient')
+            ->willReturn($githubClient);
+
         $this->projectGitSyncer = new ProjectGitSyncer(
             $this->processFactory,
-            $githubClient,
+            $githubClientProvider,
             $this->projectsDir
         );
     }

--- a/tests/Projects/ProjectGitSyncerTest.php
+++ b/tests/Projects/ProjectGitSyncerTest.php
@@ -91,7 +91,7 @@ class ProjectGitSyncerTest extends TestCase
                 $this->projectsDir
             ));
 
-        $this->projectGitSyncer->checkoutMaster($repositoryName);
+        $this->projectGitSyncer->checkoutDefaultBranch($repositoryName);
     }
 
     public function testCheckoutBranch(): void


### PR DESCRIPTION
In order for the release workflow and changing branch names, this PR introduces fetching the .doctrine-project.json infos of each repository from the default branch instead of master.

Repositories that need to move the website config `.doctrine-project.json` to the default branch:

- [x] annotations
- [x] cache
- [x] coding-standard
- [x] collections
- [x] common (still on master)
- [x] couchdb-client (still on master)
- [x] couchdb-odm (still on master)
- [x] dbal
- [x] doctrine1 (still on master)
- [x] DoctrineBundle
- [x] DoctrineCacheBundle (still on master)
- [x] DoctrineMigrationsBundle
- [x] DoctrineMongoDBBundle
- [x] DoctrineORMModule (still on master)
- [x] event-manager
- [x] inflector
- [x] instantiator
- [x] lexer (still on master)
- [x] migrations
- [x] mongodb (still on master)
- [x] mongodb-odm (still on master)
- [x] orientdb-odm (still on master)
- [x] orm
- [x] persistence
- [x] phpcr-odm (still on master)
- [x] reflection
- [x] rst-parser (still on master)
- [x] skeleton-mapper
- [x] all PRs got merged