### PR TITLE
Set a server version

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -7,6 +7,7 @@
         <parameter key="doctrine.website.mysql.user">root</parameter>
         <parameter key="doctrine.website.mysql.password"></parameter>
         <parameter key="doctrine.website.mysql.host">localhost</parameter>
+        <parameter key="doctrine.website.mysql.version">5.7</parameter>
     </parameters>
 
     <services>
@@ -532,6 +533,7 @@
                 <argument key="password">%doctrine.website.mysql.password%</argument>
                 <argument key="host">%doctrine.website.mysql.host%</argument>
                 <argument key="driver">pdo_mysql</argument>
+                <argument key="serverVersion">%doctrine.website.mysql.version%</argument>
             </argument>
         </service>
 


### PR DESCRIPTION
This avoids a round trip to the database, making it possible to run some
of the commands without setting up a database. This might make
contributing easier.