### PR TITLE
Lazy load commands

### DIFF
--- a/lib/Commands/AnnounceReleaseCommand.php
+++ b/lib/Commands/AnnounceReleaseCommand.php
@@ -16,6 +16,9 @@ use function sprintf;
 
 final class AnnounceReleaseCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'announce-release';
+
     /** @var AnnounceRelease */
     private $announceRelease;
 
@@ -29,7 +32,6 @@ final class AnnounceReleaseCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('announce-release')
             ->setDescription('Announce a release on Twitter, Slack, etc.')
             ->addArgument(
                 'project',

--- a/lib/Commands/BuildAllCommand.php
+++ b/lib/Commands/BuildAllCommand.php
@@ -22,6 +22,9 @@ use function sprintf;
 class BuildAllCommand extends Command
 {
     /** @var string */
+    protected static $defaultName = 'build-all';
+
+    /** @var string */
     private $rootDir;
 
     /** @var string */
@@ -40,7 +43,6 @@ class BuildAllCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('build-all')
             ->setDescription('Build all website components.')
             ->addArgument(
                 'build-dir',

--- a/lib/Commands/BuildDocsCommand.php
+++ b/lib/Commands/BuildDocsCommand.php
@@ -15,6 +15,9 @@ use function is_string;
 
 class BuildDocsCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'build-docs';
+
     /** @var BuildDocs */
     private $buildDocs;
 
@@ -28,7 +31,6 @@ class BuildDocsCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('build-docs')
             ->setDescription('Build the RST docs.')
             ->addOption(
                 'project',

--- a/lib/Commands/BuildWebsiteCommand.php
+++ b/lib/Commands/BuildWebsiteCommand.php
@@ -28,6 +28,9 @@ use function time;
 
 class BuildWebsiteCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'build-website';
+
     private const WATCH_DIRS = [
         'config',
         'data',
@@ -60,7 +63,6 @@ class BuildWebsiteCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('build-website')
             ->setDescription('Build the Doctrine website.')
             ->addArgument(
                 'build-dir',

--- a/lib/Commands/BuildWebsiteDataCommand.php
+++ b/lib/Commands/BuildWebsiteDataCommand.php
@@ -16,6 +16,9 @@ use function sprintf;
 
 class BuildWebsiteDataCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'build-website-data';
+
     /** @var ProjectDataBuilder */
     private $projectDataBuilder;
 
@@ -50,7 +53,6 @@ class BuildWebsiteDataCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('build-website-data')
             ->setDescription('Build the Doctrine website data.');
     }
 

--- a/lib/Commands/ClearBuildCacheCommand.php
+++ b/lib/Commands/ClearBuildCacheCommand.php
@@ -15,6 +15,9 @@ use function sprintf;
 
 class ClearBuildCacheCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'clear-build-cache';
+
     /** @var CacheClearer */
     private $cacheClearer;
 
@@ -36,7 +39,6 @@ class ClearBuildCacheCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('clear-build-cache')
             ->setDescription('Clear the build cache.')
             ->addArgument(
                 'build-dir',

--- a/lib/Commands/DeployCommand.php
+++ b/lib/Commands/DeployCommand.php
@@ -11,6 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DeployCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'deploy';
+
     /** @var Deployer */
     private $deployer;
 
@@ -24,7 +27,6 @@ class DeployCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('deploy')
             ->setDescription('Deploy the Doctrine website.');
     }
 

--- a/lib/Commands/EventParticipantsCommand.php
+++ b/lib/Commands/EventParticipantsCommand.php
@@ -26,6 +26,9 @@ use function sprintf;
 
 class EventParticipantsCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'event-participants';
+
     /** @var EventRepository */
     private $eventRepository;
 
@@ -60,7 +63,6 @@ class EventParticipantsCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('event-participants')
             ->setDescription('Command to check for event participants using the Stripe API.')
             ->addOption(
                 'save',

--- a/lib/Commands/SyncRepositoriesCommand.php
+++ b/lib/Commands/SyncRepositoriesCommand.php
@@ -13,6 +13,9 @@ use function sprintf;
 
 class SyncRepositoriesCommand extends Command
 {
+    /** @var string */
+    protected static $defaultName = 'sync-repositories';
+
     /** @var ProjectDataRepository */
     private $projectDataRepository;
 
@@ -32,7 +35,6 @@ class SyncRepositoriesCommand extends Command
     protected function configure() : void
     {
         $this
-            ->setName('sync-repositories')
             ->setDescription('Initialize or update all project repositories.');
     }
 


### PR DESCRIPTION
Making the command name available without instantiating it makes it
possible to find the right command without instantiating all of them.