### PR TITLE
Move DB password to Github secrets

### DIFF
--- a/.github/workflows/php7.2.yml
+++ b/.github/workflows/php7.2.yml
@@ -4,6 +4,7 @@ on: ["push", "pull_request"]
 
 env:
   PHP_VERSION: "7.2"
+  doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"
 
 jobs:
   tests:
@@ -15,7 +16,7 @@ jobs:
         image: "mysql:5.7"
         env:
           MYSQL_DATABASE: "doctrine_website_test"
-          MYSQL_ROOT_PASSWORD: "VdtLtifRh4gt37T"
+          MYSQL_ROOT_PASSWORD: "${{ secrets.doctrine_website_mysql_password }}"
         ports:
           - "3306:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/.github/workflows/website-configs.yml
+++ b/.github/workflows/website-configs.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron:  "0 23 * * *"
 
+env:
+  doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"
+
 jobs:
   build:
 
@@ -14,7 +17,7 @@ jobs:
         image: "mysql:5.7"
         env:
           MYSQL_DATABASE: "doctrine_website_test"
-          MYSQL_ROOT_PASSWORD: "VdtLtifRh4gt37T"
+          MYSQL_ROOT_PASSWORD: "${{ secrets.doctrine_website_mysql_password }}"
         ports:
           - "3306:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/config/config_test.yml
+++ b/config/config_test.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: config.yml }
 
 parameters:
-    doctrine.website.mysql.password: 'VdtLtifRh4gt37T'
     doctrine.website.mysql.host: '127.0.0.1'
 
 services:

--- a/config/local.yml.dist
+++ b/config/local.yml.dist
@@ -2,3 +2,4 @@ parameters:
     doctrine.website.algolia.admin_api_key: 'abcd'
     doctrine.website.projects_dir: '%doctrine.website.root_dir%/projects'
     doctrine.website.github.http_token: 'abcd'
+    doctrine.website.mysql.password: 'MyDBPassword'

--- a/config/services.xml
+++ b/config/services.xml
@@ -5,7 +5,6 @@
 
     <parameters>
         <parameter key="doctrine.website.mysql.user">root</parameter>
-        <parameter key="doctrine.website.mysql.password"></parameter>
         <parameter key="doctrine.website.mysql.host">localhost</parameter>
         <parameter key="doctrine.website.mysql.version">5.7</parameter>
     </parameters>

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -141,6 +141,7 @@ class Application
         $container->setParameter('doctrine.website.config_dir', realpath(__DIR__ . '/../config'));
         $container->setParameter('doctrine.website.cache_dir', realpath(__DIR__ . '/../cache'));
         $container->setParameter('doctrine.website.github.http_token', getenv('doctrine_website_github_http_token'));
+        $container->setParameter('doctrine.website.mysql.password', getenv('doctrine_website_mysql_password'));
 
         $xmlConfigLoader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../config'));
         $xmlConfigLoader->load('services.xml');


### PR DESCRIPTION
The test environment has a hardcoded password in the configuration and the build file of Github Actions (previously travis-ci). While it's irrelevant for the test env, it displays a bad practice and can be misunderstood without the build context ("But they also have the password in their repository"). This PR is created to lead by example and remove the password from the config file and add a new password into the Github secrets.