### PR TITLE
Install no dev dependencies for website-configs build

### DIFF
--- a/.github/workflows/website-configs.yml
+++ b/.github/workflows/website-configs.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: "Install dependencies"
       if: "steps.composer-cache.outputs.cache-hit != 'true'"
-      run: "composer install --prefer-dist --no-progress --no-suggest"
+      run: "composer install --prefer-dist --no-progress --no-suggest --no-dev"
 
     - name: "Prepare Webite files"
       run: "bin/console --env=test sync-repositories && bin/console --env=test sync && bin/console --env=test clear-build-cache  && bin/console --env=test build-website-data"


### PR DESCRIPTION
`Symfony\Component\ErrorHandler\Debug` is currently breaking the build because of notices. Because this build is supposed to check only website configs regularly, the dev dependencies of composer and therefore `Debug` doesn't need to be installed.