### PR TITLE
Fix website configs build

### DIFF
--- a/.github/workflows/website-configs.yml
+++ b/.github/workflows/website-configs.yml
@@ -3,6 +3,12 @@ name: "website-configs"
 on:
   schedule:
     - cron:  "0 23 * * *"
+  push:
+    paths:
+    - '.github/workflows/website-configs.yml'
+  pull_request:
+    paths:
+    - '.github/workflows/website-configs.yml'
 
 env:
   doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"

--- a/bin/console
+++ b/bin/console
@@ -10,7 +10,7 @@ use Symfony\Component\ErrorHandler\Debug;
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], 'dev');
 
-if (class_exists(Debug::class)) {
+if (class_exists(Debug::class) && $env === 'dev') {
     Debug::enable();
 }
 


### PR DESCRIPTION
This fixes the website-configs build that broke after `Debug::enabled()` was introduced in #346. 

Because doctrine/static-website-generator has a dependency to symfony/http-kernel, that installs symfony/error-handler as a no-dev dependency, the Debug class is always available and enables Debug mode even in prod.

I also adapted .github/workflows/website-configs.yml to start a build when the file itself was changed to make it possible to review this change (and also to ease future changes on this GA file).