### PR TITLE
Update policy on versioning composer.lock

### DIFF
--- a/source/policies.rst
+++ b/source/policies.rst
@@ -5,11 +5,11 @@ Policies
 - `Security Policy </policies/security.html>`_
 - `Release Policy </policies/releases.html>`_
 
-Composer Lock File
-------------------
+Tools and versioning constraints
+--------------------------------
 
-All Doctrine projects must commit the ``composer.lock`` file. Tools like
-`phpstan <https://github.com/phpstan/phpstan>`_ and `phpcs <https://github.com/squizlabs/PHP_CodeSniffer>`_
-are quite fragile on patch releases and we don't want builds to start failing without us having made any changes
-to our own code. Whenever a dependency needs to be upgraded, the ``composer.lock`` file
-should be updated locally and the change submitted via pull request.
+All Doctrine projects should use tight constraints for tools like
+`phpstan <https://github.com/phpstan/phpstan>`_ and `phpcs
+<https://github.com/squizlabs/PHP_CodeSniffer>`_. Those are quite
+fragile on patch releases and we don't want builds to start failing
+without us having made any changes to our own code.


### PR DESCRIPTION
We have decided to amend our policy on composer.lock for the following
reasons:
- Pinning all dependencies prevents us from seeing issues caused by our
  non-dev dependencies.
- The performance gain on composer install is less significant than with
  Composer 1
- Many of our pipeline jobs remove the lock file and perform a composer
  update except when running the mentioned tools.
- The issues caused by tools upgrade can be mitigated by using tighter
  version constraints.

We also considered and rejected `bamarni/composer-bin-plugin`, as well as
using phars.

See the outcome of the vote at https://app.mieuxvoter.fr/result/G7yS4YM8NRprqpKJjlxk