### PR TITLE
Skip zero releases without branch name

### DIFF
--- a/lib/Projects/ProjectVersionsReader.php
+++ b/lib/Projects/ProjectVersionsReader.php
@@ -51,9 +51,9 @@ class ProjectVersionsReader
                 continue;
             }
 
-            // if 0.x release doesn't have an associated branch, assume master
+            // if 0.x release doesn't have an associated branch, skip entry
             if ($tag->isMajorReleaseZero() && $branchName === null) {
-                $branchName = 'master';
+                continue;
             }
 
             $versions[$branchSlug] = [

--- a/tests/Projects/ProjectVersionsReaderTest.php
+++ b/tests/Projects/ProjectVersionsReaderTest.php
@@ -100,7 +100,7 @@ class ProjectVersionsReaderTest extends TestCase
             $repositoryPath
         );
 
-        self::assertCount(4, $versions);
+        self::assertCount(3, $versions);
 
         self::assertCount(2, $versions[0]['tags']);
         self::assertSame('v2.0.0', $versions[0]['tags'][0]->getName());
@@ -112,10 +112,6 @@ class ProjectVersionsReaderTest extends TestCase
         self::assertCount(1, $versions[2]['tags']);
         self::assertSame('0.1.0', $versions[2]['tags'][0]->getName());
         self::assertSame('0.1', $versions[2]['branchName']);
-
-        self::assertCount(1, $versions[3]['tags']);
-        self::assertSame('0.0.1', $versions[3]['tags'][0]->getName());
-        self::assertSame('master', $versions[3]['branchName']);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
```
The command "cd /home/runner/work/doctrine-website/doctrine-website/projects/coding-standard && git clean -xdf && git checkout origin/master" failed.
```

Since the default branch feature of #356 was introduced into the website-build, it can't be assumed anymore that a master branch exists for a target repository. This will also change the behaviour that tags without an existing `0` version branch won't be shown on the website anymore.

Supporting tags without existing branches will be handled in #372.