### PR TITLE
Remove MongoDB abstraction layer

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -33,9 +33,6 @@ parameters:
             repositoryName: common
 
         -
-            repositoryName: mongodb
-
-        -
             repositoryName: orientdb-odm
 
         -


### PR DESCRIPTION
This project is no longer maintained, so it should be removed from the website.