### PR TITLE
Missing headline in some blog posts

### DIFF
--- a/config/routes.yml
+++ b/config/routes.yml
@@ -210,3 +210,5 @@ parameters:
             defaults:
                 menuSlug: blog
                 layout: blog-post
+            requirements:
+                slug: .+


### PR DESCRIPTION
While headlines are shown in the blog post list, in some cases they aren't shown in the blog post itself. @stof found out that this is due to the current `slug` usage in the route. This PR is about covering this missing headline bug.