### PR TITLE
Fix github token for pull request build

### DIFF
--- a/.github/workflows/php7.2.yml
+++ b/.github/workflows/php7.2.yml
@@ -3,7 +3,7 @@ name: "Website build"
 on: ["push", "pull_request"]
 
 env:
-  doctrine_website_github_http_token: "${{ secrets.doctrine_website_github_http_token }}"
+  doctrine_website_github_http_token: "${{ github.token }}"
   PHP_VERSION: "7.2"
   doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"
 

--- a/.github/workflows/website-configs.yml
+++ b/.github/workflows/website-configs.yml
@@ -11,7 +11,7 @@ on:
     - '.github/workflows/website-configs.yml'
 
 env:
-  doctrine_website_github_http_token: "${{ secrets.doctrine_website_github_http_token }}"
+  doctrine_website_github_http_token: "${{ github.token }}"
   doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"
 
 jobs:


### PR DESCRIPTION
The usage of `${{ github.token }}` should allow a working build for pull requests.

https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret 