### PR TITLE
Code Highlighting for blog posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "test": "tests"
     },
     "dependencies": {
+        "@babel/runtime": "^7.12.13",
         "@fortawesome/fontawesome-free": "^5.8.0",
         "@sentry/browser": "^4.6.6",
         "bootstrap": "^4.3.1",
@@ -21,7 +22,9 @@
         "instantsearch.js": "^2.10.4",
         "jquery": "^3.5.0",
         "popper.js": "^1.15.0",
-        "purgecss-webpack-plugin": "^1.5.0"
+        "prismjs": "^1.23.0",
+        "purgecss-webpack-plugin": "^1.5.0",
+        "webpack-merge-and-include-globally": "^2.3.0"
     },
     "engines": {
         "node": ">=6.11.5"

--- a/source/blog.html
+++ b/source/blog.html
@@ -1,5 +1,6 @@
 ---
 permalink: /blog/index.html
+layout: blog-list
 ---
 
 {% for blogPost in blogPosts %}

--- a/templates/layouts/blog-list.html.twig
+++ b/templates/layouts/blog-list.html.twig
@@ -1,0 +1,31 @@
+{% extends 'layouts/layout.html.twig' %}
+
+{% block head_meta %}
+    <link
+            rel="stylesheet"
+            type="text/css"
+            href="{{ get_webpack_asset_url('/css/prismjs.css', site.url) }}"
+            {% if site.env == 'prod' %}
+                integrity="{{ get_webpack_asset_integrity('/css/prismjs.css') }}"
+            {% endif %}
+            crossorigin="anonymous"
+    />
+{% endblock %}
+
+{% block container %}
+    <main role="main" class="container-wrapper container">
+        {% block content_wrapper %}
+            {% block content '' %}
+        {% endblock %}
+    </main>
+{% endblock %}
+
+{% block scripts_after %}
+    <script
+            src="{{ get_webpack_asset_url('/js/prismjs.js', site.url) }}"
+            {% if site.env == 'prod' %}
+                integrity="{{ get_webpack_asset_integrity('/js/prismjs.js') }}"
+            {% endif %}
+            crossorigin="anonymous">
+    </script>
+{% endblock %}

--- a/templates/layouts/blog-post.html.twig
+++ b/templates/layouts/blog-post.html.twig
@@ -34,6 +34,15 @@
         "description": "{{ contentValue|raw|striptags|trim[:100] }}"
     }
     </script>
+    <link
+            rel="stylesheet"
+            type="text/css"
+            href="{{ get_webpack_asset_url('/css/prismjs.css', site.url) }}"
+            {% if site.env == 'prod' %}
+                integrity="{{ get_webpack_asset_integrity('/css/prismjs.css') }}"
+            {% endif %}
+            crossorigin="anonymous"
+    />
 {% endblock %}
 
 {% block content_wrapper %}
@@ -66,4 +75,14 @@
             {{ contentValue }}
         </div>
     </article>
+{% endblock %}
+
+{% block scripts_after %}
+    <script
+            src="{{ get_webpack_asset_url('/js/prismjs.js', site.url) }}"
+            {% if site.env == 'prod' %}
+                integrity="{{ get_webpack_asset_integrity('/js/prismjs.js') }}"
+            {% endif %}
+            crossorigin="anonymous">
+    </script>
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const path = require('path'),
     isWatching = process.env.WEBPACK_WATCH === '1',
     webpack = require('webpack'),
     MiniCssExtractPlugin = require('mini-css-extract-plugin'),
+    MergeIntoSingleFilePlugin = require('webpack-merge-and-include-globally'),
     PurgecssPlugin = require('purgecss-webpack-plugin');
 
 const plugins = () => {
@@ -17,6 +18,26 @@ const plugins = () => {
             'window.$': 'jquery',
             jQuery: 'jquery',
             'window.jQuery': 'jquery',
+        }),
+        new MergeIntoSingleFilePlugin({
+            files: {
+                "js/prismjs.js": [
+                    'node_modules/prismjs/components/prism-core.min.js',
+                    'node_modules/prismjs/components/prism-markup.min.js',
+                    'node_modules/prismjs/components/prism-markup-templating.min.js',
+                    'node_modules/prismjs/components/prism-php.min.js',
+                    'node_modules/prismjs/components/prism-php-extras.min.js',
+                    'node_modules/prismjs/components/prism-phpdoc.min.js',
+                    'node_modules/prismjs/components/prism-sql.min.js',
+                    'node_modules/prismjs/components/prism-bash.min.js',
+                    'node_modules/prismjs/components/prism-clike.min.js',
+                    'node_modules/prismjs/components/prism-git.min.js',
+                    'node_modules/prismjs/components/prism-json.min.js',
+                ],
+                "css/prismjs.css": [
+                    'node_modules/prismjs/themes/prism-twilight.css',
+                ]
+            }
         })
     ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
+  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@fortawesome/fontawesome-free@^5.8.0":
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
@@ -787,6 +794,15 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+clipboard@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
+  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -1072,6 +1088,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -1192,6 +1213,11 @@ es6-promise@^4.1.0:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.1.1.tgz#46837651b7b06bf6fff893d03f29393668d01621"
+  integrity sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1542,7 +1568,7 @@ glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -1606,6 +1632,13 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.10"
     minimatch "~3.0.2"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.4"
@@ -2919,6 +2952,13 @@ pretty-format@^3.5.1:
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
   integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
+prismjs@^1.23.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
+  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -3138,6 +3178,11 @@ reduce@^1.0.1:
   dependencies:
     object-keys "^1.1.0"
 
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -3241,6 +3286,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+rev-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rev-hash/-/rev-hash-3.0.0.tgz#951d73d02b9606ea4bbb7ee3d93c252cd8556ce5"
+  integrity sha512-s+87HfEKAu95TaTxnbCobn0/BkbzR23LHSwVdYvr8mn5+PPjzy+hTWyh92b5oaLgig9TKPe5d6ZcubsVBtUrZg==
+
 rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -3322,6 +3372,11 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
@@ -3732,6 +3787,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
@@ -3973,6 +4033,15 @@ webpack-cli@^3.1.2:
     supports-color "^6.1.0"
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
+
+webpack-merge-and-include-globally@^2.3.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/webpack-merge-and-include-globally/-/webpack-merge-and-include-globally-2.3.3.tgz#d91307a6f9a429c3e3d219af85307ceecb05ae62"
+  integrity sha512-se3dHRVJn5N9CvUD5lOYQ3RThCGHrMLmjR35u/IwArcgZNi68lP/osAx9/zfIAWeSA5UMHvbyPo3Be+PCNQhqw==
+  dependencies:
+    es6-promisify "^6.1.1"
+    glob "^7.1.6"
+    rev-hash "^3.0.0"
 
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
This PR will introduce syntax highlighting for code examples in blog posts. It introduces prismjs, which is compatible to the generated CSS of erusev/parsedown.

This PR is a successor to #385 and makes it possible to use the GitHub code syntax. Together with the changes of #385 the blog post will have syntax highlighting. The other blog posts need separate PRs. 