### PR TITLE
Fix code highlighting for blog posts from 2015 to today

### DIFF
--- a/source/blog/2015-01-12-dbal-244-251.md
+++ b/source/blog/2015-01-12-dbal-244-251.md
@@ -43,21 +43,21 @@ You can find all the changes on JIRA:
 You can install the DBAL using Composer and the following
 `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/dbal": "2.4.4"
     }
 }
-~~~~
+```
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/dbal": "2.5.1"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-01-15-cache-1-4-0.md
+++ b/source/blog/2015-01-15-cache-1-4-0.md
@@ -39,13 +39,13 @@ notes](https://github.com/doctrine/cache/releases/tag/v1.4.0).
 You can install the Cache component using Composer and the following
 `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/cache": "1.4.0"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-01-25-orm-2-5-0-alpha-2.md
+++ b/source/blog/2015-01-25-orm-2-5-0-alpha-2.md
@@ -51,14 +51,14 @@ Installation
 You can install this version of the ORM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/orm": "2.5.0-alpha2"
     },
     "minimum-stability": "dev"
 }
-~~~~
+```
 
 Changes since 2.5.0-alpha1
 ==========================

--- a/source/blog/2015-03-18-orm-2-5-0-beta-1.md
+++ b/source/blog/2015-03-18-orm-2-5-0-beta-1.md
@@ -48,14 +48,14 @@ Installation
 You can install this version of the ORM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/orm": "2.5.0-beta1"
     },
     "minimum-stability": "dev"
 }
-~~~~
+```
 
 Changes since 2.5.0-alpha2
 ==========================

--- a/source/blog/2015-03-25-common-2-5-0-beta-1.md
+++ b/source/blog/2015-03-25-common-2-5-0-beta-1.md
@@ -34,14 +34,14 @@ our team.
 You can install this version of the Common package by using Composer and
 the following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/common": "2.5.0-beta2"
     },
     "minimum-stability": "dev"
 }
-~~~~
+```
 
 Changes since 2.4.x
 ===================

--- a/source/blog/2015-03-25-orm-2-5-0-rc-1.md
+++ b/source/blog/2015-03-25-orm-2-5-0-rc-1.md
@@ -44,14 +44,14 @@ Installation
 You can install this version of the ORM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/orm": "2.5.0-RC1"
     },
     "minimum-stability": "dev"
 }
-~~~~
+```
 
 Changes since 2.5.0-beta1
 =========================

--- a/source/blog/2015-03-31-doctrine-mongo-odm-module-release-0-8-2.md
+++ b/source/blog/2015-03-31-doctrine-mongo-odm-module-release-0-8-2.md
@@ -25,10 +25,10 @@ Following issues were solved in this release:
 
 To install this version, simply update your \`composer.json\`:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/doctrine-mongo-odm-module": "0.8.2"
     }
 }
-~~~~
+```

--- a/source/blog/2015-03-31-orm-2-5-0-rc-2.md
+++ b/source/blog/2015-03-31-orm-2-5-0-rc-2.md
@@ -41,14 +41,14 @@ Installation
 You can install this version of the ORM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/orm": "2.5.0-RC2"
     },
     "minimum-stability": "dev"
 }
-~~~~
+```
 
 Changes since 2.5.0-RC1
 =======================

--- a/source/blog/2015-04-01-indoctrinator-0-0-1-alpha-1.md
+++ b/source/blog/2015-04-01-indoctrinator-0-0-1-alpha-1.md
@@ -32,11 +32,11 @@ How does Indoctrinator work?
 Indoctrinator is currently only working with `doctrine/orm` version
 `2.5.x-dev`, but the general working concept is as following:
 
-~~~~ {.sourceCode .json}
+```php
 $indoctrinator = new Doctrine\Indoctrinator();
 
 $indoctrinator->registerWithManager(new Doctrine\Indoctrinator\ManagerWrapper($entityManager));
-~~~~
+```
 
 Without going into much details, Indoctrinator hooks into common APIs
 used in ORM internals, and by using AOP (Aspect Oriented Programming),

--- a/source/blog/2015-04-02-common-2-5-0.md
+++ b/source/blog/2015-04-02-common-2-5-0.md
@@ -14,13 +14,13 @@ Installation
 You can install this version of Doctrine Common by using Composer and
 the following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/common": "2.5.0"
     }
 }
-~~~~
+```
 
 Changes since 2.4.x
 ===================

--- a/source/blog/2015-04-02-orm-2-5-0.md
+++ b/source/blog/2015-04-02-orm-2-5-0.md
@@ -61,13 +61,13 @@ Installation
 You can install this version of the ORM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/orm": "~2.5.0"
     }
 }
-~~~~
+```
 
 Changes since 2.4.0
 ===================

--- a/source/blog/2015-04-14-annotations-1-2-4.md
+++ b/source/blog/2015-04-14-annotations-1-2-4.md
@@ -18,13 +18,13 @@ Installation
 You can install this version of Doctrine Annotations by using Composer
 and the following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/annotations": "1.2.4"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira/browse/DCOM).

--- a/source/blog/2015-04-14-collections-1-3-0.md
+++ b/source/blog/2015-04-14-collections-1-3-0.md
@@ -14,13 +14,13 @@ Installation
 You can install this version of Doctrine Common by using Composer and
 the following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/collections": "1.3.0"
     }
 }
-~~~~
+```
 
 Changes since 1.3.0
 ===================

--- a/source/blog/2015-04-15-cache-1-4-1.md
+++ b/source/blog/2015-04-15-cache-1-4-1.md
@@ -34,13 +34,13 @@ notes](https://github.com/doctrine/cache/releases/tag/v1.4.1).
 You can install the Cache component using Composer and the following
 `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/cache": "1.4.1"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-04-16-doctrine-module-release-0-8-1.md
+++ b/source/blog/2015-04-16-doctrine-module-release-0-8-1.md
@@ -57,10 +57,10 @@ Following issues were solved in this release:
 
 To install this version, simply update your \`composer.json\`:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/doctrine-module": "0.8.1"
     }
 }
-~~~~
+```

--- a/source/blog/2015-05-05-doctrine-orm-module-release-0-9-0.md
+++ b/source/blog/2015-05-05-doctrine-orm-module-release-0-9-0.md
@@ -87,10 +87,10 @@ The Following issues were solved in this release:
 
 To install this version, simply update your `composer.json`:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/doctrine-orm-module": "0.9.0"
     }
 }
-~~~~
+```

--- a/source/blog/2015-08-31-security_misconfiguration_vulnerability_in_various_doctrine_projects.md
+++ b/source/blog/2015-08-31-security_misconfiguration_vulnerability_in_various_doctrine_projects.md
@@ -137,7 +137,7 @@ from the webserver, php-fpm or the shell. In this case you can always
 create directories with the default permissions of `0775` and files with
 `0664`:
 
-~~~~ {.sourceCode .php}
+```php
 <?php
 // safety measure to overrule webserver or shell misconfiguration
 umask(umask() | 0002);
@@ -145,7 +145,7 @@ umask(umask() | 0002);
 mkdir("/some/directory", 0775);
 file_put_contents("/some/directory/file", "data");
 chmod("/some/directory/file", 0664);
-~~~~
+```
 
 On most linux distributions it is possible to execute cronjobs or
 supervisord jobs with the `www-data`, `nginx` or `apache` users that the

--- a/source/blog/2015-09-16-doctrine_dbal_2_5_2_released.md
+++ b/source/blog/2015-09-16-doctrine_dbal_2_5_2_released.md
@@ -20,13 +20,13 @@ You can find all the changes on JIRA:
 You can install the DBAL using Composer and the following
 `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/dbal": "2.5.2"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-10-28-cache-1-4-3_and-1-5-0.md
+++ b/source/blog/2015-10-28-cache-1-4-3_and-1-5-0.md
@@ -66,21 +66,21 @@ Installation
 You can install the Cache component using Composer either of the
 following `composer.json` definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/cache": "~1.4.1"
     }
 }
-~~~~
+```
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/cache": "~1.5.0"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-11-02-cache-1-4-4_and-1-5-1.md
+++ b/source/blog/2015-11-02-cache-1-4-4_and-1-5-1.md
@@ -38,21 +38,21 @@ Installation
 You can install the Cache component using Composer either of the
 following `composer.json` definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/cache": "~1.4.4"
     }
 }
-~~~~
+```
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/cache": "~1.5.1"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-11-06-doctrine-inflector-1-1-0.md
+++ b/source/blog/2015-11-06-doctrine-inflector-1-1-0.md
@@ -33,10 +33,10 @@ Installation
 You can install the Inflector component via the following`composer.json`
 definition:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/inflector": "~1.1.0"
     }
 }
-~~~~
+```

--- a/source/blog/2015-11-23-orm-2-5-2.md
+++ b/source/blog/2015-11-23-orm-2-5-2.md
@@ -14,13 +14,13 @@ Installation
 You can install this version of the ORM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/orm": "~2.5.2"
     }
 }
-~~~~
+```
 
 Changes since 2.5.1
 ===================

--- a/source/blog/2015-12-02-doctrine-module-0-10-0.md
+++ b/source/blog/2015-12-02-doctrine-module-0-10-0.md
@@ -13,13 +13,13 @@ Installation
 You can install this version of the DoctrineModule by using Composer and
 the:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/doctrine-module": "~0.10.0"
     }
 }
-~~~~
+```
 
 Changes since 0.9.0
 ===================

--- a/source/blog/2015-12-03-cache-1-5-2.md
+++ b/source/blog/2015-12-03-cache-1-5-2.md
@@ -17,13 +17,13 @@ Fetching `false` values from the cache via
 `` fetchMultiple` was causing incorrect misses (`#105 <https://github.com/doctrine/cache/pull/105>`_).  Cache paths were exceeding the windows ``MAX\_PATH`` length (`#107 <https://github.com/doctrine/cache/pull/107>`_).  The ``MongoDBCache`` was not failing silently in case of DB-side exceptions (`#108 <https://github.com/doctrine/cache/pull/108>`_).  You can find the complete changelog for this release in the `v1.5.2 release notes <https://github.com/doctrine/cache/releases/tag/v1.5.2>`_.  Installation ~~~~~~~~~~~~  You can install the Cache component using the following ``composer.json\`\`
 definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/cache": "~1.5.2"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-12-04-common-2-5-2-and-2-6-0.md
+++ b/source/blog/2015-12-04-common-2-5-2-and-2-6-0.md
@@ -58,21 +58,21 @@ Installation
 You can install the Common component using Composer and one of the
 following `composer.json` definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/common": "~2.5.2"
     }
 }
-~~~~
+```
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/common": "~2.6.01"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2015-12-15-doctrine-mongodb-odm-release-1.0.4.md
+++ b/source/blog/2015-12-15-doctrine-mongodb-odm-release-1.0.4.md
@@ -24,13 +24,13 @@ Installation
 You can install the latest version using the following `composer.json`
 definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.0.4"
     }
 }
-~~~~
+```
 
 Doctrine MongoDB ODM 1.1 requires PHP 5.5+
 ==========================================
@@ -39,13 +39,13 @@ The current `master` branch saw its PHP requirement bumped to 5.5
 recently. If you are still using the master version in your project you
 should switch to a stable release as soon as possible:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.0"
     }
 }
-~~~~
+```
 
 This will ensure you are using stable versions and will use 1.1 as soon
 as it's released.

--- a/source/blog/2015-12-25-common-2-5-3-and-2-6-1.md
+++ b/source/blog/2015-12-25-common-2-5-3-and-2-6-1.md
@@ -27,21 +27,21 @@ Installation
 You can install the Common component using Composer and one of the
 following `composer.json` definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/common": "~2.5.3"
     }
 }
-~~~~
+```
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/common": "~2.6.1"
     }
 }
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/common/issues).

--- a/source/blog/2015-12-25-dbal-2-5-3.md
+++ b/source/blog/2015-12-25-dbal-2-5-3.md
@@ -24,9 +24,9 @@ Installation
 
 You can install the DBAL component using Composer:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/dbal:~2.5.3
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/dbal/issues).

--- a/source/blog/2015-12-25-orm-2-5-3.md
+++ b/source/blog/2015-12-25-orm-2-5-3.md
@@ -30,9 +30,9 @@ Installation
 
 You can install the ORM component using Composer:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/orm:~2.5.3
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/orm/issues).

--- a/source/blog/2015-12-31-cache-1-6-0.md
+++ b/source/blog/2015-12-31-cache-1-6-0.md
@@ -43,9 +43,9 @@ Installation
 You can install the Cache component using the following `composer.json`
 definitions:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/cache:^1.6
-~~~~
+```
 
 Please report any issues you may have with the update on the mailing
 list or on [Jira](https://www.doctrine-project.org/jira).

--- a/source/blog/2016-01-05-dbal-2-5-4-and-2-4-5.md
+++ b/source/blog/2016-01-05-dbal-2-5-4-and-2-4-5.md
@@ -54,9 +54,9 @@ Installation
 
 You can install the DBAL component using Composer:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/dbal:~2.5.4
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/dbal/issues).

--- a/source/blog/2016-01-05-orm-2-5-4.md
+++ b/source/blog/2016-01-05-orm-2-5-4.md
@@ -17,9 +17,9 @@ Installation
 
 You can install the ORM component using Composer:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/orm:~2.5.4
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/orm/issues).

--- a/source/blog/2016-02-02-doctrine_module_1_0_0_stable_release.md
+++ b/source/blog/2016-02-02-doctrine_module_1_0_0_stable_release.md
@@ -18,13 +18,13 @@ Thanks at all for yours contributions!
 Update your composer configuration to use the stable version of this
 project.
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/doctrine-module": "~1.0"
     }
 }
-~~~~
+```
 
 Changes since 0.10.0
 ====================

--- a/source/blog/2016-02-16-doctrine-mongodb-odm-release-1.0.5.md
+++ b/source/blog/2016-02-16-doctrine-mongodb-odm-release-1.0.5.md
@@ -24,13 +24,13 @@ Installation
 You can install the latest version using the following `composer.json`
 definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.0.5"
     }
 }
-~~~~
+```
 
 Doctrine MongoDB ODM and PHP 7
 ==============================

--- a/source/blog/2016-06-09-odm-1-1-0-and-1-0-6.md
+++ b/source/blog/2016-06-09-odm-1-1-0-and-1-0-6.md
@@ -30,14 +30,14 @@ provides the legacy driver API on top of the new driver. To do so, in
 your PHP 7 project, add the following Composer directives in addition to
 the MongoDB ODM requirement:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "alcaeus/mongo-php-adapter": "^1.0",
         "ext-mongo": "*"
     }
 }
-~~~~
+```
 
 Upgrading to 1.1.0
 ==================
@@ -67,13 +67,13 @@ Installation
 You can install this version of MongoDB ODM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.1.0"
     }
 }
-~~~~
+```
 
 MongoDB ODM 1.0.6
 =================

--- a/source/blog/2016-06-19-data-fixtures-1-2-0.md
+++ b/source/blog/2016-06-19-data-fixtures-1-2-0.md
@@ -32,9 +32,9 @@ Installation
 
 You can install the ORM component using Composer:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/data-fixtures:^1.2.0
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/data-fixtures/issues).

--- a/source/blog/2016-07-27-doctrine-mongodb-odm-release-1.1.1.md
+++ b/source/blog/2016-07-27-doctrine-mongodb-odm-release-1.1.1.md
@@ -25,13 +25,13 @@ Installation
 You can install the latest version using the following `composer.json`
 definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.1.1"
     }
 }
-~~~~
+```
 
 Future Releases
 ===============
@@ -61,10 +61,10 @@ milestone](https://github.com/doctrine/mongodb-odm/issues?q=milestone%3A1.0.7).
 You can install the latest version using the following `composer.json`
 definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.0.7"
     }
 }
-~~~~
+```

--- a/source/blog/2016-09-09-dbal-2-5-5.md
+++ b/source/blog/2016-09-09-dbal-2-5-5.md
@@ -58,9 +58,9 @@ Installation
 
 You can install the DBAL component using Composer:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/dbal:^2.5.5
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/dbal/issues).

--- a/source/blog/2016-09-10-orm-2-5-5.md
+++ b/source/blog/2016-09-10-orm-2-5-5.md
@@ -39,9 +39,9 @@ Installation
 
 You can install the ORM component using Composer:
 
-~~~~ {.sourceCode .shell}
+```bash
 composer require doctrine/orm:^2.5.5
-~~~~
+```
 
 Please report any issues you may have with the update on the [issue
 tracker](https://github.com/doctrine/orm/issues).

--- a/source/blog/2016-10-07-doctrine-mongodb-odm-release-1.1.2-and-1.0.8.md
+++ b/source/blog/2016-10-07-doctrine-mongodb-odm-release-1.1.2-and-1.0.8.md
@@ -38,13 +38,13 @@ Installation
 You can install the latest version using the following `composer.json`
 definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.1.2"
     }
 }
-~~~~
+```
 
 Support for Doctrine ODM 1.0.x
 ==============================

--- a/source/blog/2016-11-22-doctrine-mongodb-release-1.4.0.md
+++ b/source/blog/2016-11-22-doctrine-mongodb-release-1.4.0.md
@@ -17,14 +17,14 @@ class, which will then be passed on to the MongoDB driver. For example,
 to pass a stream context with SSL context options, you could use the
 following code snippet:
 
-~~~~ {.sourceCode .php}
+```php
 $context = stream_context_create([
     'ssl' => [
         'allow_self_signed' => false,
     ]
 ]);
 $connection = new \Doctrine\MongoDB\Connection(null, [], null, null, ['context' => $context]);
-~~~~
+```
 
 Passing multiple expressions to logical operators
 =================================================
@@ -33,7 +33,7 @@ The `addAnd`, `addNor` and `addOr` methods in the query and aggregation
 builders now take multiple expression objects. Instead of having to call
 the method repeatedly, you may call it once with multiple arguments:
 
-~~~~ {.sourceCode .php}
+```php
 // Before
 $builder
     ->addAnd($someExpression)
@@ -41,7 +41,7 @@ $builder
 
 // After
 $builder->addAnd($someExpression, $otherExpression);
-~~~~
+```
 
 Deprecations
 ============
@@ -86,10 +86,10 @@ Installation
 You can install the latest version using the following `composer.json`
 definitions:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb": "^1.4.0"
     }
 }
-~~~~
+```

--- a/source/blog/2017-07-25-php-7.1-requirement-and-composer.md
+++ b/source/blog/2017-07-25-php-7.1-requirement-and-composer.md
@@ -26,13 +26,13 @@ Composer version constraints
 Chances are your version constraints in `composer.json` look something
 like this:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/orm": "^2.5"
     }
 }
-~~~~
+```
 
 The `^2.5` constraint resolves to: `>= 2.5.0 && <= 2.999999.999999`.
 This is intended: our projects all follow [Semantic

--- a/source/blog/2017-10-24-odm-1-2-0-and-1-1-7.md
+++ b/source/blog/2017-10-24-odm-1-2-0-and-1-1-7.md
@@ -63,13 +63,13 @@ Installation
 You can install the new version of MongoDB ODM by using Composer and the
 following `composer.json` contents:
 
-~~~~ {.sourceCode .json}
+```json
 {
     "require": {
         "doctrine/mongodb-odm": "^1.2.0"
     }
 }
-~~~~
+```
 
 Stability and upcoming releases
 ===============================


### PR DESCRIPTION
I'm creating multiple PRs to adapt the markdown of the blog posts for the use of prismjs. This is the first one.