### PR TITLE
Add option for search-index for build-all

### DIFF
--- a/lib/Commands/BuildAllCommand.php
+++ b/lib/Commands/BuildAllCommand.php
@@ -62,12 +62,21 @@ class BuildAllCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Clear the build cache before building everything.'
+            )
+            ->addOption(
+                'search',
+                null,
+                InputOption::VALUE_NONE,
+                'Build the search indexes.'
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $buildDocsArgs = $this->env === 'prod' ? ['--search' => null] : [];
+        $buildSearchIndexes = $input->getOption('search');
+        assert(is_bool($buildSearchIndexes));
+
+        $buildDocsArgs = $buildSearchIndexes ? ['--search' => null] : [];
         $commands      = [
             'sync-repositories' => [],
             'build-website-data' => [],


### PR DESCRIPTION
The current state of our Algolia db doesn't allow too much search-index builds. As a first step the search-index build in the build-all command becomes optional.