### PR TITLE
Update 2021-03-29-dbal-2.13.md

### DIFF
--- a/source/blog/2021-03-29-dbal-2.13.md
+++ b/source/blog/2021-03-29-dbal-2.13.md
@@ -38,7 +38,7 @@ New Code:
 ```php
 $statement = $connection->prepare('SELECT * FROM tbl WHERE col = ?');
 $statement->bindParam(1, $value);
-$result = $statement->execute();
+$result = $statement->executeQuery();
 
 while (($row = $result->fetchAssociative()) !== false) {
 }


### PR DESCRIPTION
Under "New Code" it says:
$result = $statement->execute();

but Statement::execute() is deprecated (and returns boolean).

So it should say:
$result = $statement->executeQuery();