### PR TITLE
Code highlighting for Attributes and Annotations

### DIFF
--- a/lib/Commands/BuildWebsiteCommand.php
+++ b/lib/Commands/BuildWebsiteCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Website\Commands;
 
 use Doctrine\Website\WebsiteBuilder;
+use Highlight\Highlighter;
 use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -88,6 +89,7 @@ class BuildWebsiteCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         ini_set('memory_limit', '2048M');
+        $this->registerHighlighter();
 
         $publish = $input->getOption('publish');
         assert(is_bool($publish));
@@ -164,5 +166,12 @@ class BuildWebsiteCommand extends Command
             ->mustRun(static function ($type, $buffer) use ($output): void {
                 $output->write($buffer);
             });
+    }
+
+    private function registerHighlighter(): void
+    {
+        $phpHighlightPath = sprintf('%s/vendor/scrivo/highlight.php/Highlight/languages/php.json', $this->rootDir);
+        Highlighter::registerLanguage('annotation', $phpHighlightPath);
+        Highlighter::registerLanguage('attribute', $phpHighlightPath);
     }
 }


### PR DESCRIPTION
I created this PR to make it possible to show PHP Attributes and Annotations code examples with an appropriate tab name in a configuration-block. It's basically the PHP code highlighting, so that the following RST

``` rst
.. configuration-block::

    .. code-block:: annotation

        <?php

        /** @Entity */
        class Message
        {
            // ...
        }

    .. code-block:: attribute

        <?php

        #[Entity()]
        class Message
        {
            // ...
        }

    .. code-block:: xml

        <doctrine-mapping>
            <entity name="Message">
                <!-- ... -->
            </entity>
        </doctrine-mapping>
```

would result in

![code highlighting](https://user-images.githubusercontent.com/859964/127235472-e0693bfb-84cf-4656-ac8f-affb50d4d9ad.png)