### PR TITLE
Introduce GitHub Actions deployment (Stage)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,65 @@
+name: "deployment"
+
+on:
+  push:
+    branches:
+      - "staging"
+
+env:
+  doctrine_website_github_http_token: "${{ github.token }}"
+  doctrine_website_mysql_password: "${{ secrets.doctrine_website_mysql_password }}"
+
+jobs:
+  build:
+
+    runs-on: "ubuntu-18.04"
+
+    services:
+      mysql:
+        image: "mysql:5.7"
+        env:
+          MYSQL_DATABASE: "doctrine_website_test"
+          MYSQL_ROOT_PASSWORD: "${{ secrets.doctrine_website_mysql_password }}"
+        ports:
+          - "3306:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+    - uses: "actions/checkout@v2"
+
+    - name: "Cache Composer packages"
+      id: "composer-cache"
+      uses: "actions/cache@v2"
+      with:
+        path: "vendor"
+        key: "${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}"
+        restore-keys: |
+          ${{ runner.os }}-php-
+    - name: "Setup PHP Action"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: "7.2"
+
+    - name: "Install dependencies"
+      if: "steps.composer-cache.outputs.cache-hit != 'true'"
+      run: "composer install --no-progress --no-suggest --no-dev"
+
+    - name: "apt-get install yarn"
+      run: "sudo apt-get update && sudo apt-get install -y yarn"
+
+    - name: "yarn install"
+      run: "yarn install"
+
+    - name: "Prepare Website files"
+      run: "bin/console --env=staging build-all"
+
+    - name: "Deploy to staging"
+      uses: "cpina/github-action-push-to-another-repository@v1.3"
+      env:
+        API_TOKEN_GITHUB: "${{ secrets.doctrine_website_deployment_token }}"
+      with:
+        source-directory: "build-staging"
+        destination-github-username: "doctrine"
+        destination-repository-name: "doctrine-website-build-staging"
+        target-branch: "master"
+        commit-message: "New version of Doctrine website"

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -137,7 +137,7 @@ class Application
     {
         $container = new ContainerBuilder();
         $container->setParameter('doctrine.website.env', $env);
-        $container->setParameter('doctrine.website.debug', $env !== 'prod');
+        $container->setParameter('doctrine.website.debug', $env !== Deployer::ENV_PROD);
         $container->setParameter('doctrine.website.root_dir', realpath(__DIR__ . '/..'));
         $container->setParameter('doctrine.website.config_dir', realpath(__DIR__ . '/../config'));
         $container->setParameter('doctrine.website.cache_dir', realpath(__DIR__ . '/../cache'));

--- a/lib/Deployer.php
+++ b/lib/Deployer.php
@@ -62,7 +62,7 @@ class Deployer
 
         $this->startDeploy($output);
 
-        $deployRef = $this->env === 'prod' ? 'master' : $deploy;
+        $deployRef = $this->env === self::ENV_PROD ? 'master' : $deploy;
 
         $output->writeln(sprintf('Deploying website for <info>%s</info> environment.', $this->env));
 

--- a/lib/Hydrators/EventHydrator.php
+++ b/lib/Hydrators/EventHydrator.php
@@ -6,6 +6,7 @@ namespace Doctrine\Website\Hydrators;
 
 use DateTimeImmutable;
 use Doctrine\SkeletonMapper\ObjectManagerInterface;
+use Doctrine\Website\Deployer;
 use Doctrine\Website\Model\Address;
 use Doctrine\Website\Model\DateTimeRange;
 use Doctrine\Website\Model\Entity\EventParticipantRepository;
@@ -44,10 +45,10 @@ use function sprintf;
 final class EventHydrator extends ModelHydrator
 {
     private const ENV_SKU_MAP = [
-        'dev'     => 'test',
-        'prod'    => 'prod',
-        'staging' => 'test',
-        'test'    => 'test',
+        'dev'                 => 'test',
+        Deployer::ENV_PROD    => Deployer::ENV_PROD,
+        Deployer::ENV_STAGING => 'test',
+        'test'                => 'test',
     ];
 
     /** @var EventParticipantRepository */

--- a/lib/WebsiteBuilder.php
+++ b/lib/WebsiteBuilder.php
@@ -26,14 +26,14 @@ use function unlink;
 
 class WebsiteBuilder
 {
-    public const PUBLISHABLE_ENVS = ['prod', 'staging'];
+    public const PUBLISHABLE_ENVS = [Deployer::ENV_PROD, Deployer::ENV_STAGING];
 
     private const URL_PRODUCTION = 'www.doctrine-project.org';
     private const URL_STAGING    = 'staging.doctrine-project.org';
 
     private const PUBLISHABLE_ENV_URLS = [
-        'prod' => self::URL_PRODUCTION,
-        'staging' => self::URL_STAGING,
+        Deployer::ENV_PROD    => self::URL_PRODUCTION,
+        Deployer::ENV_STAGING => self::URL_STAGING,
     ];
 
     /** @var ProcessFactory */


### PR DESCRIPTION
This PR handles issue #388.

With this workflow we re-introduce the [staging](https://staging.doctrine-project.org) environment of the Doctrine website and the first step to move the deployment away from the current build-server.

The reappearance of staging doesn't come with a change for the PR and merge workflow, so it's just used as a preview for the website.

After this PR, I will take on the deployment for the prod system where a few more steps will be added.