### PR TITLE
Added driehle and updated maintained project names

### DIFF
--- a/data/team_members.yml
+++ b/data/team_members.yml
@@ -29,6 +29,13 @@ parameters:
             website: 'https://www.dzh-online.de/'
             location: 'Hamburg, Germany'
             maintains: ["dbal", "coding-standard"]
+        driehle:
+            name: 'Dennis Riehle'
+            github: driehle
+            avatarUrl: 'https://avatars.githubusercontent.com/u/1586788?v=4'
+            website: ~
+            location: 'Germany'
+            maintains: ["DoctrineModule", "DoctrineORMModule", "DoctrineMongoODMModule", "doctrine-laminas-hydrator"]
         greg0ire:
             name: 'Grégoire Paris'
             twitter: greg0ire
@@ -126,9 +133,9 @@ parameters:
             avatarUrl: 'https://avatars1.githubusercontent.com/u/493920?v=4'
             website: 'https://tomhanderson.com/'
             location: 'Salt Lake City, Utah'
-            maintains: ["doctrine-module", "doctrine-orm-module", "doctrine-mongo-odm-module", "doctrine-laminas-hydrator"]
+            maintains: ["DoctrineModule", "DoctrineORMModule", "DoctrineMongoODMModule", "doctrine-laminas-hydrator"]
             bio: > 
-                Tom is an intellectual architect software engineer.  Proud to contribute to open source and to work
+                Tom is an intellectual architect software engineer. Proud to contribute to open source and to work
                 along side such a talented group of programmers.
         dbu:
             name: 'David Buchmann'


### PR DESCRIPTION
This PR adds me to the list of maintainers and updates the list of projects maintained by Tom, as discussed on Slack, since it looks like the GitHub URL slugs are expected in `team_members.yml`, not the documentation slugs.