### PR TITLE
Add all four Laminas integrations to website

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -103,8 +103,27 @@ parameters:
             integrationType: symfony
 
         -
+            repositoryName: DoctrineModule
+            slug: doctrine-module
+            integration: true
+            integrationType: laminas
+
+        -
             repositoryName: DoctrineORMModule
             slug: doctrine-orm-module
             integration: true
             integrationFor: orm
+            integrationType: laminas
+
+        -
+            repositoryName: DoctrineMongoODMModule
+            slug: doctrine-mongo-odm-module
+            integration: true
+            integrationFor: mongodb-odm
+            integrationType: laminas
+
+        -
+            repositoryName: doctrine-laminas-hydrator
+            slug: doctrine-laminas-hydrator
+            integration: true
             integrationType: laminas

--- a/data/team_members.yml
+++ b/data/team_members.yml
@@ -35,7 +35,7 @@ parameters:
             avatarUrl: 'https://avatars.githubusercontent.com/u/1586788?v=4'
             website: ~
             location: 'Germany'
-            maintains: ["DoctrineModule", "DoctrineORMModule", "DoctrineMongoODMModule", "doctrine-laminas-hydrator"]
+            maintains: ["doctrine-module", "doctrine-orm-module", "doctrine-mongo-odm-module", "doctrine-laminas-hydrator"]
         greg0ire:
             name: 'Grégoire Paris'
             twitter: greg0ire
@@ -133,7 +133,7 @@ parameters:
             avatarUrl: 'https://avatars1.githubusercontent.com/u/493920?v=4'
             website: 'https://tomhanderson.com/'
             location: 'Salt Lake City, Utah'
-            maintains: ["DoctrineModule", "DoctrineORMModule", "DoctrineMongoODMModule", "doctrine-laminas-hydrator"]
+            maintains: ["doctrine-module", "doctrine-orm-module", "doctrine-mongo-odm-module", "doctrine-laminas-hydrator"]
             bio: > 
                 Tom is an intellectual architect software engineer. Proud to contribute to open source and to work
                 along side such a talented group of programmers.


### PR DESCRIPTION
This PR adds, besides DoctrineORMModule, the DoctrineModule, DoctrineMongoODMModule and doctrine-laminas-hydrator projects to the Doctrine website.

All Laminas projects now use their package names, i.e. lowercase and hyphens, as slugs to integrate nicely with the other Doctrine projects. The docs have been converted to RST for all projects. The respective `.doctrine-project.json` files of all projects have been updated accordingly. Last step is updating the `.doctrine-project.json` of `DoctrineORMModule`, which is this PR:

- https://github.com/doctrine/DoctrineORMModule/pull/674

We need to merge [#674](https://github.com/doctrine/DoctrineORMModule/pull/674) first before merging this PR. Then, wenn it is merged, we should merge this PR quickly, as otherwise the build of Doctrine website will fail. This is because the slugs need to be in sync on both ends.

I have built the website locally already (with PHP 7.3 though) and did not experience any issues so far.

cc @SenseException @greg0ire 
