### PR TITLE
Fix of highlighting for docs files

### DIFF
--- a/lib/Commands/BuildWebsiteCommand.php
+++ b/lib/Commands/BuildWebsiteCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Website\Commands;
 
 use Doctrine\Website\WebsiteBuilder;
-use Highlight\Highlighter;
 use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -82,7 +81,6 @@ class BuildWebsiteCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         ini_set('memory_limit', '2048M');
-        $this->registerHighlighter();
 
         $buildDir = $input->getArgument('build-dir');
         assert(is_string($buildDir));
@@ -152,12 +150,5 @@ class BuildWebsiteCommand extends Command
             ->mustRun(static function ($type, $buffer) use ($output): void {
                 $output->write($buffer);
             });
-    }
-
-    private function registerHighlighter(): void
-    {
-        $phpHighlightPath = sprintf('%s/vendor/scrivo/highlight.php/Highlight/languages/php.json', $this->rootDir);
-        Highlighter::registerLanguage('annotation', $phpHighlightPath);
-        Highlighter::registerLanguage('attribute', $phpHighlightPath);
     }
 }

--- a/lib/Docs/CodeBlockLanguageDetector.php
+++ b/lib/Docs/CodeBlockLanguageDetector.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Docs;
 
+use Highlight\Highlighter;
+
+use function sprintf;
 use function trim;
 
 class CodeBlockLanguageDetector
@@ -18,11 +21,20 @@ class CodeBlockLanguageDetector
         'php-annotations' => 'php',
     ];
 
+    /** @var string */
+    private $rootDir;
+
+    public function __construct(string $rootDir)
+    {
+        $this->rootDir = $rootDir;
+    }
+
     /**
      * @param string[] $lines
      */
     public function detectLanguage(string $language, array $lines): string
     {
+        $this->registerHighlighter();
         $language = trim($language);
 
         if ($language !== '' && isset(self::ALIASES[$language])) {
@@ -45,5 +57,12 @@ class CodeBlockLanguageDetector
         }
 
         return $language;
+    }
+
+    private function registerHighlighter(): void
+    {
+        $phpHighlightPath = sprintf('%s/vendor/scrivo/highlight.php/Highlight/languages/php.json', $this->rootDir);
+        Highlighter::registerLanguage('annotation', $phpHighlightPath);
+        Highlighter::registerLanguage('attribute', $phpHighlightPath);
     }
 }

--- a/tests/Docs/CodeBlockLanguageDetectorTest.php
+++ b/tests/Docs/CodeBlockLanguageDetectorTest.php
@@ -49,6 +49,6 @@ class CodeBlockLanguageDetectorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->codeBlockLanguageDetector = new CodeBlockLanguageDetector();
+        $this->codeBlockLanguageDetector = new CodeBlockLanguageDetector(__DIR__ . '/../..');
     }
 }


### PR DESCRIPTION
Mentioned in https://github.com/doctrine/orm/pull/9184, the highlighting doesn't cover the complete website and docs build. This fix will include the rest of the website.

![grafik](https://user-images.githubusercontent.com/859964/142511860-e1b7c5f1-8f7a-4566-8aff-ba3854abc9f9.png)
