### PR TITLE
Fix of node version for yarn install (Deployment blocker)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -59,9 +59,7 @@ jobs:
         node-version: '10.22.0'
 
     - name: "yarn install"
-      uses: "borales/actions-yarn@v2.0.0"
-      with:
-        cmd: "install"
+      run: "yarn install"
 
     - name: "Prepare Website files"
       run: "bin/console --env=${{ inputs.environment }} build-all"


### PR DESCRIPTION
I forgot to do the same changes to the deployment workflow I introduced in #440. The deployment is currently blocked without the changes.