### PR TITLE
Add annotation and attributes naming of Symfony docs

### DIFF
--- a/lib/Docs/CodeBlockLanguageDetector.php
+++ b/lib/Docs/CodeBlockLanguageDetector.php
@@ -19,6 +19,7 @@ class CodeBlockLanguageDetector
         'html+php' => 'php',
         'html+jinja' => 'html',
         'php-annotations' => 'php',
+        'php-attributes' => 'php',
     ];
 
     /** @var string */
@@ -63,6 +64,8 @@ class CodeBlockLanguageDetector
     {
         $phpHighlightPath = sprintf('%s/vendor/scrivo/highlight.php/Highlight/languages/php.json', $this->rootDir);
         Highlighter::registerLanguage('annotation', $phpHighlightPath);
+        Highlighter::registerLanguage('php-annotations', $phpHighlightPath);
         Highlighter::registerLanguage('attribute', $phpHighlightPath);
+        Highlighter::registerLanguage('php-attributes', $phpHighlightPath);
     }
 }


### PR DESCRIPTION
This PR adds new aliases as a current compatibility to the Symfony docs codeblock syntax.