### PR TITLE
Allow necessary Composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,10 @@
         "symfony/var-dumper": "^4.4"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Our "Doctrine" coding standard cannot be found otherwise.