### PR TITLE
Use latest ubuntu version in workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   tests:
 
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-latest"
 
     services:
       mysql:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-latest"
 
     services:
       mysql:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,7 +5,7 @@ on: ["push", "pull_request"]
 jobs:
   code-analysis:
 
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-latest"
 
     steps:
     - uses: "actions/checkout@v2"


### PR DESCRIPTION
Ubuntu 18.04 is done for in GitHub workflows and the website doesn't depend on this exact version anymore.