### PR TITLE
Update `2022-01-11-orm-2.11.md` to be clear about some limitations over "Support for Readonly Properties"

### DIFF
--- a/source/blog/2022-01-11-orm-2.11.md
+++ b/source/blog/2022-01-11-orm-2.11.md
@@ -88,20 +88,24 @@ Another PHP 8.1 feature is the new readonly keyword that prevents the value of
 a property to be written again after it has been initialized in the constructor
 of an object.
 
-With ORM 2.11 the support now works as you would expect with no additional
-mapping options necessary:
+With ORM 2.11 the support now works only for entities which use the "NONE"
+strategy for identifier generator:
 
 ```php
 #[Entity, Table(name: 'author')]
 class Author
 {
-    #[Column, Id, GeneratedValue]
+    #[Column, Id, GeneratedValue(strategy: 'NONE')]
     private readonly int $id;
 
     #[Column]
     private readonly string $name;
 }
 ```
+
+For entities which use another strategy for their identifier generator,
+it will not work because when an entity is removed, the Unit of Work
+will try to set the value of the identifier as `null` which is not possible.
 
 ## AssociationOverrides and AttributeOverrides in Attribute Driver
 


### PR DESCRIPTION
The support for read only properties only works fine for entities which use the "None" strategy for identifier generator. When the entity use other strategy, like the suggested in the documentation, an exception is thrown when you try to remove the entity.

See: 
- https://github.com/doctrine/orm/issues/10032
- https://github.com/doctrine/orm/blob/2.14.x/lib/Doctrine/ORM/UnitOfWork.php#L1271-L1273
- https://github.com/doctrine/orm/blob/2.14.x/lib/Doctrine/ORM/Mapping/ReflectionReadonlyProperty.php#L46
- https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.readonly-properties
- https://3v4l.org/FrhLN