### PR TITLE
Run dev tools on PHP 8.2

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,6 +6,4 @@ on: ["pull_request", "push"]
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@2.1.0"
-    with:
-      php-version: "7.4"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@3.0.0"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     - name: "Setup PHP Action"
       uses: "shivammathur/setup-php@v2"
       with:
-        php-version: "7.4"
+        php-version: "8.2"
 
     - name: "Install dependencies with Composer"
       uses: "ramsey/composer-install@v2"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,20 +9,10 @@
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
 
+    <config name="php_version" value="70433"/>
+
     <file>lib</file>
     <file>tests</file>
-
-    <rule ref="Doctrine">
-        <!-- This rule requires PHP 7.4 -->
-        <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
-    </rule>
-
-    <!-- This rule requires PHP 7.4 -->
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-        <properties>
-            <property name="enableNativeTypeHint" value="false"/>
-        </properties>
-    </rule>
 
     <!-- The interface of the class below is defined in a dependency and has to remain unchanged -->
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">


### PR DESCRIPTION
We can run static analysis tools on a higher PHP version than the actual project.