### PR TITLE
Bump node to v14

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,9 +37,9 @@ jobs:
         composer-options: "--prefer-dist --no-progress --no-suggest"
 
     - name: "Installation of node"
-      uses: "actions/setup-node@v2"
+      uses: "actions/setup-node@v3"
       with:
-        node-version: '10.22.0'
+        node-version: '14.21.3'
 
     - name: "yarn install"
       run: "yarn install"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -54,9 +54,9 @@ jobs:
         composer-options: "--no-progress --no-suggest --no-dev"
 
     - name: "Installation of node"
-      uses: "actions/setup-node@v2"
+      uses: "actions/setup-node@v3"
       with:
-        node-version: '10.22.0'
+        node-version: '14.21.3'
 
     - name: "yarn install"
       run: "yarn install"


### PR DESCRIPTION
Node 10 is dead and buried. Node 14 is the highest version, I could manage to run the website build on. Let's bump as a first step and investigate what keeps us from bumping to 18/20 afterwards.