### PR TITLE
Remove event participants command from deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -51,9 +51,6 @@ jobs:
     - name: "Prepare Website files"
       run: "bin/console --env=${{ inputs.environment }} build-all"
 
-    - name: "Event Participants"
-      run: "bin/console --env=${{ inputs.environment }} event-participants --save"
-
     - name: "Deploy to ${{ inputs.environment }}"
       uses: "cpina/github-action-push-to-another-repository@v1.3"
       env:


### PR DESCRIPTION
I've missed the command in the deployment workflow in #515.