### PR TITLE
Enable symlink-alias functional test

### DIFF
--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -193,8 +193,6 @@ class FunctionalTest extends TestCase
             ));
 
             self::assertCount(3, $crawler->filter('nav.breadcrumbs ol.breadcrumb li.breadcrumb-item'));
-
-            self::markTestSkipped('This failing test is temporarily disabled');
         }
     }
 


### PR DESCRIPTION
This is the sequel to #459: Revenge of the tests.

Now that the symlinks for the aliases are fixed and thanks to @dbu for adding docs to the phpcr-odm 1.x branch, this test can be released to play with the other test cases again.