### PR TITLE
Schedule the Algolia search index build

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,6 +6,11 @@ on:
       environment:
         required: true
         type: string
+      search-index-only:
+        description: 'Only build the search index without deployment'
+        required: false
+        type: boolean
+        default: false
     secrets:
       doctrine_website_algolia_admin_api_key:
         required: true
@@ -49,9 +54,15 @@ jobs:
       run: "yarn install"
 
     - name: "Prepare Website files"
+      if: "! inputs.search-index-only"
       run: "bin/console --env=${{ inputs.environment }} build-all"
 
+    - name: "Build search index"
+      if: "inputs.search-index-only"
+      run: "bin/console --env=${{ inputs.environment }} build-all --search"
+
     - name: "Deploy to ${{ inputs.environment }}"
+      if: "! inputs.search-index-only"
       uses: "cpina/github-action-push-to-another-repository@v1.3"
       env:
         API_TOKEN_GITHUB: "${{ secrets.doctrine_website_deployment_token }}"

--- a/.github/workflows/search-index.yml
+++ b/.github/workflows/search-index.yml
@@ -1,0 +1,18 @@
+name: "Build Algolia Search Index"
+
+on:
+  schedule:
+    - cron:  '0 4 28 * *'
+
+jobs:
+  search_index:
+    name: "Search Index"
+    uses: "doctrine/doctrine-website/.github/workflows/deployment.yml@master"
+    with:
+      environment: "prod"
+      search-index-only: true
+    secrets:
+      doctrine_website_algolia_admin_api_key: "${{ secrets.doctrine_website_algolia_admin_api_key }}"
+      doctrine_website_stripe_secret_key: "${{ secrets.doctrine_website_stripe_secret_key }}"
+      doctrine_website_send_grid_api_key: "${{ secrets.doctrine_website_send_grid_api_key }}"
+      doctrine_website_deployment_token: "${{ secrets.doctrine_website_deployment_token }}"


### PR DESCRIPTION
As mentioned in #417 the first step to a reoccurring search index build can happen in a monthly cronjob.