### PR TITLE
Follow rakeroutes redirection

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -243,7 +243,7 @@ to read in different tools.
 There are already a few articles (or even single purpose websites) about
 this in case you want to read more about this:
 
-- `Deliberate git <https://www.rakeroutes.com/deliberate-git>`_
+- `Deliberate git <https://www.strangeleaflet.com/blog/deliberate-git>`_
 - `Commit message style for git <https://commit.style/>`_
 - `A note about git commit messages <https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_
 


### PR DESCRIPTION
There is no redirection for the url of the blog post itself, but when browsing https://www.rakeroutes.com, there is a redirection, and it is possible to find the blog post again.