### PR TITLE
Increase DataBuilder code coverage

### DIFF
--- a/lib/DataBuilder/WebsiteDataReader.php
+++ b/lib/DataBuilder/WebsiteDataReader.php
@@ -40,7 +40,7 @@ class WebsiteDataReader
 
         $data = json_decode($json, true);
 
-        if ($data === false) {
+        if ($data === null) {
             throw new RuntimeException(
                 sprintf('Could not load JSON from file %s', $jsonPath),
             );

--- a/tests/DataBuilder/WebsiteDataReaderTest.php
+++ b/tests/DataBuilder/WebsiteDataReaderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Tests\DataBuilder;
+
+use Doctrine\Website\DataBuilder\WebsiteData;
+use Doctrine\Website\DataBuilder\WebsiteDataReader;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class WebsiteDataReaderTest extends TestCase
+{
+    private WebsiteDataReader $websiteDataReader;
+
+    public function testRead(): void
+    {
+        $websiteData = $this->websiteDataReader->read('valid');
+
+        $expected = new WebsiteData('valid', []);
+
+        self::assertEquals($expected, $websiteData);
+    }
+
+    public function testReadInvalidFilePath(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('File vfs://cache/data/foo.json does not exist. Run ./doctrine build-website-data to generate.');
+
+        $this->websiteDataReader->read('foo');
+    }
+
+    public function testReadInvalidJson(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not load JSON from file vfs://cache/data/invalid.json');
+
+        $this->websiteDataReader->read('invalid');
+    }
+
+    protected function setUp(): void
+    {
+        $structure = [
+            'data' => [
+                'invalid.json' => '{',
+                'valid.json' => '{}',
+            ],
+        ];
+        vfsStream::setup('cache', null, $structure);
+
+        $this->websiteDataReader = new WebsiteDataReader(vfsStream::url('cache'));
+    }
+}

--- a/tests/DataBuilder/WebsiteDataWriterTest.php
+++ b/tests/DataBuilder/WebsiteDataWriterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Tests\DataBuilder;
+
+use Doctrine\Website\DataBuilder\WebsiteData;
+use Doctrine\Website\DataBuilder\WebsiteDataWriter;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+class WebsiteDataWriterTest extends TestCase
+{
+    public function testWrite(): void
+    {
+        vfsStream::setup('cache', null, [
+            'data' => [],
+            'expected.json' => '{"key": "value"}',
+        ]);
+        $cacheRoot = vfsStream::url('cache');
+
+        $websiteDataWriter = new WebsiteDataWriter($cacheRoot);
+
+        $websiteDataWriter->write(new WebsiteData('foo', ['key' => 'value']));
+
+        $filePath         = $cacheRoot . '/data/foo.json';
+        $expectedFilePath = $cacheRoot . '/expected.json';
+
+        self::assertFileExists($filePath);
+        self::assertJsonFileEqualsJsonFile($expectedFilePath, $filePath);
+    }
+
+    public function testWriteCreatesDataDirectoryWhenMissing(): void
+    {
+        vfsStream::setup('cache');
+        $cacheRoot = vfsStream::url('cache');
+
+        $websiteDataWriter = new WebsiteDataWriter($cacheRoot);
+
+        self::assertDirectoryDoesNotExist($cacheRoot . '/data');
+
+        $websiteDataWriter->write(new WebsiteData('foo', []));
+
+        self::assertDirectoryExists($cacheRoot . '/data');
+    }
+}


### PR DESCRIPTION
One of the tests is causing a PHPUnit warning because one of the tests forces a `false` return value from the function `file_get_contents()`, which is on purpose. Any ideas how I can tell that test that this is expected?