### PR TITLE
Use final and readonly where possible

### DIFF
--- a/lib/Application.php
+++ b/lib/Application.php
@@ -28,7 +28,7 @@ use function is_string;
 use function realpath;
 use function sprintf;
 
-class Application
+final readonly class Application
 {
     public const ENV_PROD    = 'prod';
     public const ENV_STAGING = 'staging';

--- a/lib/Assets/AssetIntegrityGenerator.php
+++ b/lib/Assets/AssetIntegrityGenerator.php
@@ -10,13 +10,16 @@ use function file_get_contents;
 use function hash;
 use function realpath;
 
+/** @final */
 class AssetIntegrityGenerator
 {
     /** @var string[] */
     private array $cache = [];
 
-    public function __construct(private string $sourceDir, private string $webpackBuildDir)
-    {
+    public function __construct(
+        private readonly string $sourceDir,
+        private readonly string $webpackBuildDir,
+    ) {
     }
 
     public function getAssetIntegrity(string $path, string|null $rootPath = null): string

--- a/lib/Cache/CacheClearer.php
+++ b/lib/Cache/CacheClearer.php
@@ -10,7 +10,7 @@ use function array_filter;
 use function glob;
 use function sprintf;
 
-class CacheClearer
+final readonly class CacheClearer
 {
     public function __construct(
         private Filesystem $filesystem,

--- a/lib/Commands/BuildAllCommand.php
+++ b/lib/Commands/BuildAllCommand.php
@@ -20,11 +20,11 @@ use function is_bool;
 use function is_string;
 use function sprintf;
 
-class BuildAllCommand extends Command
+final class BuildAllCommand extends Command
 {
     public function __construct(
-        private string $rootDir,
-        private string $env,
+        private readonly string $rootDir,
+        private readonly string $env,
     ) {
         parent::__construct();
     }

--- a/lib/Commands/BuildDocsCommand.php
+++ b/lib/Commands/BuildDocsCommand.php
@@ -14,10 +14,11 @@ use function assert;
 use function is_bool;
 use function is_string;
 
-class BuildDocsCommand extends Command
+final class BuildDocsCommand extends Command
 {
-    public function __construct(private BuildDocs $buildDocs)
-    {
+    public function __construct(
+        private readonly BuildDocs $buildDocs,
+    ) {
         parent::__construct();
     }
 

--- a/lib/Commands/BuildWebsiteCommand.php
+++ b/lib/Commands/BuildWebsiteCommand.php
@@ -26,7 +26,7 @@ use function realpath;
 use function sprintf;
 use function time;
 
-class BuildWebsiteCommand extends Command
+final class BuildWebsiteCommand extends Command
 {
     private const WATCH_DIRS = [
         'config',
@@ -37,9 +37,9 @@ class BuildWebsiteCommand extends Command
     ];
 
     public function __construct(
-        private WebsiteBuilder $websiteBuilder,
-        private string $rootDir,
-        private string $env,
+        private readonly WebsiteBuilder $websiteBuilder,
+        private readonly string $rootDir,
+        private readonly string $env,
     ) {
         parent::__construct();
     }

--- a/lib/Commands/BuildWebsiteDataCommand.php
+++ b/lib/Commands/BuildWebsiteDataCommand.php
@@ -15,14 +15,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
 
-class BuildWebsiteDataCommand extends Command
+final class BuildWebsiteDataCommand extends Command
 {
     public function __construct(
-        private ProjectDataBuilder $projectDataBuilder,
-        private ProjectContributorDataBuilder $projectContributorDataBuilder,
-        private ContributorDataBuilder $contributorDataBuilder,
-        private BlogPostDataBuilder $blogPostDataBuilder,
-        private WebsiteDataWriter $dataWriter,
+        private readonly ProjectDataBuilder $projectDataBuilder,
+        private readonly ProjectContributorDataBuilder $projectContributorDataBuilder,
+        private readonly ContributorDataBuilder $contributorDataBuilder,
+        private readonly BlogPostDataBuilder $blogPostDataBuilder,
+        private readonly WebsiteDataWriter $dataWriter,
     ) {
         parent::__construct();
     }

--- a/lib/Commands/ClearBuildCacheCommand.php
+++ b/lib/Commands/ClearBuildCacheCommand.php
@@ -14,10 +14,13 @@ use function assert;
 use function is_string;
 use function sprintf;
 
-class ClearBuildCacheCommand extends Command
+final class ClearBuildCacheCommand extends Command
 {
-    public function __construct(private CacheClearer $cacheClearer, private string $rootDir, private string $env)
-    {
+    public function __construct(
+        private readonly CacheClearer $cacheClearer,
+        private readonly string $rootDir,
+        private readonly string $env,
+    ) {
         parent::__construct();
     }
 

--- a/lib/Commands/SyncRepositoriesCommand.php
+++ b/lib/Commands/SyncRepositoriesCommand.php
@@ -12,11 +12,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function sprintf;
 
-class SyncRepositoriesCommand extends Command
+final class SyncRepositoriesCommand extends Command
 {
     public function __construct(
-        private ProjectDataRepository $projectDataRepository,
-        private ProjectGitSyncer $projectGitSyncer,
+        private readonly ProjectDataRepository $projectDataRepository,
+        private readonly ProjectGitSyncer $projectGitSyncer,
     ) {
         parent::__construct();
     }

--- a/lib/Controllers/AtomController.php
+++ b/lib/Controllers/AtomController.php
@@ -8,11 +8,12 @@ use Doctrine\StaticWebsiteGenerator\Controller\Response;
 use Doctrine\Website\Model\BlogPost;
 use Doctrine\Website\Repositories\BlogPostRepository;
 
-class AtomController
+final readonly class AtomController
 {
     /** @param BlogPostRepository<BlogPost> $blogPostRepository */
-    public function __construct(private BlogPostRepository $blogPostRepository)
-    {
+    public function __construct(
+        private BlogPostRepository $blogPostRepository,
+    ) {
     }
 
     public function index(): Response

--- a/lib/Controllers/BlogController.php
+++ b/lib/Controllers/BlogController.php
@@ -8,11 +8,12 @@ use Doctrine\StaticWebsiteGenerator\Controller\Response;
 use Doctrine\Website\Model\BlogPost;
 use Doctrine\Website\Repositories\BlogPostRepository;
 
-class BlogController
+final readonly class BlogController
 {
     /** @param BlogPostRepository<BlogPost> $blogPostRepository */
-    public function __construct(private BlogPostRepository $blogPostRepository)
-    {
+    public function __construct(
+        private BlogPostRepository $blogPostRepository,
+    ) {
     }
 
     public function index(): Response

--- a/lib/Controllers/ConsultingController.php
+++ b/lib/Controllers/ConsultingController.php
@@ -9,11 +9,12 @@ use Doctrine\Website\Model\CommittersStats;
 use Doctrine\Website\Model\TeamMember;
 use Doctrine\Website\Repositories\TeamMemberRepository;
 
-class ConsultingController
+final readonly class ConsultingController
 {
     /** @param TeamMemberRepository<TeamMember> $teamMemberRepository */
-    public function __construct(private TeamMemberRepository $teamMemberRepository)
-    {
+    public function __construct(
+        private TeamMemberRepository $teamMemberRepository,
+    ) {
     }
 
     public function index(): Response

--- a/lib/Controllers/DocumentationController.php
+++ b/lib/Controllers/DocumentationController.php
@@ -8,11 +8,12 @@ use Doctrine\StaticWebsiteGenerator\Controller\Response;
 use Doctrine\Website\Model\Project;
 use Doctrine\Website\Repositories\ProjectRepository;
 
-class DocumentationController
+final readonly class DocumentationController
 {
     /** @param ProjectRepository<Project> $projectRepository */
-    public function __construct(private ProjectRepository $projectRepository)
-    {
+    public function __construct(
+        private ProjectRepository $projectRepository,
+    ) {
     }
 
     public function view(string $docsSlug, string $docsVersion): Response

--- a/lib/Controllers/HomepageController.php
+++ b/lib/Controllers/HomepageController.php
@@ -15,7 +15,7 @@ use Doctrine\Website\Repositories\DoctrineUserRepository;
 use Doctrine\Website\Repositories\PartnerRepository;
 use Doctrine\Website\Repositories\ProjectRepository;
 
-class HomepageController
+final readonly class HomepageController
 {
     /**
      * @param BlogPostRepository<BlogPost>         $blogPostRepository

--- a/lib/Controllers/PartnersController.php
+++ b/lib/Controllers/PartnersController.php
@@ -8,11 +8,12 @@ use Doctrine\StaticWebsiteGenerator\Controller\Response;
 use Doctrine\Website\Model\Partner;
 use Doctrine\Website\Repositories\PartnerRepository;
 
-final class PartnersController
+final readonly class PartnersController
 {
     /** @param PartnerRepository<Partner> $partnerRepository */
-    public function __construct(private PartnerRepository $partnerRepository)
-    {
+    public function __construct(
+        private PartnerRepository $partnerRepository,
+    ) {
     }
 
     public function index(): Response

--- a/lib/Controllers/ProjectController.php
+++ b/lib/Controllers/ProjectController.php
@@ -10,7 +10,7 @@ use Doctrine\Website\Model\ProjectContributor;
 use Doctrine\Website\Repositories\ProjectContributorRepository;
 use Doctrine\Website\Repositories\ProjectRepository;
 
-class ProjectController
+final readonly class ProjectController
 {
     /**
      * @param ProjectRepository<Project>                       $projectRepository

--- a/lib/Controllers/SitemapController.php
+++ b/lib/Controllers/SitemapController.php
@@ -8,11 +8,12 @@ use Doctrine\StaticWebsiteGenerator\Controller\Response;
 use Doctrine\Website\Model\SitemapPage;
 use Doctrine\Website\Repositories\SitemapPageRepository;
 
-class SitemapController
+final readonly class SitemapController
 {
     /** @param SitemapPageRepository<SitemapPage> $sitemapPageRepository */
-    public function __construct(private SitemapPageRepository $sitemapPageRepository)
-    {
+    public function __construct(
+        private SitemapPageRepository $sitemapPageRepository,
+    ) {
     }
 
     public function index(): Response

--- a/lib/Controllers/SponsorshipController.php
+++ b/lib/Controllers/SponsorshipController.php
@@ -8,11 +8,12 @@ use Doctrine\StaticWebsiteGenerator\Controller\Response;
 use Doctrine\Website\Model\Sponsor;
 use Doctrine\Website\Repositories\SponsorRepository;
 
-class SponsorshipController
+final readonly class SponsorshipController
 {
     /** @param SponsorRepository<Sponsor> $sponsorRepository */
-    public function __construct(private SponsorRepository $sponsorRepository)
-    {
+    public function __construct(
+        private SponsorRepository $sponsorRepository,
+    ) {
     }
 
     public function index(): Response

--- a/lib/Controllers/TeamController.php
+++ b/lib/Controllers/TeamController.php
@@ -8,11 +8,12 @@ use Doctrine\StaticWebsiteGenerator\Controller\Response;
 use Doctrine\Website\Model\Contributor;
 use Doctrine\Website\Repositories\ContributorRepository;
 
-class TeamController
+final readonly class TeamController
 {
     /** @param ContributorRepository<Contributor> $contributorRepository */
-    public function __construct(private ContributorRepository $contributorRepository)
-    {
+    public function __construct(
+        private ContributorRepository $contributorRepository,
+    ) {
     }
 
     public function maintainers(): Response

--- a/lib/DataBuilder/BlogPostDataBuilder.php
+++ b/lib/DataBuilder/BlogPostDataBuilder.php
@@ -6,12 +6,13 @@ namespace Doctrine\Website\DataBuilder;
 
 use Doctrine\StaticWebsiteGenerator\SourceFile\SourceFileFilesystemReader;
 
-class BlogPostDataBuilder implements DataBuilder
+final readonly class BlogPostDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'blog_posts';
 
-    public function __construct(private SourceFileFilesystemReader $sourceFileFilesystemReader)
-    {
+    public function __construct(
+        private SourceFileFilesystemReader $sourceFileFilesystemReader,
+    ) {
     }
 
     public function getName(): string

--- a/lib/DataBuilder/ContributorDataBuilder.php
+++ b/lib/DataBuilder/ContributorDataBuilder.php
@@ -7,13 +7,14 @@ namespace Doctrine\Website\DataBuilder;
 use Doctrine\Website\Model\ProjectContributor;
 use Doctrine\Website\Repositories\ProjectContributorRepository;
 
-class ContributorDataBuilder implements DataBuilder
+final readonly class ContributorDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'contributors';
 
     /** @param ProjectContributorRepository<ProjectContributor> $projectContributorRepository */
-    public function __construct(private ProjectContributorRepository $projectContributorRepository)
-    {
+    public function __construct(
+        private ProjectContributorRepository $projectContributorRepository,
+    ) {
     }
 
     public function getName(): string

--- a/lib/DataBuilder/ProjectContributorDataBuilder.php
+++ b/lib/DataBuilder/ProjectContributorDataBuilder.php
@@ -10,7 +10,7 @@ use Doctrine\Website\Model\TeamMember;
 use Doctrine\Website\Repositories\ProjectRepository;
 use Doctrine\Website\Repositories\TeamMemberRepository;
 
-class ProjectContributorDataBuilder implements DataBuilder
+final readonly class ProjectContributorDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'project_contributors';
 

--- a/lib/DataBuilder/ProjectDataBuilder.php
+++ b/lib/DataBuilder/ProjectDataBuilder.php
@@ -21,7 +21,7 @@ use function end;
 use function strnatcmp;
 use function usort;
 
-class ProjectDataBuilder implements DataBuilder
+final readonly class ProjectDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'projects';
 

--- a/lib/DataBuilder/WebsiteData.php
+++ b/lib/DataBuilder/WebsiteData.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\DataBuilder;
 
-class WebsiteData
+final readonly class WebsiteData
 {
     /** @param mixed[] $data */
-    public function __construct(private string $name, private array $data)
-    {
+    public function __construct(
+        private string $name,
+        private array $data,
+    ) {
     }
 
     public function getName(): string

--- a/lib/DataBuilder/WebsiteDataReader.php
+++ b/lib/DataBuilder/WebsiteDataReader.php
@@ -11,10 +11,12 @@ use function file_get_contents;
 use function json_decode;
 use function sprintf;
 
+/** @final */
 class WebsiteDataReader
 {
-    public function __construct(private string $cacheDir)
-    {
+    public function __construct(
+        private readonly string $cacheDir,
+    ) {
     }
 
     public function read(string $file): WebsiteData

--- a/lib/DataBuilder/WebsiteDataWriter.php
+++ b/lib/DataBuilder/WebsiteDataWriter.php
@@ -13,10 +13,11 @@ use function mkdir;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 
-class WebsiteDataWriter
+final readonly class WebsiteDataWriter
 {
-    public function __construct(private string $cacheDir)
-    {
+    public function __construct(
+        private string $cacheDir,
+    ) {
     }
 
     public function write(WebsiteData $websiteData): void

--- a/lib/DataSources/ArrayDataSource.php
+++ b/lib/DataSources/ArrayDataSource.php
@@ -6,11 +6,12 @@ namespace Doctrine\Website\DataSources;
 
 use Doctrine\SkeletonMapper\DataSource\DataSource;
 
-final class ArrayDataSource implements DataSource
+final readonly class ArrayDataSource implements DataSource
 {
     /** @param mixed[] $sourceRows */
-    public function __construct(private array $sourceRows)
-    {
+    public function __construct(
+        private array $sourceRows,
+    ) {
     }
 
     /** @return mixed[][] */

--- a/lib/DataSources/BlogPosts.php
+++ b/lib/DataSources/BlogPosts.php
@@ -9,10 +9,11 @@ use Doctrine\SkeletonMapper\DataSource\DataSource;
 use Doctrine\Website\DataBuilder\BlogPostDataBuilder;
 use Doctrine\Website\DataBuilder\WebsiteDataReader;
 
-class BlogPosts implements DataSource
+final readonly class BlogPosts implements DataSource
 {
-    public function __construct(private WebsiteDataReader $dataReader)
-    {
+    public function __construct(
+        private WebsiteDataReader $dataReader,
+    ) {
     }
 
     /** @return mixed[][] */

--- a/lib/DataSources/Contributors.php
+++ b/lib/DataSources/Contributors.php
@@ -12,7 +12,7 @@ use Doctrine\Website\Model\TeamMember;
 use Doctrine\Website\Repositories\ProjectRepository;
 use Doctrine\Website\Repositories\TeamMemberRepository;
 
-class Contributors implements DataSource
+final readonly class Contributors implements DataSource
 {
     /**
      * @param TeamMemberRepository<TeamMember> $teamMemberRepository

--- a/lib/DataSources/ProjectContributors.php
+++ b/lib/DataSources/ProjectContributors.php
@@ -12,7 +12,7 @@ use Doctrine\Website\Model\TeamMember;
 use Doctrine\Website\Repositories\ProjectRepository;
 use Doctrine\Website\Repositories\TeamMemberRepository;
 
-class ProjectContributors implements DataSource
+final readonly class ProjectContributors implements DataSource
 {
     /**
      * @param TeamMemberRepository<TeamMember> $teamMemberRepository

--- a/lib/DataSources/Projects.php
+++ b/lib/DataSources/Projects.php
@@ -8,10 +8,11 @@ use Doctrine\SkeletonMapper\DataSource\DataSource;
 use Doctrine\Website\DataBuilder\ProjectDataBuilder;
 use Doctrine\Website\DataBuilder\WebsiteDataReader;
 
-class Projects implements DataSource
+final readonly class Projects implements DataSource
 {
-    public function __construct(private WebsiteDataReader $dataReader)
-    {
+    public function __construct(
+        private WebsiteDataReader $dataReader,
+    ) {
     }
 
     /** @return mixed[][] */

--- a/lib/DataSources/SitemapPages.php
+++ b/lib/DataSources/SitemapPages.php
@@ -8,10 +8,11 @@ use DateTimeImmutable;
 use Doctrine\SkeletonMapper\DataSource\DataSource;
 use Doctrine\StaticWebsiteGenerator\SourceFile\SourceFileRepository;
 
-class SitemapPages implements DataSource
+final readonly class SitemapPages implements DataSource
 {
-    public function __construct(private SourceFileRepository $sourceFileRepository)
-    {
+    public function __construct(
+        private SourceFileRepository $sourceFileRepository,
+    ) {
     }
 
     /** @return mixed[][] */

--- a/lib/Docs/BuildDocs.php
+++ b/lib/Docs/BuildDocs.php
@@ -17,7 +17,7 @@ use function array_filter;
 use function count;
 use function sprintf;
 
-class BuildDocs
+final readonly class BuildDocs
 {
     /** @param ProjectRepository<Project> $projectRepository */
     public function __construct(

--- a/lib/Docs/CodeBlockConsoleRenderer.php
+++ b/lib/Docs/CodeBlockConsoleRenderer.php
@@ -10,6 +10,7 @@ use function ltrim;
 use function sprintf;
 use function substr;
 
+/** @final */
 class CodeBlockConsoleRenderer
 {
     /** @param string[] $lines */

--- a/lib/Docs/CodeBlockLanguageDetector.php
+++ b/lib/Docs/CodeBlockLanguageDetector.php
@@ -9,7 +9,7 @@ use Highlight\Highlighter;
 use function sprintf;
 use function trim;
 
-class CodeBlockLanguageDetector
+final readonly class CodeBlockLanguageDetector
 {
     /**
      * We use some language aliases not supported by our highlighter library
@@ -22,8 +22,9 @@ class CodeBlockLanguageDetector
         'php-attributes' => 'php',
     ];
 
-    public function __construct(private string $rootDir)
-    {
+    public function __construct(
+        private string $rootDir,
+    ) {
     }
 
     /** @param string[] $lines */

--- a/lib/Docs/CodeBlockRenderer.php
+++ b/lib/Docs/CodeBlockRenderer.php
@@ -6,7 +6,7 @@ namespace Doctrine\Website\Docs;
 
 use function in_array;
 
-class CodeBlockRenderer
+final readonly class CodeBlockRenderer
 {
     private const CONSOLE_LANGUAGES = ['terminal', 'bash', 'sh', 'console'];
 

--- a/lib/Docs/CodeBlockWithLineNumbersRenderer.php
+++ b/lib/Docs/CodeBlockWithLineNumbersRenderer.php
@@ -14,6 +14,7 @@ use function sha1;
 use function sprintf;
 use function str_replace;
 
+/** @final */
 class CodeBlockWithLineNumbersRenderer
 {
     /**
@@ -31,23 +32,24 @@ class CodeBlockWithLineNumbersRenderer
     private const CODE_LINE_TABLE_COLUMN_TEMPLATE = '<td class="code-line" rowspan="%d">{{ RENDERED_CODE }}</td>';
 
     private const CODE_BLOCK_TABLE_TEMPLATE = <<<'TEMPLATE'
-<pre class="code-block-table">
-    <code class="%s">
-        <button
-            type="button"
-            class="copy-to-clipboard"
-            data-copy-element-id="%s"
-            title="Copy to Clipboard"
-        >
-            <i class="fas fa-copy"></i>
-        </button>
-        <div id="%s">%s</div>
-    </code>
-</pre>
-TEMPLATE;
+        <pre class="code-block-table">
+            <code class="%s">
+                <button
+                    type="button"
+                    class="copy-to-clipboard"
+                    data-copy-element-id="%s"
+                    title="Copy to Clipboard"
+                >
+                    <i class="fas fa-copy"></i>
+                </button>
+                <div id="%s">%s</div>
+            </code>
+        </pre>
+        TEMPLATE;
 
-    public function __construct(private Highlighter $highlighter)
-    {
+    public function __construct(
+        private readonly Highlighter $highlighter,
+    ) {
     }
 
     /** @param string[] $lines */

--- a/lib/Docs/RST/RSTBuilder.php
+++ b/lib/Docs/RST/RSTBuilder.php
@@ -10,16 +10,17 @@ use Doctrine\Website\Model\Project;
 use Doctrine\Website\Model\ProjectVersion;
 use Symfony\Component\Filesystem\Filesystem;
 
+/** @final */
 class RSTBuilder
 {
     public function __construct(
-        private RSTFileRepository $rstFileRepository,
-        private RSTCopier $rstCopier,
+        private readonly RSTFileRepository $rstFileRepository,
+        private readonly RSTCopier $rstCopier,
         private Builder $builder,
-        private RSTPostBuildProcessor $rstPostBuildProcessor,
-        private Filesystem $filesystem,
-        private string $sourceDir,
-        private string $docsDir,
+        private readonly RSTPostBuildProcessor $rstPostBuildProcessor,
+        private readonly Filesystem $filesystem,
+        private readonly string $sourceDir,
+        private readonly string $docsDir,
     ) {
     }
 

--- a/lib/Docs/RST/RSTCopier.php
+++ b/lib/Docs/RST/RSTCopier.php
@@ -13,30 +13,31 @@ use function preg_replace;
 use function sprintf;
 use function str_replace;
 
+/** @final */
 class RSTCopier
 {
-    public const RST_TEMPLATE = <<<'TEMPLATE'
-SIDEBAR BEGIN
+    final public const RST_TEMPLATE = <<<'TEMPLATE'
+        SIDEBAR BEGIN
+        
+        {{ sidebar }}
+        
+        CONTENT BEGIN
+        
+        {{ content }}
+        TEMPLATE;
 
-{{ sidebar }}
-
-CONTENT BEGIN
-
-{{ content }}
-TEMPLATE;
-
-    public const DEFAULT_SIDEBAR = <<<'SIDEBAR'
-.. toctree::
-    :depth: 3
-    :glob:
-
-    /*
-SIDEBAR;
+    final public const DEFAULT_SIDEBAR = <<<'SIDEBAR'
+        .. toctree::
+            :depth: 3
+            :glob:
+        
+            /*
+        SIDEBAR;
 
     public function __construct(
-        private RSTFileRepository $rstFileRepository,
-        private Filesystem $filesystem,
-        private string $docsDir,
+        private readonly RSTFileRepository $rstFileRepository,
+        private readonly Filesystem $filesystem,
+        private readonly string $docsDir,
     ) {
     }
 

--- a/lib/Docs/RST/RSTFileRepository.php
+++ b/lib/Docs/RST/RSTFileRepository.php
@@ -16,6 +16,7 @@ use function iterator_to_array;
 use function sprintf;
 use function trim;
 
+/** @final */
 class RSTFileRepository
 {
     /** @throws InvalidArgumentException */

--- a/lib/Docs/RST/RSTLanguage.php
+++ b/lib/Docs/RST/RSTLanguage.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Docs\RST;
 
-class RSTLanguage
+final readonly class RSTLanguage
 {
-    public function __construct(private string $code, private string $path)
-    {
+    public function __construct(
+        private string $code,
+        private string $path,
+    ) {
     }
 
     public function getCode(): string

--- a/lib/Docs/RST/RSTLanguagesDetector.php
+++ b/lib/Docs/RST/RSTLanguagesDetector.php
@@ -17,9 +17,10 @@ use function is_dir;
 use function iterator_to_array;
 use function strlen;
 
+/** @final */
 class RSTLanguagesDetector
 {
-    public const ENGLISH_LANGUAGE_CODE = 'en';
+    final public const ENGLISH_LANGUAGE_CODE = 'en';
 
     /** @return RSTLanguage[] */
     public function detectLanguages(string $docsDir): array

--- a/lib/Docs/RST/RSTPostBuildProcessor.php
+++ b/lib/Docs/RST/RSTPostBuildProcessor.php
@@ -14,21 +14,22 @@ use function sprintf;
 use function str_replace;
 use function strpos;
 
+/** @final */
 class RSTPostBuildProcessor
 {
-    public const PARAMETERS_TEMPLATE = <<<'TEMPLATE'
----
-title: "%s"
-docsIndex: %s
-docsSourcePath: "%s"
----
-%s
-TEMPLATE;
+    final public const PARAMETERS_TEMPLATE = <<<'TEMPLATE'
+        ---
+        title: "%s"
+        docsIndex: %s
+        docsSourcePath: "%s"
+        ---
+        %s
+        TEMPLATE;
 
     public function __construct(
-        private RSTFileRepository $rstFileRepository,
-        private Filesystem $filesystem,
-        private string $sourceDir,
+        private readonly RSTFileRepository $rstFileRepository,
+        private readonly Filesystem $filesystem,
+        private readonly string $sourceDir,
     ) {
     }
 

--- a/lib/Docs/SearchIndexer.php
+++ b/lib/Docs/SearchIndexer.php
@@ -22,13 +22,16 @@ use function strpos;
 
 /**
  * Influenced by Laravel.com website code search indexes that also use Algolia.
+ *
+ * @final
  */
 class SearchIndexer
 {
-    public const INDEX_NAME = 'pages';
+    final public const INDEX_NAME = 'pages';
 
-    public function __construct(private SearchClient $client)
-    {
+    public function __construct(
+        private readonly SearchClient $client,
+    ) {
     }
 
     public function initSearchIndex(): void

--- a/lib/EventListener/NodeValue.php
+++ b/lib/EventListener/NodeValue.php
@@ -9,7 +9,7 @@ use Doctrine\RST\Nodes\Node;
 
 use function str_replace;
 
-final class NodeValue
+final readonly class NodeValue
 {
     public function preNodeRender(PreNodeRenderEvent $event): void
     {

--- a/lib/EventListener/TableIncompatibility.php
+++ b/lib/EventListener/TableIncompatibility.php
@@ -9,7 +9,7 @@ use Doctrine\RST\Event\PreParseDocumentEvent;
 use function str_contains;
 use function str_replace;
 
-final class TableIncompatibility
+final readonly class TableIncompatibility
 {
     private const BEFORE = '| **SQL Server**           |         +----------------------------------------------------------+';
     private const AFTER  = '| **SQL Server**           |         |                                                          |';

--- a/lib/Git/Tag.php
+++ b/lib/Git/Tag.php
@@ -11,7 +11,7 @@ use function stripos;
 use function strpos;
 use function strtoupper;
 
-class Tag
+final readonly class Tag
 {
     private const ALPHA  = 'alpha';
     private const BETA   = 'beta';
@@ -27,8 +27,10 @@ class Tag
 
     private const COMPOSER_EPOCH = '2011-09-25';
 
-    public function __construct(private string $name, private DateTimeImmutable $date)
-    {
+    public function __construct(
+        private string $name,
+        private DateTimeImmutable $date,
+    ) {
     }
 
     public function getName(): string

--- a/lib/Git/TagBranchGuesser.php
+++ b/lib/Git/TagBranchGuesser.php
@@ -12,12 +12,14 @@ use function ltrim;
 use function preg_match_all;
 use function sprintf;
 
+/** @final */
 class TagBranchGuesser
 {
     private const COMMAND = 'cd %s && git branch -a';
 
-    public function __construct(private ProcessFactory $processFactory)
-    {
+    public function __construct(
+        private ProcessFactory $processFactory,
+    ) {
     }
 
     public function guessTagBranchName(string $repositoryPath, Tag $tag): string|null

--- a/lib/Git/TagReader.php
+++ b/lib/Git/TagReader.php
@@ -13,12 +13,14 @@ use function sprintf;
 use function str_replace;
 use function usort;
 
+/** @final */
 class TagReader
 {
     private const COMMAND = "cd %s && git tag -l --format='refname: %%(refname) creatordate: %%(creatordate)'";
 
-    public function __construct(private ProcessFactory $processFactory)
-    {
+    public function __construct(
+        private readonly ProcessFactory $processFactory,
+    ) {
     }
 
     /** @return Tag[] */

--- a/lib/Github/GithubClientProvider.php
+++ b/lib/Github/GithubClientProvider.php
@@ -8,12 +8,15 @@ use Github\AuthMethod;
 use Github\Client;
 use InvalidArgumentException;
 
+/** @final */
 class GithubClientProvider
 {
     private bool $authenticated = false;
 
-    public function __construct(private Client $githubClient, private string $githubHttpToken)
-    {
+    public function __construct(
+        private readonly Client $githubClient,
+        private readonly string $githubHttpToken,
+    ) {
         if ($githubHttpToken === '') {
             throw new InvalidArgumentException('You must configure a Github http token.');
         }

--- a/lib/Github/ProdGithubProjectContributors.php
+++ b/lib/Github/ProdGithubProjectContributors.php
@@ -14,7 +14,7 @@ use function assert;
 use function sleep;
 use function sprintf;
 
-class ProdGithubProjectContributors implements GithubProjectContributors
+final readonly class ProdGithubProjectContributors implements GithubProjectContributors
 {
     public function __construct(
         private CacheItemPoolInterface $cache,

--- a/lib/Hydrators/ModelHydrator.php
+++ b/lib/Hydrators/ModelHydrator.php
@@ -15,13 +15,14 @@ abstract class ModelHydrator extends ObjectHydrator
     private object $object;
 
     /** @var ClassMetadataInterface<T> */
-    private ClassMetadataInterface $classMetadata;
+    private readonly ClassMetadataInterface $classMetadata;
 
     /** @var ReflectionProperty[] */
     private array $reflectionProperties;
 
-    public function __construct(protected ObjectManagerInterface $objectManager)
-    {
+    public function __construct(
+        protected readonly ObjectManagerInterface $objectManager,
+    ) {
         $this->classMetadata = $this->objectManager->getClassMetadata($this->getClassName());
     }
 

--- a/lib/ProcessFactory.php
+++ b/lib/ProcessFactory.php
@@ -8,6 +8,7 @@ use Closure;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
+/** @final */
 class ProcessFactory
 {
     /** @return Process<string, string> */

--- a/lib/Projects/GetProjectPackagistData.php
+++ b/lib/Projects/GetProjectPackagistData.php
@@ -8,10 +8,12 @@ use function file_get_contents;
 use function json_decode;
 use function sprintf;
 
+/** @final */
 class GetProjectPackagistData
 {
-    public function __construct(private string $packagistUrlFormat)
-    {
+    public function __construct(
+        private readonly string $packagistUrlFormat,
+    ) {
     }
 
     /** @return mixed[] */

--- a/lib/Projects/GetTotalDownloads.php
+++ b/lib/Projects/GetTotalDownloads.php
@@ -7,11 +7,12 @@ namespace Doctrine\Website\Projects;
 use Doctrine\Website\Model\Project;
 use Doctrine\Website\Repositories\ProjectRepository;
 
-final class GetTotalDownloads
+final readonly class GetTotalDownloads
 {
     /** @param ProjectRepository<Project> $projectRepository */
-    public function __construct(private ProjectRepository $projectRepository)
-    {
+    public function __construct(
+        private ProjectRepository $projectRepository,
+    ) {
     }
 
     public function __invoke(): int

--- a/lib/Projects/ProjectDataReader.php
+++ b/lib/Projects/ProjectDataReader.php
@@ -21,22 +21,23 @@ use function str_replace;
 
 use const JSON_ERROR_NONE;
 
+/** @final */
 class ProjectDataReader
 {
     private const DOCTRINE_PROJECT_JSON_FILE_NAME = '.doctrine-project.json';
 
     private const COMPOSER_JSON_FILE_NAME = 'composer.json';
 
-    private Inflector $inflector;
+    private readonly Inflector $inflector;
 
     /**
      * @param mixed[] $projectsData
      * @param mixed[] $projectIntegrationTypes
      */
     public function __construct(
-        private string $projectsDir,
-        private array $projectsData,
-        private array $projectIntegrationTypes,
+        private readonly string $projectsDir,
+        private readonly array $projectsData,
+        private readonly array $projectIntegrationTypes,
     ) {
         $this->inflector = InflectorFactory::create()->build();
     }

--- a/lib/Projects/ProjectDataRepository.php
+++ b/lib/Projects/ProjectDataRepository.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Projects;
 
+/** @final */
 class ProjectDataRepository
 {
     /** @param mixed[][] $projectsData */
-    public function __construct(private array $projectsData = [])
-    {
+    public function __construct(
+        private readonly array $projectsData = [],
+    ) {
     }
 
     /** @return string[] */

--- a/lib/Projects/ProjectGitSyncer.php
+++ b/lib/Projects/ProjectGitSyncer.php
@@ -12,12 +12,16 @@ use function escapeshellarg;
 use function is_dir;
 use function sprintf;
 
+/** @final */
 class ProjectGitSyncer
 {
-    private Repo $githubRepo;
+    private readonly Repo $githubRepo;
 
-    public function __construct(private ProcessFactory $processFactory, GithubClientProvider $githubClientProvider, private string $projectsDir)
-    {
+    public function __construct(
+        private readonly ProcessFactory $processFactory,
+        GithubClientProvider $githubClientProvider,
+        private readonly string $projectsDir,
+    ) {
         // TODO Inject Repo instead of GithubClientProvider
         $this->githubRepo = $githubClientProvider->getGithubClient()->repo();
     }

--- a/lib/Projects/ProjectVersionsReader.php
+++ b/lib/Projects/ProjectVersionsReader.php
@@ -11,10 +11,13 @@ use Doctrine\Website\Git\TagReader;
 use function array_filter;
 use function array_values;
 
+/** @final */
 class ProjectVersionsReader
 {
-    public function __construct(private TagReader $tagReader, private TagBranchGuesser $tagBranchGuesser)
-    {
+    public function __construct(
+        private readonly TagReader $tagReader,
+        private readonly TagBranchGuesser $tagBranchGuesser,
+    ) {
     }
 
     /** @return mixed[] */

--- a/lib/Requests/ContributorRequests.php
+++ b/lib/Requests/ContributorRequests.php
@@ -9,11 +9,12 @@ use Doctrine\StaticWebsiteGenerator\Request\RequestCollection;
 use Doctrine\Website\Model\Contributor;
 use Doctrine\Website\Repositories\ContributorRepository;
 
-class ContributorRequests
+final readonly class ContributorRequests
 {
     /** @param ContributorRepository<Contributor> $contributorRepository */
-    public function __construct(private ContributorRepository $contributorRepository)
-    {
+    public function __construct(
+        private ContributorRepository $contributorRepository,
+    ) {
     }
 
     public function getContributors(): RequestCollection

--- a/lib/Requests/PartnerRequests.php
+++ b/lib/Requests/PartnerRequests.php
@@ -9,11 +9,12 @@ use Doctrine\StaticWebsiteGenerator\Request\RequestCollection;
 use Doctrine\Website\Model\Partner;
 use Doctrine\Website\Repositories\PartnerRepository;
 
-class PartnerRequests
+final readonly class PartnerRequests
 {
     /** @param PartnerRepository<Partner> $partnerRepository */
-    public function __construct(private PartnerRepository $partnerRepository)
-    {
+    public function __construct(
+        private PartnerRepository $partnerRepository,
+    ) {
     }
 
     public function getPartners(): RequestCollection

--- a/lib/Requests/ProjectRequests.php
+++ b/lib/Requests/ProjectRequests.php
@@ -9,11 +9,12 @@ use Doctrine\StaticWebsiteGenerator\Request\RequestCollection;
 use Doctrine\Website\Model\Project;
 use Doctrine\Website\Repositories\ProjectRepository;
 
-class ProjectRequests
+final readonly class ProjectRequests
 {
     /** @param ProjectRepository<Project> $projectRepository */
-    public function __construct(private ProjectRepository $projectRepository)
-    {
+    public function __construct(
+        private ProjectRepository $projectRepository,
+    ) {
     }
 
     public function getProjects(): RequestCollection

--- a/lib/Requests/ProjectVersionRequests.php
+++ b/lib/Requests/ProjectVersionRequests.php
@@ -9,11 +9,12 @@ use Doctrine\StaticWebsiteGenerator\Request\RequestCollection;
 use Doctrine\Website\Model\Project;
 use Doctrine\Website\Repositories\ProjectRepository;
 
-class ProjectVersionRequests
+final readonly class ProjectVersionRequests
 {
     /** @param ProjectRepository<Project> $projectRepository */
-    public function __construct(private ProjectRepository $projectRepository)
-    {
+    public function __construct(
+        private ProjectRepository $projectRepository,
+    ) {
     }
 
     public function getProjectVersions(): RequestCollection

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -17,7 +17,7 @@ final class Site extends BaseSite
         string $description,
         string $env,
         string $googleAnalyticsTrackingId,
-        private string $assetsUrl,
+        private readonly string $assetsUrl,
     ) {
         parent::__construct(
             $title,

--- a/lib/Twig/MainExtension.php
+++ b/lib/Twig/MainExtension.php
@@ -23,13 +23,13 @@ use function strlen;
 use function strrpos;
 use function substr;
 
-class MainExtension extends AbstractExtension
+final class MainExtension extends AbstractExtension
 {
     public function __construct(
-        private Parsedown $parsedown,
-        private AssetIntegrityGenerator $assetIntegrityGenerator,
-        private string $sourceDir,
-        private string $webpackBuildDir,
+        private readonly Parsedown $parsedown,
+        private readonly AssetIntegrityGenerator $assetIntegrityGenerator,
+        private readonly string $sourceDir,
+        private readonly string $webpackBuildDir,
     ) {
     }
 

--- a/lib/Twig/ProjectExtension.php
+++ b/lib/Twig/ProjectExtension.php
@@ -14,11 +14,13 @@ use function file_exists;
 use function str_replace;
 use function strpos;
 
-class ProjectExtension extends AbstractExtension
+final class ProjectExtension extends AbstractExtension
 {
     /** @param ProjectRepository<Project> $projectRepository */
-    public function __construct(private ProjectRepository $projectRepository, private string $sourceDir)
-    {
+    public function __construct(
+        private readonly ProjectRepository $projectRepository,
+        private readonly string $sourceDir,
+    ) {
     }
 
     /** {@inheritDoc} */

--- a/lib/WebsiteBuilder.php
+++ b/lib/WebsiteBuilder.php
@@ -22,6 +22,7 @@ use function is_dir;
 use function is_link;
 use function sprintf;
 
+/** @final */
 class WebsiteBuilder
 {
     public const PUBLISHABLE_ENVS = [Application::ENV_PROD, Application::ENV_STAGING];
@@ -36,14 +37,14 @@ class WebsiteBuilder
 
     /** @param ProjectRepository<Project> $projectRepository */
     public function __construct(
-        private ProcessFactory $processFactory,
-        private ProjectRepository $projectRepository,
-        private Filesystem $filesystem,
-        private SourceFileRepository $sourceFileRepository,
-        private SourceFilesBuilder $sourceFilesBuilder,
-        private string $rootDir,
-        private string $cacheDir,
-        private string $webpackBuildDir,
+        private readonly ProcessFactory $processFactory,
+        private readonly ProjectRepository $projectRepository,
+        private readonly Filesystem $filesystem,
+        private readonly SourceFileRepository $sourceFileRepository,
+        private readonly SourceFilesBuilder $sourceFilesBuilder,
+        private readonly string $rootDir,
+        private readonly string $cacheDir,
+        private readonly string $webpackBuildDir,
     ) {
     }
 


### PR DESCRIPTION
Finalizing classes/methods or flagging properties as readonly helps a reader understand how a class is used and what impact a code change may have. I propose to make `final` and `readonly` the default in this codebase.