### PR TITLE
Create cache data fixtures for test evironment

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
         coverage: "pcov"
 
     - name: "Build website"
-      run: "./bin/console --env=test build-all"
+      run: "./bin/console --env=dev build-all"
 
     - name: "Run PHP tests with coverage"
       run: "./vendor/bin/phpunit --coverage-clover clover.xml"

--- a/config/config_test.yml
+++ b/config/config_test.yml
@@ -1,2 +1,5 @@
 imports:
     - { resource: config.yml }
+
+parameters:
+    doctrine.website.cache_dir: 'tests/test-cache'

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -56,10 +56,10 @@ class FunctionalTest extends TestCase
 
         $tags = $firstVersion->getTags();
 
-        self::assertCount(14, $tags);
+        self::assertCount(3, $tags);
 
-        self::assertSame('2.0.7', $firstVersion->getLatestTag()->getName());
-        self::assertSame('2.0.0-BETA1', $firstVersion->getFirstTag()->getName());
+        self::assertSame('2.0.2', $firstVersion->getLatestTag()->getName());
+        self::assertSame('2.0.0', $firstVersion->getFirstTag()->getName());
     }
 
     public function testHomepageEditLink(): void

--- a/tests/test-cache/data/blog_posts.json
+++ b/tests/test-cache/data/blog_posts.json
@@ -1,0 +1,29 @@
+[
+    {
+        "url": "/1.html",
+        "slug": "one",
+        "title": "One",
+        "authorName": "me",
+        "authorEmail": "",
+        "contents": "Doctrine Blog 1",
+        "date": "2023-09-18 00:00:00"
+    },
+    {
+        "url": "/2.html",
+        "slug": "two",
+        "title": "Two",
+        "authorName": "you",
+        "authorEmail": "",
+        "contents": "Doctrine Blog 2",
+        "date": "2023-10-29 00:00:00"
+    },
+    {
+        "url": "/3.html",
+        "slug": "three",
+        "title": "Three",
+        "authorName": "we",
+        "authorEmail": "",
+        "contents": "Doctrine Blog 3",
+        "date": "2009-12-31 00:00:00"
+    }
+]

--- a/tests/test-cache/data/contributors.json
+++ b/tests/test-cache/data/contributors.json
@@ -1,0 +1,25 @@
+{
+    "username1": {
+        "isTeamMember": false,
+        "github": "username1",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/1?v=4",
+        "numCommits": 1,
+        "numAdditions": 2,
+        "numDeletions": 3,
+        "projects": [
+            "annotations"
+        ]
+    },
+    "username2": {
+        "isTeamMember": true,
+        "github": "username2",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/2?v=4",
+        "numCommits": 4,
+        "numAdditions": 5,
+        "numDeletions": 6,
+        "projects": [
+            "orm",
+            "dbal"
+        ]
+    }
+}

--- a/tests/test-cache/data/project_contributors.json
+++ b/tests/test-cache/data/project_contributors.json
@@ -1,0 +1,22 @@
+[
+    {
+        "isTeamMember": false,
+        "isMaintainer": false,
+        "projectSlug": "annotations",
+        "github": "username1",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/1?v=4",
+        "numCommits": 1,
+        "numAdditions": 2,
+        "numDeletions": 3
+    },
+    {
+        "isTeamMember": true,
+        "isMaintainer": true,
+        "projectSlug": "annotations",
+        "github": "username2",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/2?v=4",
+        "numCommits": 4,
+        "numAdditions": 5,
+        "numDeletions": 6
+    }
+]

--- a/tests/test-cache/data/projects.json
+++ b/tests/test-cache/data/projects.json
@@ -1,0 +1,989 @@
+[
+    {
+            "active": true,
+            "archived": false,
+            "integration": false,
+            "name": "Object Relational Mapper",
+            "repositoryName": "orm",
+            "docsPath": "/docs",
+            "codePath": "/lib",
+            "slug": "orm",
+            "versions": [
+                {
+                    "name": "3.0",
+                    "branchName": "3.0.x",
+                    "slug": "latest",
+                    "upcoming": true,
+                    "hasDocs": true,
+                    "docsLanguages": [
+                        {
+                            "code": "en",
+                            "path": "/docs/en"
+                        }
+                    ]
+                },
+                {
+                    "name": "2.17",
+                    "branchName": "2.17.x",
+                    "slug": "2.17",
+                    "upcoming": true,
+                    "hasDocs": true,
+                    "docsLanguages": [
+                        {
+                            "code": "en",
+                            "path": "/docs/en"
+                        }
+                    ]
+                },
+                {
+                    "name": "2.0",
+                    "slug": "2.0",
+                    "branchName": "2.0.x",
+                    "tags": [
+                        {
+                            "name": "2.0.0",
+                            "date": "2010-12-21 16:45:22"
+                        },
+                        {
+                            "name": "2.0.1",
+                            "date": "2011-01-30 11:17:20"
+                        },
+                        {
+                            "name": "2.0.2",
+                            "date": "2011-03-05 04:12:35"
+                        }
+                    ],
+                    "maintained": false,
+                    "hasDocs": false,
+                    "docsLanguages": []
+                }
+            ],
+            "composerPackageName": "doctrine/orm",
+            "description": "Object-Relational-Mapper for PHP",
+            "keywords": [
+                "orm",
+                "database"
+            ],
+            "shortName": "ORM",
+            "docsSlug": "doctrine-orm",
+            "packagistData": {
+                "package": {
+                    "name": "doctrine/orm",
+                    "description": "Object-Relational-Mapper for PHP",
+                    "time": "2011-10-10T17:32:08+00:00",
+                    "maintainers": [
+                        {
+                            "name": "beberlei",
+                            "avatar_url": "https://www.gravatar.com/avatar/75f5fb3ddda052e46f1daed314ae69ab?d=identicon"
+                        },
+                        {
+                            "name": "jwage",
+                            "avatar_url": "https://www.gravatar.com/avatar/f76041410752f9019752b6afd2bebc2a?d=identicon"
+                        }
+                    ],
+                    "versions": {
+                        "2.16.x-dev": {
+                            "name": "doctrine/orm",
+                            "description": "Object-Relational-Mapper for PHP",
+                            "keywords": [
+                                "database",
+                                "orm"
+                            ],
+                            "homepage": "https://www.doctrine-project.org/projects/orm.html",
+                            "version": "2.16.x-dev",
+                            "version_normalized": "2.16.9999999.9999999-dev",
+                            "license": [
+                                "MIT"
+                            ],
+                            "authors": [
+                                {
+                                    "name": "Guilherme Blanco",
+                                    "email": "guilhermeblanco@gmail.com"
+                                },
+                                {
+                                    "name": "Roman Borschel",
+                                    "email": "roman@code-factory.org"
+                                },
+                                {
+                                    "name": "Benjamin Eberlei",
+                                    "email": "kontakt@beberlei.de"
+                                },
+                                {
+                                    "name": "Jonathan Wage",
+                                    "email": "jonwage@gmail.com"
+                                },
+                                {
+                                    "name": "Marco Pivetta",
+                                    "email": "ocramius@gmail.com"
+                                }
+                            ],
+                            "source": {
+                                "url": "https://github.com/doctrine/orm.git",
+                                "type": "git",
+                                "reference": "38ad3925e2465c9be233b7ec6a5adfb6958de6ec"
+                            },
+                            "dist": {
+                                "url": "https://api.github.com/repos/doctrine/orm/zipball/38ad3925e2465c9be233b7ec6a5adfb6958de6ec",
+                                "type": "zip",
+                                "shasum": "",
+                                "reference": "38ad3925e2465c9be233b7ec6a5adfb6958de6ec"
+                            },
+                            "type": "library",
+                            "support": {
+                                "issues": "https://github.com/doctrine/orm/issues",
+                                "source": "https://github.com/doctrine/orm/tree/2.16.x"
+                            },
+                            "time": "2023-09-14T22:17:48+00:00",
+                            "autoload": {
+                                "psr-4": {
+                                    "Doctrine\\ORM\\": "lib/Doctrine/ORM"
+                                }
+                            },
+                            "bin": [
+                                "bin/doctrine"
+                            ],
+                            "default-branch": true,
+                            "require": {
+                                "php": "^7.1 || ^8.0",
+                                "composer-runtime-api": "^2",
+                                "ext-ctype": "*",
+                                "doctrine/cache": "^1.12.1 || ^2.1.1",
+                                "doctrine/collections": "^1.5 || ^2.1",
+                                "doctrine/common": "^3.0.3",
+                                "doctrine/dbal": "^2.13.1 || ^3.2",
+                                "doctrine/deprecations": "^0.5.3 || ^1",
+                                "doctrine/event-manager": "^1.2 || ^2",
+                                "doctrine/inflector": "^1.4 || ^2.0",
+                                "doctrine/instantiator": "^1.3 || ^2",
+                                "doctrine/lexer": "^2",
+                                "doctrine/persistence": "^2.4 || ^3",
+                                "psr/cache": "^1 || ^2 || ^3",
+                                "symfony/polyfill-php72": "^1.23",
+                                "symfony/polyfill-php80": "^1.16",
+                                "symfony/console": "^4.2 || ^5.0 || ^6.0"
+                            },
+                            "require-dev": {
+                                "doctrine/annotations": "^1.13 || ^2",
+                                "doctrine/coding-standard": "^9.0.2 || ^12.0",
+                                "phpbench/phpbench": "^0.16.10 || ^1.0",
+                                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
+                                "psr/log": "^1 || ^2 || ^3",
+                                "squizlabs/php_codesniffer": "3.7.2",
+                                "symfony/cache": "^4.4 || ^5.4 || ^6.0",
+                                "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
+                                "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+                                "phpstan/phpstan": "~1.4.10 || 1.10.28",
+                                "vimeo/psalm": "4.30.0 || 5.14.1"
+                            },
+                            "suggest": {
+                                "ext-dom": "Provides support for XSD validation for XML mapping files",
+                                "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0",
+                                "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
+                            },
+                            "conflict": {
+                                "doctrine/annotations": "<1.13 || >= 3.0"
+                            }
+                        },
+                        "2.17.x-dev": {
+                            "name": "doctrine/orm",
+                            "description": "Object-Relational-Mapper for PHP",
+                            "keywords": [
+                                "database",
+                                "orm"
+                            ],
+                            "homepage": "https://www.doctrine-project.org/projects/orm.html",
+                            "version": "2.17.x-dev",
+                            "version_normalized": "2.17.9999999.9999999-dev",
+                            "license": [
+                                "MIT"
+                            ],
+                            "authors": [
+                                {
+                                    "name": "Guilherme Blanco",
+                                    "email": "guilhermeblanco@gmail.com"
+                                },
+                                {
+                                    "name": "Roman Borschel",
+                                    "email": "roman@code-factory.org"
+                                },
+                                {
+                                    "name": "Benjamin Eberlei",
+                                    "email": "kontakt@beberlei.de"
+                                },
+                                {
+                                    "name": "Jonathan Wage",
+                                    "email": "jonwage@gmail.com"
+                                },
+                                {
+                                    "name": "Marco Pivetta",
+                                    "email": "ocramius@gmail.com"
+                                }
+                            ],
+                            "source": {
+                                "url": "https://github.com/doctrine/orm.git",
+                                "type": "git",
+                                "reference": "a2d2e173c28562a23fb67ee5da61d09935179069"
+                            },
+                            "dist": {
+                                "url": "https://api.github.com/repos/doctrine/orm/zipball/a2d2e173c28562a23fb67ee5da61d09935179069",
+                                "type": "zip",
+                                "shasum": "",
+                                "reference": "a2d2e173c28562a23fb67ee5da61d09935179069"
+                            },
+                            "type": "library",
+                            "support": {
+                                "issues": "https://github.com/doctrine/orm/issues",
+                                "source": "https://github.com/doctrine/orm/tree/2.17.x"
+                            },
+                            "time": "2023-08-28T07:50:37+00:00",
+                            "autoload": {
+                                "psr-4": {
+                                    "Doctrine\\ORM\\": "lib/Doctrine/ORM"
+                                }
+                            },
+                            "bin": [
+                                "bin/doctrine"
+                            ],
+                            "require": {
+                                "php": "^7.1 || ^8.0",
+                                "composer-runtime-api": "^2",
+                                "ext-ctype": "*",
+                                "doctrine/cache": "^1.12.1 || ^2.1.1",
+                                "doctrine/collections": "^1.5 || ^2.1",
+                                "doctrine/common": "^3.0.3",
+                                "doctrine/dbal": "^2.13.1 || ^3.2",
+                                "doctrine/deprecations": "^0.5.3 || ^1",
+                                "doctrine/event-manager": "^1.2 || ^2",
+                                "doctrine/inflector": "^1.4 || ^2.0",
+                                "doctrine/instantiator": "^1.3 || ^2",
+                                "doctrine/lexer": "^2",
+                                "doctrine/persistence": "^2.4 || ^3",
+                                "psr/cache": "^1 || ^2 || ^3",
+                                "symfony/console": "^4.2 || ^5.0 || ^6.0 || ^7.0",
+                                "symfony/polyfill-php72": "^1.23",
+                                "symfony/polyfill-php80": "^1.16"
+                            },
+                            "require-dev": {
+                                "doctrine/annotations": "^1.13 || ^2",
+                                "doctrine/coding-standard": "^9.0.2 || ^12.0",
+                                "phpbench/phpbench": "^0.16.10 || ^1.0",
+                                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
+                                "psr/log": "^1 || ^2 || ^3",
+                                "squizlabs/php_codesniffer": "3.7.2",
+                                "symfony/cache": "^4.4 || ^5.4 || ^6.0",
+                                "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
+                                "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+                                "phpstan/phpstan": "~1.4.10 || 1.10.28",
+                                "vimeo/psalm": "4.30.0 || 5.14.1"
+                            },
+                            "suggest": {
+                                "ext-dom": "Provides support for XSD validation for XML mapping files",
+                                "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0",
+                                "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
+                            },
+                            "conflict": {
+                                "doctrine/annotations": "<1.13 || >= 3.0"
+                            }
+                        },
+                        "3.0.x-dev": {
+                            "name": "doctrine/orm",
+                            "description": "Object-Relational-Mapper for PHP",
+                            "keywords": [
+                                "database",
+                                "orm"
+                            ],
+                            "homepage": "https://www.doctrine-project.org/projects/orm.html",
+                            "version": "3.0.x-dev",
+                            "version_normalized": "3.0.9999999.9999999-dev",
+                            "license": [
+                                "MIT"
+                            ],
+                            "authors": [
+                                {
+                                    "name": "Guilherme Blanco",
+                                    "email": "guilhermeblanco@gmail.com"
+                                },
+                                {
+                                    "name": "Roman Borschel",
+                                    "email": "roman@code-factory.org"
+                                },
+                                {
+                                    "name": "Benjamin Eberlei",
+                                    "email": "kontakt@beberlei.de"
+                                },
+                                {
+                                    "name": "Jonathan Wage",
+                                    "email": "jonwage@gmail.com"
+                                },
+                                {
+                                    "name": "Marco Pivetta",
+                                    "email": "ocramius@gmail.com"
+                                }
+                            ],
+                            "source": {
+                                "url": "https://github.com/doctrine/orm.git",
+                                "type": "git",
+                                "reference": "2c39b3f118fad3c35bd07a18f6312308e23a6695"
+                            },
+                            "dist": {
+                                "url": "https://api.github.com/repos/doctrine/orm/zipball/2c39b3f118fad3c35bd07a18f6312308e23a6695",
+                                "type": "zip",
+                                "shasum": "",
+                                "reference": "2c39b3f118fad3c35bd07a18f6312308e23a6695"
+                            },
+                            "type": "library",
+                            "support": {
+                                "issues": "https://github.com/doctrine/orm/issues",
+                                "source": "https://github.com/doctrine/orm/tree/3.0.x"
+                            },
+                            "time": "2023-08-15T13:44:34+00:00",
+                            "autoload": {
+                                "psr-4": {
+                                    "Doctrine\\ORM\\": "lib/Doctrine/ORM"
+                                }
+                            },
+                            "require": {
+                                "psr/cache": "^1 || ^2 || ^3",
+                                "ext-ctype": "*",
+                                "doctrine/inflector": "^1.4 || ^2.0",
+                                "composer-runtime-api": "^2",
+                                "doctrine/common": "^3.3",
+                                "doctrine/deprecations": "^0.5.3 || ^1",
+                                "php": "^8.1",
+                                "doctrine/event-manager": "^1.2 || ^2",
+                                "doctrine/persistence": "^3.1.1",
+                                "doctrine/collections": "^2.1",
+                                "doctrine/lexer": "^2.1 || ^3",
+                                "doctrine/instantiator": "^1.3 || ^2",
+                                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                                "doctrine/dbal": "^3.6 || ^4"
+                            },
+                            "require-dev": {
+                                "psr/log": "^1 || ^2 || ^3",
+                                "symfony/var-exporter": "^5.4 || ^6.2",
+                                "phpbench/phpbench": "^1.0",
+                                "squizlabs/php_codesniffer": "3.7.2",
+                                "phpunit/phpunit": "^10.0.14",
+                                "doctrine/coding-standard": "^12.0",
+                                "phpstan/phpstan": "1.10.18",
+                                "symfony/cache": "^5.4 || ^6.2",
+                                "vimeo/psalm": "5.13.0"
+                            },
+                            "suggest": {
+                                "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0",
+                                "ext-dom": "Provides support for XSD validation for XML mapping files"
+                            }
+                        }
+                    },
+                    "type": "library",
+                    "repository": "https://github.com/doctrine/orm",
+                    "github_stars": 9668,
+                    "github_watchers": 259,
+                    "github_forks": 2502,
+                    "github_open_issues": 1418,
+                    "language": "PHP",
+                    "dependents": 6282,
+                    "suggesters": 423,
+                    "downloads": {
+                        "total": 171490626,
+                        "monthly": 3189620,
+                        "daily": 128498
+                    },
+                    "favers": 9839
+                }
+            }
+        },
+    {
+        "active": true,
+        "archived": false,
+        "integration": false,
+        "name": "Database Abstraction Layer",
+        "repositoryName": "dbal",
+        "docsPath": "/docs",
+        "codePath": "/src",
+        "slug": "dbal",
+        "versions": [
+            {
+                "name": "4.0",
+                "branchName": "4.0.x",
+                "slug": "latest",
+                "upcoming": true,
+                "tags": [
+                    {
+                        "name": "4.0.0-beta1",
+                        "date": "2022-10-22 12:39:29"
+                    },
+                    {
+                        "name": "4.0.0-beta2",
+                        "date": "2023-02-08 00:11:22"
+                    }
+                ],
+                "hasDocs": true,
+                "docsLanguages": [
+                    {
+                        "code": "en",
+                        "path": "/docs/en"
+                    }
+                ]
+            },
+            {
+                "name": "3.7",
+                "branchName": "3.7.x",
+                "slug": "3.7",
+                "upcoming": true,
+                "hasDocs": true,
+                "docsLanguages": [
+                    {
+                        "code": "en",
+                        "path": "/docs/en"
+                    }
+                ]
+            }
+        ],
+        "composerPackageName": "doctrine/dbal",
+        "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+        "keywords": [
+            "abstraction",
+            "database",
+            "dbal",
+            "db2",
+            "mariadb",
+            "mssql",
+            "mysql",
+            "pgsql",
+            "postgresql",
+            "oci8",
+            "oracle",
+            "pdo",
+            "queryobject",
+            "sasql",
+            "sql",
+            "sqlite",
+            "sqlserver",
+            "sqlsrv"
+        ],
+        "shortName": "DBAL",
+        "docsSlug": "doctrine-dbal",
+        "packagistData": {
+            "package": {
+                "name": "doctrine/dbal",
+                "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+                "time": "2011-10-10T17:32:36+00:00",
+                "maintainers": [
+                    {
+                        "name": "beberlei",
+                        "avatar_url": "https://www.gravatar.com/avatar/75f5fb3ddda052e46f1daed314ae69ab?d=identicon"
+                    },
+                    {
+                        "name": "morozov",
+                        "avatar_url": "https://www.gravatar.com/avatar/22203482572193fd53863a81ca947635?d=identicon"
+                    }
+                ],
+                "versions": {
+                    "3.6.x-dev": {
+                        "name": "doctrine/dbal",
+                        "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+                        "keywords": [
+                            "database",
+                            "dbal",
+                            "queryobject",
+                            "sql",
+                            "abstraction",
+                            "mysql",
+                            "sqlite",
+                            "postgresql",
+                            "pdo",
+                            "pgsql",
+                            "sqlserver",
+                            "mssql",
+                            "oracle",
+                            "mariadb",
+                            "sqlsrv",
+                            "oci8",
+                            "db2",
+                            "sasql"
+                        ],
+                        "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+                        "version": "3.6.x-dev",
+                        "version_normalized": "3.6.9999999.9999999-dev",
+                        "license": [
+                            "MIT"
+                        ],
+                        "authors": [
+                            {
+                                "name": "Guilherme Blanco",
+                                "email": "guilhermeblanco@gmail.com"
+                            },
+                            {
+                                "name": "Roman Borschel",
+                                "email": "roman@code-factory.org"
+                            },
+                            {
+                                "name": "Benjamin Eberlei",
+                                "email": "kontakt@beberlei.de"
+                            },
+                            {
+                                "name": "Jonathan Wage",
+                                "email": "jonwage@gmail.com"
+                            }
+                        ],
+                        "source": {
+                            "url": "https://github.com/doctrine/dbal.git",
+                            "type": "git",
+                            "reference": "8e79bee7130f889851d1a7d05ce25a116946f285"
+                        },
+                        "dist": {
+                            "url": "https://api.github.com/repos/doctrine/dbal/zipball/8e79bee7130f889851d1a7d05ce25a116946f285",
+                            "type": "zip",
+                            "shasum": "",
+                            "reference": "8e79bee7130f889851d1a7d05ce25a116946f285"
+                        },
+                        "type": "library",
+                        "support": {
+                            "issues": "https://github.com/doctrine/dbal/issues",
+                            "source": "https://github.com/doctrine/dbal/tree/3.6.x"
+                        },
+                        "funding": [
+                            {
+                                "url": "https://www.doctrine-project.org/sponsorship.html",
+                                "type": "custom"
+                            },
+                            {
+                                "url": "https://www.patreon.com/phpdoctrine",
+                                "type": "patreon"
+                            },
+                            {
+                                "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                                "type": "tidelift"
+                            }
+                        ],
+                        "time": "2023-09-14T13:00:57+00:00",
+                        "autoload": {
+                            "psr-4": {
+                                "Doctrine\\DBAL\\": "src"
+                            }
+                        },
+                        "bin": [
+                            "bin/doctrine-dbal"
+                        ],
+                        "default-branch": true,
+                        "require": {
+                            "php": "^7.4 || ^8.0",
+                            "composer-runtime-api": "^2",
+                            "doctrine/cache": "^1.11|^2.0",
+                            "doctrine/deprecations": "^0.5.3|^1",
+                            "doctrine/event-manager": "^1|^2",
+                            "psr/cache": "^1|^2|^3",
+                            "psr/log": "^1|^2|^3"
+                        },
+                        "require-dev": {
+                            "psalm/plugin-phpunit": "0.18.4",
+                            "symfony/cache": "^5.4|^6.0",
+                            "symfony/console": "^4.4|^5.4|^6.0",
+                            "vimeo/psalm": "4.30.0",
+                            "fig/log-test": "^1",
+                            "phpstan/phpstan-strict-rules": "^1.5",
+                            "squizlabs/php_codesniffer": "3.7.2",
+                            "doctrine/coding-standard": "12.0.0",
+                            "jetbrains/phpstorm-stubs": "2023.1",
+                            "slevomat/coding-standard": "8.13.1",
+                            "phpstan/phpstan": "1.10.34",
+                            "phpunit/phpunit": "9.6.12"
+                        },
+                        "suggest": {
+                            "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                        }
+                    },
+                    "3.7.x-dev": {
+                        "name": "doctrine/dbal",
+                        "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+                        "keywords": [
+                            "database",
+                            "dbal",
+                            "queryobject",
+                            "sql",
+                            "abstraction",
+                            "mysql",
+                            "sqlite",
+                            "postgresql",
+                            "pdo",
+                            "pgsql",
+                            "sqlserver",
+                            "mssql",
+                            "oracle",
+                            "mariadb",
+                            "sqlsrv",
+                            "oci8",
+                            "db2",
+                            "sasql"
+                        ],
+                        "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+                        "version": "3.7.x-dev",
+                        "version_normalized": "3.7.9999999.9999999-dev",
+                        "license": [
+                            "MIT"
+                        ],
+                        "authors": [
+                            {
+                                "name": "Guilherme Blanco",
+                                "email": "guilhermeblanco@gmail.com"
+                            },
+                            {
+                                "name": "Roman Borschel",
+                                "email": "roman@code-factory.org"
+                            },
+                            {
+                                "name": "Benjamin Eberlei",
+                                "email": "kontakt@beberlei.de"
+                            },
+                            {
+                                "name": "Jonathan Wage",
+                                "email": "jonwage@gmail.com"
+                            }
+                        ],
+                        "source": {
+                            "url": "https://github.com/doctrine/dbal.git",
+                            "type": "git",
+                            "reference": "2dd7eb8b892b3d4e3ae723fe7212a22142ff9738"
+                        },
+                        "dist": {
+                            "url": "https://api.github.com/repos/doctrine/dbal/zipball/2dd7eb8b892b3d4e3ae723fe7212a22142ff9738",
+                            "type": "zip",
+                            "shasum": "",
+                            "reference": "2dd7eb8b892b3d4e3ae723fe7212a22142ff9738"
+                        },
+                        "type": "library",
+                        "support": {
+                            "issues": "https://github.com/doctrine/dbal/issues",
+                            "source": "https://github.com/doctrine/dbal/tree/3.7.x"
+                        },
+                        "funding": [
+                            {
+                                "url": "https://www.doctrine-project.org/sponsorship.html",
+                                "type": "custom"
+                            },
+                            {
+                                "url": "https://www.patreon.com/phpdoctrine",
+                                "type": "patreon"
+                            },
+                            {
+                                "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                                "type": "tidelift"
+                            }
+                        ],
+                        "time": "2023-09-14T06:50:59+00:00",
+                        "autoload": {
+                            "psr-4": {
+                                "Doctrine\\DBAL\\": "src"
+                            }
+                        },
+                        "bin": [
+                            "bin/doctrine-dbal"
+                        ],
+                        "require": {
+                            "php": "^7.4 || ^8.0",
+                            "composer-runtime-api": "^2",
+                            "doctrine/cache": "^1.11|^2.0",
+                            "doctrine/deprecations": "^0.5.3|^1",
+                            "doctrine/event-manager": "^1|^2",
+                            "psr/cache": "^1|^2|^3",
+                            "psr/log": "^1|^2|^3"
+                        },
+                        "require-dev": {
+                            "fig/log-test": "^1",
+                            "phpstan/phpstan-strict-rules": "^1.5",
+                            "psalm/plugin-phpunit": "0.18.4",
+                            "squizlabs/php_codesniffer": "3.7.2",
+                            "symfony/cache": "^5.4|^6.0",
+                            "symfony/console": "^4.4|^5.4|^6.0",
+                            "vimeo/psalm": "4.30.0",
+                            "doctrine/coding-standard": "12.0.0",
+                            "jetbrains/phpstorm-stubs": "2023.1",
+                            "slevomat/coding-standard": "8.13.1",
+                            "phpstan/phpstan": "1.10.32",
+                            "phpunit/phpunit": "9.6.11"
+                        },
+                        "suggest": {
+                            "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                        }
+                    }
+                },
+                "type": "library",
+                "repository": "https://github.com/doctrine/dbal",
+                "github_stars": 9161,
+                "github_watchers": 114,
+                "github_forks": 1266,
+                "github_open_issues": 204,
+                "language": "PHP",
+                "dependents": 5193,
+                "suggesters": 205,
+                "downloads": {
+                    "total": 342795692,
+                    "monthly": 6770734,
+                    "daily": 277149
+                },
+                "favers": 9306
+            }
+        }
+    },
+    {
+        "active": false,
+        "archived": false,
+        "integration": false,
+        "name": "Annotations",
+        "repositoryName": "annotations",
+        "docsPath": "/docs",
+        "codePath": "/lib",
+        "slug": "annotations",
+        "versions": [
+            {
+                "name": "2.0",
+                "branchName": "2.0.x",
+                "aliases": [
+                    "current",
+                    "stable"
+                ],
+                "current": true,
+                "maintained": true,
+                "tags": [
+                    {
+                        "name": "2.0.0",
+                        "date": "2022-12-19 18:24:23"
+                    },
+                    {
+                        "name": "2.0.1",
+                        "date": "2023-02-02 22:07:43"
+                    }
+                ],
+                "hasDocs": true,
+                "docsLanguages": [
+                    {
+                        "code": "en",
+                        "path": "/docs/en"
+                    }
+                ]
+            },
+            {
+                "name": "1.14",
+                "branchName": "1.14.x",
+                "maintained": true,
+                "tags": [
+                    {
+                        "name": "1.14.0",
+                        "date": "2022-12-11 18:26:52"
+                    },
+                    {
+                        "name": "1.14.1",
+                        "date": "2022-12-12 12:47:10"
+                    },
+                    {
+                        "name": "1.14.2",
+                        "date": "2022-12-19 18:21:54"
+                    },
+                    {
+                        "name": "1.14.3",
+                        "date": "2023-02-02 21:55:02"
+                    }
+                ],
+                "hasDocs": true,
+                "docsLanguages": [
+                    {
+                        "code": "en",
+                        "path": "/docs/en"
+                    }
+                ]
+            }
+        ],
+        "composerPackageName": "doctrine/annotations",
+        "description": "Docblock Annotations Parser",
+        "keywords": [
+            "annotations",
+            "docblock",
+            "parser"
+        ],
+        "docsSlug": "doctrine-annotations",
+        "packagistData": {
+            "package": {
+                "name": "doctrine/annotations",
+                "description": "Docblock Annotations Parser",
+                "time": "2013-01-12T19:24:37+00:00",
+                "maintainers": [
+                    {
+                        "name": "beberlei",
+                        "avatar_url": "https://www.gravatar.com/avatar/75f5fb3ddda052e46f1daed314ae69ab?d=identicon"
+                    }
+                ],
+                "versions": {
+                    "2.0.x-dev": {
+                        "name": "doctrine/annotations",
+                        "description": "Docblock Annotations Parser",
+                        "keywords": [
+                            "annotations",
+                            "parser",
+                            "docblock"
+                        ],
+                        "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+                        "version": "2.0.x-dev",
+                        "version_normalized": "2.0.9999999.9999999-dev",
+                        "license": [
+                            "MIT"
+                        ],
+                        "authors": [
+                            {
+                                "name": "Guilherme Blanco",
+                                "email": "guilhermeblanco@gmail.com"
+                            },
+                            {
+                                "name": "Roman Borschel",
+                                "email": "roman@code-factory.org"
+                            },
+                            {
+                                "name": "Benjamin Eberlei",
+                                "email": "kontakt@beberlei.de"
+                            },
+                            {
+                                "name": "Jonathan Wage",
+                                "email": "jonwage@gmail.com"
+                            },
+                            {
+                                "name": "Johannes Schmitt",
+                                "email": "schmittjoh@gmail.com"
+                            }
+                        ],
+                        "source": {
+                            "url": "https://github.com/doctrine/annotations.git",
+                            "type": "git",
+                            "reference": "94f40ad7ecbc6931958faa8a57c48dce5da2b468"
+                        },
+                        "dist": {
+                            "url": "https://api.github.com/repos/doctrine/annotations/zipball/94f40ad7ecbc6931958faa8a57c48dce5da2b468",
+                            "type": "zip",
+                            "shasum": "",
+                            "reference": "94f40ad7ecbc6931958faa8a57c48dce5da2b468"
+                        },
+                        "type": "library",
+                        "support": {
+                            "issues": "https://github.com/doctrine/annotations/issues",
+                            "source": "https://github.com/doctrine/annotations/tree/2.0.x"
+                        },
+                        "time": "2023-08-23T17:36:07+00:00",
+                        "autoload": {
+                            "psr-4": {
+                                "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                            }
+                        },
+                        "default-branch": true,
+                        "require": {
+                            "ext-tokenizer": "*",
+                            "psr/cache": "^1 || ^2 || ^3",
+                            "php": "^7.2 || ^8.0",
+                            "doctrine/lexer": "^2 || ^3"
+                        },
+                        "require-dev": {
+                            "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                            "vimeo/psalm": "^4.10",
+                            "doctrine/cache": "^2.0",
+                            "doctrine/coding-standard": "^10",
+                            "phpstan/phpstan": "^1.8.0",
+                            "symfony/cache": "^5.4 || ^6"
+                        },
+                        "suggest": {
+                            "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+                        }
+                    },
+                    "1.14.x-dev": {
+                        "name": "doctrine/annotations",
+                        "description": "Docblock Annotations Parser",
+                        "keywords": [
+                            "annotations",
+                            "parser",
+                            "docblock"
+                        ],
+                        "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+                        "version": "1.14.x-dev",
+                        "version_normalized": "1.14.9999999.9999999-dev",
+                        "license": [
+                            "MIT"
+                        ],
+                        "authors": [
+                            {
+                                "name": "Guilherme Blanco",
+                                "email": "guilhermeblanco@gmail.com"
+                            },
+                            {
+                                "name": "Roman Borschel",
+                                "email": "roman@code-factory.org"
+                            },
+                            {
+                                "name": "Benjamin Eberlei",
+                                "email": "kontakt@beberlei.de"
+                            },
+                            {
+                                "name": "Jonathan Wage",
+                                "email": "jonwage@gmail.com"
+                            },
+                            {
+                                "name": "Johannes Schmitt",
+                                "email": "schmittjoh@gmail.com"
+                            }
+                        ],
+                        "source": {
+                            "url": "https://github.com/doctrine/annotations.git",
+                            "type": "git",
+                            "reference": "50f9235edd3a3b0fc509d458eaf469f2f5cad932"
+                        },
+                        "dist": {
+                            "url": "https://api.github.com/repos/doctrine/annotations/zipball/50f9235edd3a3b0fc509d458eaf469f2f5cad932",
+                            "type": "zip",
+                            "shasum": "",
+                            "reference": "50f9235edd3a3b0fc509d458eaf469f2f5cad932"
+                        },
+                        "type": "library",
+                        "support": {
+                            "issues": "https://github.com/doctrine/annotations/issues",
+                            "source": "https://github.com/doctrine/annotations/tree/1.14.x"
+                        },
+                        "time": "2023-08-14T13:42:08+00:00",
+                        "autoload": {
+                            "psr-4": {
+                                "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                            }
+                        },
+                        "require": {
+                            "php": "^7.1 || ^8.0",
+                            "ext-tokenizer": "*",
+                            "psr/cache": "^1 || ^2 || ^3",
+                            "doctrine/lexer": "^1 || ^2"
+                        },
+                        "require-dev": {
+                            "doctrine/cache": "^1.11 || ^2.0",
+                            "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                            "symfony/cache": "^4.4 || ^5.4 || ^6",
+                            "doctrine/coding-standard": "^9 || ^12",
+                            "phpstan/phpstan": "~1.4.10 || ^1.10.28",
+                            "vimeo/psalm": "^4.30 || ^5.14"
+                        },
+                        "suggest": {
+                            "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+                        }
+                    }
+                },
+                "type": "library",
+                "repository": "https://github.com/doctrine/annotations",
+                "github_stars": 6693,
+                "github_watchers": 42,
+                "github_forks": 239,
+                "github_open_issues": 30,
+                "language": "PHP",
+                "dependents": 2287,
+                "suggesters": 73,
+                "downloads": {
+                    "total": 361008455,
+                    "monthly": 6620958,
+                    "daily": 285450
+                },
+                "favers": 6731
+            }
+        }
+    }
+]


### PR DESCRIPTION
Many functional tests depend on actual generated website + project data, which can result into failing tests just because of a project- or repository-state (e.g. #459). This PR is the first step to not depend on original project cache/data files, that can change over time, but on static files that replaces the usually generated ones.