### PR TITLE
Replace travis-ci badge with GitHub badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Doctrine Website
 
-[![Build Status](https://travis-ci.org/doctrine/doctrine-website.svg?branch=master)](https://travis-ci.org/doctrine/doctrine-website)
+## Tests
+
+[![PHP Tests](https://github.com/doctrine/doctrine-website/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/doctrine-website/actions/workflows/continuous-integration.yml)
+[![JS Tests](https://github.com/doctrine/doctrine-website/actions/workflows/js-tests.yml/badge.svg)](https://github.com/doctrine/doctrine-website/actions/workflows/js-tests.yml)
 [![Code Coverage](https://codecov.io/gh/doctrine/doctrine-website/branch/master/graph/badge.svg)](https://codecov.io/gh/doctrine/doctrine-website/branch/master)
+
+## Coding Standards and Static Analysis
+
+[![PHP Coding Standards](https://github.com/doctrine/doctrine-website/actions/workflows/coding-standards.yml/badge.svg)](https://github.com/doctrine/doctrine-website/actions/workflows/coding-standards.yml)
+[![PHP Static Analysis](https://github.com/doctrine/doctrine-website/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/doctrine/doctrine-website/actions/workflows/static-analysis.yml)
+[![JS Analysis tools](https://github.com/doctrine/doctrine-website/actions/workflows/js-analysis.yml/badge.svg)](https://github.com/doctrine/doctrine-website/actions/workflows/js-analysis.yml)
+
+## Contributing to doctrine-project.org
 
 Learn more about how to contribute to doctrine-project.org [here](https://www.doctrine-project.org/contribute/website/).


### PR DESCRIPTION
I was pretty sure that I already removed it when I dropped TravisCI in the past, but it looks like I forgot it in the readme.