### PR TITLE
Hamburger menu doesn't open navigation

### DIFF
--- a/source/js/index.js
+++ b/source/js/index.js
@@ -5,6 +5,7 @@ import(/* webpackChunkName: "sentry" */ '@sentry/browser').then((module) => {
 });
 
 import 'bootstrap/js/dist/index';
+import 'bootstrap/dist/js/bootstrap';
 
 import(/* webpackChunkName: "main" */ './main').then((module) => {
   module.default();


### PR DESCRIPTION
During some tests of different features of the website I realized by coincidence that the hamburger menu doesn't work anymore which is a bummer for people who are using the website on a mobile.

The navigation is using the [bootstrap toggle button](node_modules/bootstrap/dist/js/bootstrap.js) to do this and it seems that the JS part of bootstrap isn't loaded anymore. I'm not sure if I put it into the right place or if it needs to be loaded somewhere else, but this made the navigation work again.