### PR TITLE
Allow only node 20 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "webpack-merge-and-include-globally": "^2.3.4"
     },
     "engines": {
-        "node": ">=20"
+        "node": "^20"
     },
     "scripts": {
         "build": "NODE_ENV=production webpack",


### PR DESCRIPTION
During installation of the website @jwage had issues to install and build it with node 21.  I'm not sure if every 20.x version will work on our website build, but for now we can reduce the node version at least to 20.