### PR TITLE
Create tests for the scroll to top button

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,6 @@ module.exports = {
     "transform": {
         "^.+\\.js$": "babel-jest",
     },
+    "setupFiles": ["./jest/setup/jest.js"],
     testEnvironment: 'jsdom'
 };

--- a/jest/setup/jest.js
+++ b/jest/setup/jest.js
@@ -1,0 +1,2 @@
+import $ from 'jquery';
+global.$ = global.jQuery = $;

--- a/jest/source/js/back-to-top.test.js
+++ b/jest/source/js/back-to-top.test.js
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import main from '../../../source/js/main';
+document.body.innerHTML = fs.readFileSync('templates/layouts/layout.html.twig');
+
+describe('Scroll back to the top button', function () {
+    test('Scroll back-to-top button is invisible at the top', function () {
+        main();
+
+        document.body.scrollTop = 0;
+        document.documentElement.scrollTop = 0;
+        window.onscroll();
+
+        const backToTopButton = document.getElementById('back-to-top');
+
+        expect(backToTopButton.style.display).toBe('none');
+    });
+
+    test('Scoll back-to-top button is visible above 20 from top', function () {
+        main();
+
+        document.body.scrollTop = 21;
+        document.documentElement.scrollTop = 21;
+        window.onscroll();
+
+        const backToTopButton = document.getElementById('back-to-top');
+
+        expect(backToTopButton.style.display).toBe('block');
+    });
+
+    test('Click on back-to-top button scrolls page to the top', function () {
+        main();
+
+        document.body.scrollTop = 100;
+        document.documentElement.scrollTop = 100;
+        window.onscroll();
+
+        const backToTopButton = document.getElementById('back-to-top');
+
+        backToTopButton.click();
+
+        expect(document.body.scrollTop).toBe(0);
+        expect(document.documentElement.scrollTop).toBe(0);
+    });
+});


### PR DESCRIPTION
These tests are covering the scroll back-to-top button that appears at the bottom right on the page when a user scrolls down.

I've also chosen to test this part of the JS implementation to improve the jest configuration to support the globally available jQuery object, which is still widely in use on the website in other scripts that need tests.