### PR TITLE
Unreadable code colour on green background

### DIFF
--- a/source/styles/index.scss
+++ b/source/styles/index.scss
@@ -433,6 +433,12 @@ div.jsactive pre {
   margin: 0;
 }
 
+.bg-success {
+  code {
+    color: #ffffff;
+  }
+}
+
 .tidelift-badge {
   border-radius: 3px;
   font-weight: 600;


### PR DESCRIPTION
Fixes #327 

The green background-color is set as `! important` in bootstrap and before I make a new background-color more `! important`, I choose to change the text color for `<code>` tags to white.