### PR TITLE
Increase Algolia indexing cronjob to twice a month

### DIFF
--- a/.github/workflows/search-index.yml
+++ b/.github/workflows/search-index.yml
@@ -2,7 +2,7 @@ name: "Build Algolia Search Index"
 
 on:
   schedule:
-    - cron:  '0 4 28 * *'
+    - cron:  '0 4 14,28 * *'
 
 jobs:
   search_index:


### PR DESCRIPTION
Looks like we can increase a full indexing in Algolia because our monthly limit allows it.