### PR TITLE
Realign of the website navigation elements for mobiles

### DIFF
--- a/source/styles/index.scss
+++ b/source/styles/index.scss
@@ -528,6 +528,17 @@ div.jsactive pre {
   h4 {
     font-size: 10px;
   }
+
+  .doctrine-navbar .nav-outbound {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 101;
+  }
+
+  #search-box {
+    width: 160px;
+  }
 }
 
 @media (min-width: 576px) and (max-width: 768px) {

--- a/source/styles/index.scss
+++ b/source/styles/index.scss
@@ -74,6 +74,7 @@ h6 {
   background: linear-gradient(-90deg, #2c374c, #1f2e4b);
   color: white;
   padding: 0 10px 0 10px;
+  align-items: normal;
 }
 
 .doctrine-navbar input {
@@ -89,6 +90,18 @@ h6 {
 
 .doctrine-navbar .navbar-brand img {
   width: 30px;
+}
+
+.doctrine-navbar .nav-outbound {
+  padding-top: 4px;
+}
+
+#search-box {
+  float: left;
+}
+
+.doctrine-navbar .navbar-collapse {
+  flex-basis: auto;
 }
 
 .dropdown:hover > .dropdown-menu {

--- a/templates/layouts/layout.html.twig
+++ b/templates/layouts/layout.html.twig
@@ -125,9 +125,6 @@
 
             <nav class="doctrine-navbar navbar navbar-expand-lg navbar-dark sticky-top bg-dark flex-md-nowrap">
                 <a class="navbar-brand text-hide" href="{{ path('homepage') }}"><img src="{{ get_asset_url('/logos/doctrine-logo.svg', site.url) }}" />{{ site.title }}</a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
                 <div class="collapse navbar-collapse" id="navbarCollapse">
                     <ul class="navbar-nav mr-auto">
                         <li class="nav-item dropdown{% if menuSlug == 'projects' %} active{% endif %}">
@@ -172,10 +169,14 @@
                             <a href="https://github.com/doctrine/doctrine-website/edit/master/source{{ page.sourcePath }}" class="btn btn-light" target="_blank" rel="noopener noreferrer">Edit</a>
                         {% endif %}
                     </div>
-
+                </div>
+                <div class="nav-outbound">
                     <div id="search-box">
                         <!-- SearchBox widget will appear here -->
                     </div>
+                    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
                 </div>
             </nav>
 


### PR DESCRIPTION
I did some work and tests on the website navigation for the usage on mobiles and how we can improve it.

# Current design

![Auswahl_001](https://github.com/doctrine/doctrine-website/assets/859964/61aad0f4-b7c8-4b3d-a8d2-aa190302773c)

While the navigation looks good for usage in a regular browser, the mobile view doesn't provide the same experience. In its "closed" state it provides all space for the website content, which is great:

![Auswahl_004](https://github.com/doctrine/doctrine-website/assets/859964/97b20f94-fcf5-4026-ade6-4f52689ff9f1)

Once the navigation gets triggered with the hamburger icon, we currently get this:

![Auswahl_005](https://github.com/doctrine/doctrine-website/assets/859964/43ab54ad-f3cb-440d-a0c0-3f14f79094da)

 Because of this I propose this PR with the following changes to the mobile view of the navigation.

# New design

When the navigation is closed, the search box is already visible and can be used right after entering the website.

![Auswahl_002](https://github.com/doctrine/doctrine-website/assets/859964/89bd3b9f-bfa1-4d76-acd3-838ffbbb7205)

This allows more space for the search results, especially on smaller devices like a smartphone. Once the navigation gets activated, we're going to get this view:

![Auswahl_003](https://github.com/doctrine/doctrine-website/assets/859964/40c835a3-6975-4fa1-8baf-3b448dcebaa8)

The Doctrine logo doesn't increase the height of the navigation anymore and won't take much of the content space just like the search box currently does. And because the navigation only needs to get activated for going to another page, it won't be needed that often as before, when the search box was part of the collapsed DOM.

As a bonus: This PR will also implicitly fix #337.

I've tested this on
* Firefox (119)
* Chromium (119.0.6045.159)

What isn't handled in this PR:

* The edit button
  * The mobile view probably doesn't need it 
* The sub-navigation
  * Especially the "Projects" nav element takes a lot of space

I'll take on these points on another time.