### PR TITLE
Remove superfluous phpunit call from workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,9 +34,6 @@ jobs:
     - name: "yarn install"
       run: "yarn install"
 
-    - name: "Run tests"
-      run: "./vendor/bin/phpunit"
-
     - name: "Setup PHP Action"
       uses: "shivammathur/setup-php@v2"
       with:


### PR DESCRIPTION
An early phpunit call made sense when `build-all` took a lot of runtime because of all the repositories it needed to build. This was made to run all tests without the ones that depend on a fully created website and break early without reaching the `build-all` step. That call can be removed now that we reduced the build time for the workflow.