### PR TITLE
Tagged services for DataBuilders

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -20,6 +20,7 @@
             <bind key="$webpackBuildDir">%doctrine.website.webpack_build_dir%</bind>
             <bind key="$projectIntegrationTypes">%doctrine.website.project_integration.types%</bind>
             <bind key="$packagistUrlFormat">https://packagist.org/packages/%s.json</bind>
+            <bind key="$dataBuilders" tag="doctrine.website.data_builder" type="tagged" />
         </defaults>
 
         <prototype namespace="Doctrine\Website\" resource="../lib/*" />

--- a/lib/Commands/BuildWebsiteDataCommand.php
+++ b/lib/Commands/BuildWebsiteDataCommand.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Commands;
 
-use Doctrine\Website\DataBuilder\BlogPostDataBuilder;
-use Doctrine\Website\DataBuilder\ContributorDataBuilder;
-use Doctrine\Website\DataBuilder\ProjectContributorDataBuilder;
-use Doctrine\Website\DataBuilder\ProjectDataBuilder;
+use Doctrine\Website\DataBuilder\DataBuilder;
 use Doctrine\Website\DataBuilder\WebsiteDataWriter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,13 +14,9 @@ use function sprintf;
 
 final class BuildWebsiteDataCommand extends Command
 {
-    public function __construct(
-        private readonly ProjectDataBuilder $projectDataBuilder,
-        private readonly ProjectContributorDataBuilder $projectContributorDataBuilder,
-        private readonly ContributorDataBuilder $contributorDataBuilder,
-        private readonly BlogPostDataBuilder $blogPostDataBuilder,
-        private readonly WebsiteDataWriter $dataWriter,
-    ) {
+    /** @param iterable<DataBuilder> $dataBuilders */
+    public function __construct(private readonly iterable $dataBuilders, private readonly WebsiteDataWriter $dataWriter)
+    {
         parent::__construct();
     }
 
@@ -38,14 +31,7 @@ final class BuildWebsiteDataCommand extends Command
     {
         $output->writeln('Building website data.');
 
-        $dataBuilders = [
-            $this->projectDataBuilder,
-            $this->projectContributorDataBuilder,
-            $this->contributorDataBuilder,
-            $this->blogPostDataBuilder,
-        ];
-
-        foreach ($dataBuilders as $dataBuilder) {
+        foreach ($this->dataBuilders as $dataBuilder) {
             $output->writeln(sprintf('Building <info>%s</info> data.', $dataBuilder->getName()));
 
             $websiteData = $dataBuilder->build();

--- a/lib/DataBuilder/BlogPostDataBuilder.php
+++ b/lib/DataBuilder/BlogPostDataBuilder.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\Website\DataBuilder;
 
 use Doctrine\StaticWebsiteGenerator\SourceFile\SourceFileFilesystemReader;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
+#[AutoconfigureTag('doctrine.website.data_builder', ['priority' => 70])]
 final readonly class BlogPostDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'blog_posts';

--- a/lib/DataBuilder/ContributorDataBuilder.php
+++ b/lib/DataBuilder/ContributorDataBuilder.php
@@ -6,7 +6,9 @@ namespace Doctrine\Website\DataBuilder;
 
 use Doctrine\Website\Model\ProjectContributor;
 use Doctrine\Website\Repositories\ProjectContributorRepository;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
+#[AutoconfigureTag('doctrine.website.data_builder', ['priority' => 80])]
 final readonly class ContributorDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'contributors';

--- a/lib/DataBuilder/ProjectContributorDataBuilder.php
+++ b/lib/DataBuilder/ProjectContributorDataBuilder.php
@@ -9,7 +9,9 @@ use Doctrine\Website\Model\Project;
 use Doctrine\Website\Model\TeamMember;
 use Doctrine\Website\Repositories\ProjectRepository;
 use Doctrine\Website\Repositories\TeamMemberRepository;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
+#[AutoconfigureTag('doctrine.website.data_builder', ['priority' => 90])]
 final readonly class ProjectContributorDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'project_contributors';

--- a/lib/DataBuilder/ProjectDataBuilder.php
+++ b/lib/DataBuilder/ProjectDataBuilder.php
@@ -12,6 +12,7 @@ use Doctrine\Website\Projects\ProjectDataReader;
 use Doctrine\Website\Projects\ProjectDataRepository;
 use Doctrine\Website\Projects\ProjectGitSyncer;
 use Doctrine\Website\Projects\ProjectVersionsReader;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 use function array_filter;
 use function array_map;
@@ -21,6 +22,7 @@ use function end;
 use function strnatcmp;
 use function usort;
 
+#[AutoconfigureTag('doctrine.website.data_builder', ['priority' => 100])]
 final readonly class ProjectDataBuilder implements DataBuilder
 {
     public const DATA_FILE = 'projects';


### PR DESCRIPTION
During my work on another task, I came up with changes that can be outsourced into their own pull request. 

This PR introduces tags for the DataBuilder and their priority of execution in the `build-website-data` command. This should reduce the size of the command's constructor.