### PR TITLE
Very minor tweaks to the navbar searchbox styling

### DIFF
--- a/source/styles/index.scss
+++ b/source/styles/index.scss
@@ -79,13 +79,16 @@ h6 {
 
 .doctrine-navbar input {
   height: 40px;
-  margin-top: 2px;
   color: black;
   background-color: white;
 }
 
 .doctrine-navbar a:hover {
   text-decoration: underline;
+}
+
+.doctrine-navbar form {
+  background-color: transparent;
 }
 
 .doctrine-navbar .navbar-brand img {


### PR DESCRIPTION
Hello! 

I noticed that the search box in the website navbar has a white background. This fixes that and tweaks some spacing just a tad to line up things up better. 

| Before | After | 
| ------------- | ------------- |
|<img width="1178" alt="Screenshot 2024-03-04 at 11 00 14" src="https://github.com/doctrine/doctrine-website/assets/884548/7d90c2f3-653e-4ac9-a17a-177ce5126933"> | <img width="1188" alt="Screenshot 2024-03-04 at 11 00 16" src="https://github.com/doctrine/doctrine-website/assets/884548/958d17f6-d613-4e37-b889-9b316f35e000"> |


