### PR TITLE
Removes mentions of the mailing list from the community page

### DIFF
--- a/source/community.html
+++ b/source/community.html
@@ -6,7 +6,7 @@ permalink: /community/index.html
 The Doctrine community is made up of thousands of developers all around
 the world. The project has had over 500 contributors and is maintained
 by a core team of developers. If you want to get involved, find other
-Doctrine developers on GitHub, Slack and the Mailing List.
+Doctrine developers on GitHub and Slack.
 {% endblock %}
 
 {% block content %}
@@ -17,7 +17,7 @@ Doctrine developers on GitHub, Slack and the Mailing List.
     the world. The project has had over <a href="https://github.com/doctrine/orm/graphs/contributors" target="_blank"
         rel="noopener noreferrer">500 contributors</a> and is maintained by a core team of developers. If you want to
     get involved, find other
-    Doctrine developers on GitHub, Slack and the Mailing List.
+    Doctrine developers on GitHub and Slack.
 </p>
 
 <div class="card mb-4 w-100">
@@ -45,19 +45,6 @@ Doctrine developers on GitHub, Slack and the Mailing List.
 
         <a href="https://www.doctrine-project.org/slack" class="btn btn-primary" target="_blank"
             rel="noopener noreferrer">Go to Slack</a>
-    </div>
-</div>
-
-<div class="card mb-4 w-100">
-    <div class="card-body">
-        <h5 class="card-title"><i class="fas fa-envelope-square"></i> Mailing List</h5>
-        <p class="card-text">
-            You can also use the mailing list hosted with Google Groups
-            to communicate with other Doctrine developers.
-        </p>
-
-        <a href="https://groups.google.com/forum/#!forum/doctrine-user" class="btn btn-primary" target="_blank"
-            rel="noopener noreferrer">Go to Mailing List</a>
     </div>
 </div>
 


### PR DESCRIPTION
The [mailing list](https://groups.google.com/g/doctrine-user) linked to from the Doctrine community page appears to be defunct. This PR removes links to the mailing list from the community page. I'm assuming the blog posts mentioning the mailing list should remain untouched.