### PR TITLE
Replace SkeletonMapper DataSource interface with custom one

### DIFF
--- a/lib/DataSources/ArrayDataSource.php
+++ b/lib/DataSources/ArrayDataSource.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\DataSources;
 
-use Doctrine\SkeletonMapper\DataSource\DataSource;
-
 final readonly class ArrayDataSource implements DataSource
 {
     /** @param mixed[] $sourceRows */

--- a/lib/DataSources/BlogPosts.php
+++ b/lib/DataSources/BlogPosts.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Website\DataSources;
 
 use DateTimeImmutable;
-use Doctrine\SkeletonMapper\DataSource\DataSource;
 use Doctrine\Website\DataBuilder\BlogPostDataBuilder;
 use Doctrine\Website\DataBuilder\WebsiteDataReader;
 

--- a/lib/DataSources/DataSource.php
+++ b/lib/DataSources/DataSource.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\DataSources;
+
+use Doctrine\SkeletonMapper\DataSource\DataSource as SkeletonMapperDataSource;
+
+interface DataSource extends SkeletonMapperDataSource
+{
+    /** @return mixed[][] */
+    public function getSourceRows(): array;
+}

--- a/lib/DataSources/Projects.php
+++ b/lib/DataSources/Projects.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\DataSources;
 
-use Doctrine\SkeletonMapper\DataSource\DataSource;
 use Doctrine\Website\DataBuilder\ProjectDataBuilder;
 use Doctrine\Website\DataBuilder\WebsiteDataReader;
 

--- a/lib/DataSources/SitemapPages.php
+++ b/lib/DataSources/SitemapPages.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Website\DataSources;
 
 use DateTimeImmutable;
-use Doctrine\SkeletonMapper\DataSource\DataSource;
 use Doctrine\StaticWebsiteGenerator\SourceFile\SourceFileRepository;
 
 final readonly class SitemapPages implements DataSource


### PR DESCRIPTION
This is a first step on a goal to remove the Doctrine SkeletonMapper from being used in the Doctrine Website. The SkeletonMapper is going to be unsupported in the future once it got completely removed from being used on the Website build.

In this PR I removed the `Doctrine\SkeletonMapper\DataSource\DataSource` from the Website data-source classes. This interface is pretty small and it shouldn't be a problem to copy it 1 on 1 for a custom DataSource interface.
The interface of the SkeletonMapper is still used in the custom DataSource interface, because the SkeletonMapper is still involved and `Doctrine\SkeletonMapper\DataSource\DataSourceObjectDataRepository` is still expecting the original one. Once the involved SkeletonMapper classes were removed, then we can also remove `Doctrine\SkeletonMapper\DataSource\DataSource` from the introduced interface.