### PR TITLE
Introduce filtering to reduce versions in the documentation

### DIFF
--- a/config/data/projects.yml
+++ b/config/data/projects.yml
@@ -21,7 +21,7 @@ parameters:
         - repositoryName: data-fixtures
         -
             repositoryName: dbal
-            versionFilter: "/^[3-9]\\.[0-9]+/"
+            versionsGreaterThan: "2.99.0"
 
         - repositoryName: doctrine1
         - repositoryName: event-manager

--- a/config/data/projects.yml
+++ b/config/data/projects.yml
@@ -19,7 +19,10 @@ parameters:
         - repositoryName: couchdb-client
         - repositoryName: couchdb-odm
         - repositoryName: data-fixtures
-        - repositoryName: dbal
+        -
+            repositoryName: dbal
+            versionFilter: "/^[3-9]\\.[0-9]+/"
+
         - repositoryName: doctrine1
         - repositoryName: event-manager
         - repositoryName: inflector

--- a/lib/Docs/BuildDocs.php
+++ b/lib/Docs/BuildDocs.php
@@ -134,12 +134,10 @@ final readonly class BuildDocs
     /** @return ProjectVersion[] */
     private function getProjectVersionsToBuild(Project $project, string $versionToBuild): array
     {
-        $versions = $project->getFilteredVersions();
-
         $filter = static function (ProjectVersion $version) use ($versionToBuild): bool {
             return $versionToBuild === '' || $version->getSlug() === $versionToBuild;
         };
 
-        return array_filter($versions, $filter);
+        return $project->getVersions($filter);
     }
 }

--- a/lib/Docs/BuildDocs.php
+++ b/lib/Docs/BuildDocs.php
@@ -134,8 +134,12 @@ final readonly class BuildDocs
     /** @return ProjectVersion[] */
     private function getProjectVersionsToBuild(Project $project, string $versionToBuild): array
     {
-        return array_filter($project->getVersions(), static function (ProjectVersion $version) use ($versionToBuild): bool {
+        $versions = $project->getFilteredVersions();
+
+        $filter = static function (ProjectVersion $version) use ($versionToBuild): bool {
             return $versionToBuild === '' || $version->getSlug() === $versionToBuild;
-        });
+        };
+
+        return array_filter($versions, $filter);
     }
 }

--- a/lib/Hydrators/ProjectHydrator.php
+++ b/lib/Hydrators/ProjectHydrator.php
@@ -9,6 +9,8 @@ use Doctrine\Website\Model\ProjectIntegrationType;
 use Doctrine\Website\Model\ProjectStats;
 use Doctrine\Website\Model\ProjectVersion;
 
+use function preg_match;
+
 /**
  * @property bool $active
  * @property bool $archived
@@ -24,7 +26,6 @@ use Doctrine\Website\Model\ProjectVersion;
  * @property string $docsPath
  * @property string $codePath
  * @property string $description
- * @property string|null $versionFilter
  * @property string[] $keywords
  * @property ProjectVersion[] $versions
  * @property ProjectIntegrationType $projectIntegrationType
@@ -57,7 +58,6 @@ final class ProjectHydrator extends ModelHydrator
         $this->codePath            = (string) ($data['codePath'] ?? '/lib');
         $this->description         = (string) ($data['description'] ?? '');
         $this->keywords            = $data['keywords'] ?? [];
-        $this->versionFilter       = $data['versionFilter'] ?? null;
 
         if (! isset($data['versions'])) {
             return;
@@ -66,9 +66,15 @@ final class ProjectHydrator extends ModelHydrator
         $versions = [];
 
         foreach ($data['versions'] as $version) {
-            $versions[] = $version instanceof ProjectVersion
+            $projectVersion = $version instanceof ProjectVersion
                 ? $version
                 : new ProjectVersion($version);
+
+            if (isset($data['versionFilter']) && preg_match($data['versionFilter'], $projectVersion->getName()) !== 1) {
+                continue;
+            }
+
+            $versions[] = $projectVersion;
         }
 
         $this->versions = $versions;

--- a/lib/Hydrators/ProjectHydrator.php
+++ b/lib/Hydrators/ProjectHydrator.php
@@ -24,6 +24,7 @@ use Doctrine\Website\Model\ProjectVersion;
  * @property string $docsPath
  * @property string $codePath
  * @property string $description
+ * @property string|null $versionFilter
  * @property string[] $keywords
  * @property ProjectVersion[] $versions
  * @property ProjectIntegrationType $projectIntegrationType
@@ -56,6 +57,7 @@ final class ProjectHydrator extends ModelHydrator
         $this->codePath            = (string) ($data['codePath'] ?? '/lib');
         $this->description         = (string) ($data['description'] ?? '');
         $this->keywords            = $data['keywords'] ?? [];
+        $this->versionFilter       = $data['versionFilter'] ?? null;
 
         if (! isset($data['versions'])) {
             return;

--- a/lib/Hydrators/ProjectHydrator.php
+++ b/lib/Hydrators/ProjectHydrator.php
@@ -9,7 +9,7 @@ use Doctrine\Website\Model\ProjectIntegrationType;
 use Doctrine\Website\Model\ProjectStats;
 use Doctrine\Website\Model\ProjectVersion;
 
-use function preg_match;
+use function version_compare;
 
 /**
  * @property bool $active
@@ -70,7 +70,8 @@ final class ProjectHydrator extends ModelHydrator
                 ? $version
                 : new ProjectVersion($version);
 
-            if (isset($data['versionFilter']) && preg_match($data['versionFilter'], $projectVersion->getName()) !== 1) {
+            $tagVersion = $projectVersion->getLatestTag()?->getName();
+            if (isset($data['versionsGreaterThan']) && $tagVersion !== null && version_compare($data['versionsGreaterThan'], $tagVersion, '>')) {
                 continue;
             }
 

--- a/lib/Model/Project.php
+++ b/lib/Model/Project.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
 
 use function array_filter;
 use function array_values;
-use function preg_match;
 use function sprintf;
 
 class Project implements LoadMetadataInterface
@@ -53,8 +52,6 @@ class Project implements LoadMetadataInterface
 
     /** @var ProjectVersion[] */
     private array $versions = [];
-
-    private string|null $versionFilter = null;
 
     public static function loadMetadata(ClassMetadataInterface $metadata): void
     {
@@ -159,17 +156,6 @@ class Project implements LoadMetadataInterface
         }
 
         return $this->versions;
-    }
-
-    /** @return ProjectVersion[] */
-    public function getFilteredVersions(): array
-    {
-        $filter = null;
-        if ($this->versionFilter !== null) {
-            $filter = fn (ProjectVersion $version) => preg_match($this->versionFilter, $version->getName()) === 1;
-        }
-
-        return $this->getVersions($filter);
     }
 
     /** @return ProjectVersion[] */

--- a/lib/Model/Project.php
+++ b/lib/Model/Project.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 
 use function array_filter;
 use function array_values;
+use function preg_match;
 use function sprintf;
 
 class Project implements LoadMetadataInterface
@@ -52,6 +53,8 @@ class Project implements LoadMetadataInterface
 
     /** @var ProjectVersion[] */
     private array $versions = [];
+
+    private string|null $versionFilter = null;
 
     public static function loadMetadata(ClassMetadataInterface $metadata): void
     {
@@ -144,7 +147,11 @@ class Project implements LoadMetadataInterface
         return $this->keywords;
     }
 
-    /** @return ProjectVersion[] */
+    /**
+     * @phpstan-param Closure(ProjectVersion $version): bool $filter
+     *
+     * @return ProjectVersion[]
+     */
     public function getVersions(Closure|null $filter = null): array
     {
         if ($filter !== null) {
@@ -152,6 +159,17 @@ class Project implements LoadMetadataInterface
         }
 
         return $this->versions;
+    }
+
+    /** @return ProjectVersion[] */
+    public function getFilteredVersions(): array
+    {
+        $filter = null;
+        if ($this->versionFilter !== null) {
+            $filter = fn (ProjectVersion $version) => preg_match($this->versionFilter, $version->getName()) === 1;
+        }
+
+        return $this->getVersions($filter);
     }
 
     /** @return ProjectVersion[] */

--- a/tests/Hydrators/ProjectHydratorTest.php
+++ b/tests/Hydrators/ProjectHydratorTest.php
@@ -157,4 +157,29 @@ class ProjectHydratorTest extends Hydrators
 
         self::assertEquals($expected, $project);
     }
+
+    public function testHydrateWithFilter(): void
+    {
+        $hydrator       = $this->createHydrator(ProjectHydrator::class);
+        $propertyValues = [
+            'name' => 'name',
+            'slug' => 'slug',
+            'repositoryName' => 'repositoryName',
+            'versionFilter' => '/^2\.0/',
+            'versions' => [
+                ['name' => '1.0.0'],
+                new ProjectVersion(['name' => '2.0.0']),
+            ],
+        ];
+
+        $expected = [
+            new ProjectVersion(['name' => '2.0.0']),
+        ];
+
+        $project = new Project();
+
+        $hydrator->hydrate($project, $propertyValues);
+
+        self::assertEquals($expected, $project->getVersions());
+    }
 }

--- a/tests/Hydrators/ProjectHydratorTest.php
+++ b/tests/Hydrators/ProjectHydratorTest.php
@@ -165,21 +165,18 @@ class ProjectHydratorTest extends Hydrators
             'name' => 'name',
             'slug' => 'slug',
             'repositoryName' => 'repositoryName',
-            'versionFilter' => '/^2\.0/',
+            'versionsGreaterThan' => '1.99.0',
             'versions' => [
-                ['name' => '1.0.0'],
-                new ProjectVersion(['name' => '2.0.0']),
+                ['name' => '1.0.0', 'tags' => [['name' => '1.0.0', 'date' => '2024-10-10']]],
+                new ProjectVersion(['name' => '2.0.0', 'tags' => [['name' => '2.0.0', 'date' => '2024-10-10']]]),
             ],
-        ];
-
-        $expected = [
-            new ProjectVersion(['name' => '2.0.0']),
         ];
 
         $project = new Project();
 
         $hydrator->hydrate($project, $propertyValues);
 
-        self::assertEquals($expected, $project->getVersions());
+        self::assertCount(1, $project->getVersions());
+        self::assertEquals('2.0.0', $project->getVersions()[0]->getLatestTag()?->getName());
     }
 }


### PR DESCRIPTION
This PR will introduce a filtering that will allow to remove older versions from the documentation website. It also introduces to drop all dbal versions from the docs that are older than version 3.
I decided to put the config value to the website instead using a `.doctrine-project.json` file because of #380.

This will also have the positive side effect that it will reduce the indices and index usage of Algolia.