### PR TITLE
Use tag for GitHub link on missing branch

### DIFF
--- a/templates/project-version.html.twig
+++ b/templates/project-version.html.twig
@@ -51,7 +51,7 @@
         <a href="{{ site.url }}/projects/{{ project.docsSlug }}/en/{{ version.slug ?? 'latest' }}/index.html" class="btn btn-primary mr-2">Docs</a>
     {% endif %}
 
-    <a href="https://github.com/doctrine/{{ project.repositoryName }}/tree/{{ version.branchName }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    <a href="https://github.com/doctrine/{{ project.repositoryName }}/tree/{{ version.branchName ?? latestTag.name }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">GitHub</a>
 
     <hr />
 


### PR DESCRIPTION
The link to GitHub is broken once a branch was deleted. Using the latest tag will give at least a direct connection to the corresponding version on GitHub.