### PR TITLE
Fix filename and add year of meetup to title

### DIFF
--- a/source/blog/2024-07-09-doctrine-core-team-meetup.md
+++ b/source/blog/2024-07-09-doctrine-core-team-meetup.md
@@ -1,5 +1,5 @@
 ---
-title: "Doctrine Core Team Meetup in Bonn, Germany"
+title: "Doctrine Core Team Meetup 2024 in Bonn, Germany"
 authorName: Benjamin Eberlei
 authorEmail: kontakt@beberlei.de
 permalink: /2024/07/09/doctrine-core-team-meetup.html


### PR DESCRIPTION
It seems that the file suffix is relevant for the presentation of the blog posts. The build happens without errors when it's omitted.