### PR TITLE
Move footer links to navigation

### DIFF
--- a/templates/layouts/layout.html.twig
+++ b/templates/layouts/layout.html.twig
@@ -152,6 +152,10 @@
                             </div>
                         </li>
 
+                        <li class="nav-item{% if menuSlug == 'sponsorship' %} active{% endif %}">
+                            <a class="nav-link" href="{{ path('sponsorship') }}">Sponsorship</a>
+                        </li>
+
                         <li class="nav-item{% if menuSlug == 'partners' %} active{% endif %}">
                             <a class="nav-link" href="{{ path('partners') }}">Partners</a>
                         </li>
@@ -196,17 +200,6 @@
         <button id="back-to-top" title="Go to top">Top</button>
 
         {% block footer %}
-            <footer class="footer">
-                <div class="container">
-                    <ul class="list-inline">
-                        <li class="list-inline-item"><a href="{{ path('projects') }}">Projects</a></li>
-                        <li class="list-inline-item"><a href="{{ path('partners') }}">Partners</a></li>
-                        <li class="list-inline-item"><a href="{{ path('sponsorship') }}">Sponsorship</a></li>
-                        <li class="list-inline-item"><a href="{{ path('community') }}">Community</a></li>
-                        <li class="list-inline-item"><a href="{{ path('blog') }}">Blog</a></li>
-                    </ul>
-                </div>
-            </footer>
         {% endblock %}
 
         <script id="instantsearch-template" type="text/template">


### PR DESCRIPTION
The footer of the website has nearly the same links as the navigation, except sponsorship. The navigation itself is sticky, so I don't see a reason why we need the same links in a footer. That's why

* I moved "sponsorship" to the navigation
* I removed the footer completely