### PR TITLE
Remove skeleton-mapper from projects

### DIFF
--- a/config/data/projects.yml
+++ b/config/data/projects.yml
@@ -39,7 +39,6 @@ parameters:
         - repositoryName: phpcr-odm
         - repositoryName: reflection
         - repositoryName: rst-parser
-        - repositoryName: skeleton-mapper
         -
             repositoryName: DoctrineBundle
             integration: true


### PR DESCRIPTION
The [repository](https://github.com/doctrine/skeleton-mapper) got archived and the project itself is removed with this PR.