### PR TITLE
Fix section author markup

### DIFF
--- a/lib/Docs/RST/RSTCopier.php
+++ b/lib/Docs/RST/RSTCopier.php
@@ -112,6 +112,14 @@ class RSTCopier
         // get rid of .. include:: toc.rst
         $content = str_replace('.. include:: toc.rst', '', $content);
 
+        $content = preg_replace(
+            '/.. sectionauthor:: ([^\(]+) \(([^\)]+)\)/',
+            '.. sectionauthor:: $1 <$2>',
+            $content,
+        );
+
+        assert(is_string($content));
+
         // replace \n::\n with \n.. code-block::\n
         // this corrects code blocks that don't render properly.
         // we should update the docs code but this makes old docs code render properly.

--- a/templates/guides/body/author.html.twig
+++ b/templates/guides/body/author.html.twig
@@ -1,0 +1,3 @@
+<div class="alert section-author bg-light text-dark border"><p class="author font-weight-bold">
+        <i class="fas fa-pencil-alt"></i> Written by <a href="mailto:{{ node.email }}">{{ node.value }}</a></p>
+</div>


### PR DESCRIPTION
Apply the correct template for section authors.
Add an extra fix in the migration from old doc styles to correct the display of author names.

See: https://staging.doctrine-project.org/projects/doctrine-orm/en/3.3/cookbook/implementing-arrayaccess-for-domain-objects.html#implementing-arrayaccess-for-domain-objects