### PR TITLE
Full wildcard match on default menu

### DIFF
--- a/lib/Docs/RST/RSTCopier.php
+++ b/lib/Docs/RST/RSTCopier.php
@@ -28,7 +28,7 @@ class RSTCopier
             :depth: 3
             :glob:
         
-            /*
+            *
         SIDEBAR;
 
     public function __construct(


### PR DESCRIPTION
We do want to include every document in the menu when we do a fallback to the default menu. `/*` does match all files are root level, while we wanted to match everything `*`.