### PR TITLE
Improve menu generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "knplabs/github-api": "^3.9",
         "monolog/monolog": "^3.7",
         "php-http/guzzle7-adapter": "^1.0",
-        "phpdocumentor/guides": "^1.3",
+        "phpdocumentor/guides": "^1.4",
         "phpdocumentor/guides-restructured-text": "^1.4",
         "scrivo/highlight.php": "^9.18",
         "symfony/cache": "^6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee0a29b539125a8fd4de75385911896b",
+    "content-hash": "c44272296c10f265ffc2149dc0e5a599",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -2670,16 +2670,16 @@
         },
         {
             "name": "phpdocumentor/guides",
-            "version": "1.3.10",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/guides-core.git",
-                "reference": "a431f1d1f398687bf93e80ef525b83e21f75b15b"
+                "reference": "1f21f606ce030fd8989eb783f726cf32c44d61ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/a431f1d1f398687bf93e80ef525b83e21f75b15b",
-                "reference": "a431f1d1f398687bf93e80ef525b83e21f75b15b",
+                "url": "https://api.github.com/repos/phpDocumentor/guides-core/zipball/1f21f606ce030fd8989eb783f726cf32c44d61ef",
+                "reference": "1f21f606ce030fd8989eb783f726cf32c44d61ef",
                 "shasum": ""
             },
             "require": {
@@ -2716,9 +2716,9 @@
             "homepage": "https://www.phpdoc.org",
             "support": {
                 "issues": "https://github.com/phpDocumentor/guides-core/issues",
-                "source": "https://github.com/phpDocumentor/guides-core/tree/1.3.10"
+                "source": "https://github.com/phpDocumentor/guides-core/tree/1.4.1"
             },
-            "time": "2024-09-09T07:04:46+00:00"
+            "time": "2024-09-25T20:40:25+00:00"
         },
         {
             "name": "phpdocumentor/guides-restructured-text",

--- a/config/services.xml
+++ b/config/services.xml
@@ -160,6 +160,10 @@
             <tag name="phpdoc.guides.noderenderer.html" />
         </service>
 
+        <service id="Doctrine\Website\Guides\Compiler\GlobMenuFixerTransformer">
+            <tag name="phpdoc.guides.compiler.nodeTransformers" />
+        </service>
+
         <service id="Doctrine\Website\Guides\Compiler\SidebarTransformer">
             <tag name="phpdoc.guides.compiler.nodeTransformers" />
         </service>

--- a/lib/Docs/RST/RSTCopier.php
+++ b/lib/Docs/RST/RSTCopier.php
@@ -28,7 +28,7 @@ class RSTCopier
             :depth: 3
             :glob:
         
-            *
+            **
         SIDEBAR;
 
     public function __construct(

--- a/lib/Guides/Compiler/GlobMenuFixerTransformer.php
+++ b/lib/Guides/Compiler/GlobMenuFixerTransformer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Guides\Compiler;
+
+use phpDocumentor\Guides\Compiler\CompilerContext;
+use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\Menu\GlobMenuEntryNode;
+use phpDocumentor\Guides\Nodes\Node;
+
+/**
+ * This class will fix the glob menu entries.
+ *
+ * The glob menu entries are not correctly added in the docs.
+ * This transformer will fix the glob menu entries by replacing the '*' with '**'. This add a certain
+ * risk if the user had the intention to match only documents in the current directory. But this can be solved
+ * adding a `/` at the beginning of the glob pattern.
+ *
+ * @implements NodeTransformer<GlobMenuEntryNode>
+ */
+final class GlobMenuFixerTransformer implements NodeTransformer
+{
+    public function enterNode(Node $node, CompilerContext $compilerContext): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, CompilerContext $compilerContext): Node|null
+    {
+        if ($node->getUrl() === '*') {
+            return new GlobMenuEntryNode(
+                '**',
+                $node->getLevel(),
+            );
+        }
+
+        return $node;
+    }
+
+    public function supports(Node $node): bool
+    {
+        return $node instanceof GlobMenuEntryNode;
+    }
+
+    public function getPriority(): int
+    {
+        // Before GlobMenuEntryNodeTransformer
+        return 4001;
+    }
+}


### PR DESCRIPTION
So the origin of the menu's not working is in the way the menu's are defined. The doctrine parser did use * as a deep search wildcard which is not according to the behavior sphinx does it. As the toctree is a directive defined by sphinx we try to follow that one closely. The correct way of writing a toctree is

```
.. toctree::
   :glob:

   **
```

This will include all documents and sections in a project. starting at the level of the current page.