### PR TITLE
Add support for toctree captions

### DIFF
--- a/source/styles/index.scss
+++ b/source/styles/index.scss
@@ -123,6 +123,14 @@ h6 {
   color: #fff;
 }
 
+.sidebar-sticky .toc .caption {
+  padding: 8px;
+  font-size: 20px;
+  background-color: $doctrine-dark-blue;
+  margin-bottom: 0;
+  color: #fff;
+}
+
 /** 1st Level */
 .sidebar-sticky .toc ul {
   list-style-type: none;


### PR DESCRIPTION
I do not know if that was supported with `doctrine/rst-parser`, but there is such a thing as a caption option for the `toctree` directive, and it seems that `phpDocumentor/guides` supports it.
When I tried it, it produced a `p` element with a `caption` class. Adding support for that means we could get rid of the `toc` and `tocheader` directives.
These custom directives appear to be the directives that cause the most unfixable warnings (unfixable without a custom guides extension, that is).
We might end up with an extension anyway if there are other warnings, but I think this could be a nice simplification.