### PR TITLE
Render menu captions when provided

### DIFF
--- a/templates/guides/body/menu/menu.html.twig
+++ b/templates/guides/body/menu/menu.html.twig
@@ -1,3 +1,6 @@
 <div class="toc">
+    {% if node.caption %}
+        <p class="caption">{{ renderNode(node.caption) }}</p>
+    {% endif -%}
     {% include "body/menu/menu-level.html.twig" %}
 </div>


### PR DESCRIPTION
In my previous PR, I added CSS style for an element that does not get rendered, presumably because of this template override.