### PR TITLE
Adapt to NavMenuNode

### DIFF
--- a/templates/guides/body/menu/menu.html.twig
+++ b/templates/guides/body/menu/menu.html.twig
@@ -1,6 +1,6 @@
 <div class="toc">
-    {% if node.caption %}
-        <p class="caption">{{ renderNode(node.caption) }}</p>
+    {% if node.hasOption('caption') %}
+        <p class="caption">{{ node.getOption('caption') }}</p>
     {% endif -%}
     {% include "body/menu/menu-level.html.twig" %}
 </div>


### PR DESCRIPTION
In my previous PR, I copied code from https://github.com/phpDocumentor/guides/blob/main/packages/guides/resources/template/html/body/menu/table-of-content.html.twig That template has a different name than the one I copied the code into, so maybe it receives a different type of node? Anyway, I remembered how to actually build the docs and was able to create this version through trial and error rather than blindly copying code. But as you see, I do not fully understand what I am doing, hopefully somebody does.