### PR TITLE
Fix static page links

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -160,6 +160,10 @@
             <tag name="phpdoc.guides.noderenderer.html" />
         </service>
 
+        <service id="Doctrine\Website\Guides\ReferenceResolver\HtmlResolver">
+            <tag name="phpdoc.guides.reference_resolver" />
+        </service>
+
         <service id="Doctrine\Website\Guides\Compiler\GlobMenuFixerTransformer">
             <tag name="phpdoc.guides.compiler.nodeTransformers" />
         </service>

--- a/lib/Guides/ReferenceResolver/HtmlResolver.php
+++ b/lib/Guides/ReferenceResolver/HtmlResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Website\Guides\ReferenceResolver;
+
+use phpDocumentor\Guides\Nodes\Inline\LinkInlineNode;
+use phpDocumentor\Guides\ReferenceResolvers\Messages;
+use phpDocumentor\Guides\ReferenceResolvers\ReferenceResolver;
+use phpDocumentor\Guides\RenderContext;
+
+use function str_ends_with;
+
+class HtmlResolver implements ReferenceResolver
+{
+    public function resolve(LinkInlineNode $node, RenderContext $renderContext, Messages $messages): bool
+    {
+        if (str_ends_with($node->getTargetReference(), '.html')) {
+            $node->setUrl($node->getTargetReference());
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function getPriority(): int
+    {
+        return -300;
+    }
+}

--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -546,7 +546,7 @@ Maintainer Workflow
 -------------------
 
 You can learn more about the maintainer workflow
-`here </maintainer/>`_. Continue reading if you are
+`here </maintainer/index.html>`_. Continue reading if you are
 interested in learning more about how to get started with your first
 contribution.
 
@@ -556,4 +556,4 @@ Website
 The `doctrine-project.org <https://www.doctrine-project.org/>`_ website
 is completely open source! If you want to learn how to contribute to the
 Doctrine website and documentation you can read more about it
-`here </website/>`_.
+`here <website/index.html>`_.

--- a/source/policies/security.rst
+++ b/source/policies/security.rst
@@ -12,7 +12,7 @@ issue tracker in GitHub and don't publish it publicly. Instead, all security iss
 must be sent to `security@doctrine-project.org <mailto:security@doctrine-project.org>`_.
 Emails sent to this address are forwarded to the Doctrine core team private mailing-list.
 
-.. notice::
+.. note::
 
     While we are working on a patch, please do not reveal the issue publicly. The resolution can take
     anywhere between a couple of days, a month or an indefinite amount of time depending on its complexity.


### PR DESCRIPTION
Static pages do not have an source to find references, so static html links are used. Guides does see them as invalid links. This new resolver allows us to accept the static links as valid and uses the targetreference as url.