### PR TITLE
Prepare for PHPStan 2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6538,16 +6538,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.3",
+            "version": "1.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009"
+                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0fcbf194ab63d8159bb70d9aa3e1350051632009",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc4d2f145a88ea7141ae698effd64d9df46527ae",
+                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae",
                 "shasum": ""
             },
             "require": {
@@ -6592,25 +6592,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-09T08:10:35+00:00"
+            "time": "2024-10-06T15:03:59+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26"
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
-                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.11"
+                "phpstan/phpstan": "^1.12"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -6637,9 +6637,9 @@
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.0"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.1"
             },
-            "time": "2024-04-20T06:39:48+00:00"
+            "time": "2024-09-11T15:52:35+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/lib/Cache/CacheClearer.php
+++ b/lib/Cache/CacheClearer.php
@@ -7,6 +7,7 @@ namespace Doctrine\Website\Cache;
 use Symfony\Component\Filesystem\Filesystem;
 
 use function array_filter;
+use function file_exists;
 use function glob;
 use function sprintf;
 
@@ -57,6 +58,8 @@ final readonly class CacheClearer
     /** @return string[] */
     protected function glob(string $pattern): array
     {
-        return array_filter((array) glob($pattern));
+        $matches = (array) glob($pattern);
+
+        return array_filter($matches, static fn (string|false $file): bool => $file !== false && file_exists($file));
     }
 }

--- a/lib/Docs/SearchIndexer.php
+++ b/lib/Docs/SearchIndexer.php
@@ -15,6 +15,7 @@ use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\TitleNode;
 
+use function assert;
 use function md5;
 use function str_replace;
 use function strip_tags;
@@ -149,6 +150,7 @@ class SearchIndexer
         $level = $node instanceof TitleNode ? $node->getLevel() : false;
 
         if ($level !== false) {
+            assert($level >= 1 && $level <= 5);
             $current['h' . $level] = $this->renderNodeValue($node);
 
             for ($i = $level + 1; $i <= 5; $i++) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - phar://phpstan.phar/conf/bleedingEdge.neon
 
 parameters:
     level: 8

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
-    - phar://phpstan.phar/conf/bleedingEdge.neon
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
 
 parameters:
     level: 8

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,3 +16,7 @@ parameters:
         count: 1
       -
         message: "#::\\$id is never read, only written#"
+      -
+        message: "#::\\$id \\(int\\|null\\) is never assigned int#"
+      -
+        message: "#GlobMenuFixerTransformer::leaveNode\\(\\) never returns null so it can be removed from the return type#"

--- a/tests/DataSources/DbPrefill/Foo.php
+++ b/tests/DataSources/DbPrefill/Foo.php
@@ -9,4 +9,9 @@ class Foo
     public function __construct(public int $id, public string $name)
     {
     }
+
+    public function equals(Foo $foo): bool
+    {
+        return $foo->id === $this->id && $foo->name === $this->name;
+    }
 }

--- a/tests/DataSources/DbPrefill/SimpleSourceTest.php
+++ b/tests/DataSources/DbPrefill/SimpleSourceTest.php
@@ -26,7 +26,7 @@ class SimpleSourceTest extends TestCase
                 $foo1 = new Foo(1, 'foo1');
                 $foo2 = new Foo(2, 'foo2');
                 // phpcs:ignoreFile
-                if (($foo == $foo1 || $foo == $foo2)) {
+                if (($foo->equals($foo1) || $foo->equals($foo2))) {
                     return;
                 }
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -222,7 +222,6 @@ class FunctionalTest extends TestCase
 
         $lines = explode("\n", $xmlString);
 
-        self::assertTrue(isset($lines[0]));
         self::assertSame('<?xml version="1.0" encoding="UTF-8"?>', $lines[0]);
 
         $xml = simplexml_load_string($xmlString);
@@ -240,7 +239,6 @@ class FunctionalTest extends TestCase
 
         $lines = explode("\n", $xmlString);
 
-        self::assertTrue(isset($lines[0]));
         self::assertSame('<?xml version="1.0" encoding="utf-8"?>', $lines[0]);
 
         $xml = simplexml_load_string($xmlString);


### PR DESCRIPTION
With phpstan's deprecation rules and bleeding edge configuration a project should be able to [prepare for PHPStan 2](https://phpc.social/@OndrejMirtes/113208797257858662) when it gets released. I'll introduce this path to doctrine-website and maybe it can be used to make other Doctrine projects prepare for the upcoming major version.