### PR TITLE
fix: copy more than just rst files

### DIFF
--- a/lib/Docs/RST/RSTCopier.php
+++ b/lib/Docs/RST/RSTCopier.php
@@ -12,6 +12,7 @@ use function assert;
 use function file_exists;
 use function is_string;
 use function preg_replace;
+use function str_ends_with;
 use function str_replace;
 
 /** @final */
@@ -52,6 +53,11 @@ class RSTCopier
 
             foreach ($files as $file) {
                 if ($file === $language->getPath() . '/sidebar.rst') {
+                    continue;
+                }
+
+                if (! str_ends_with($file, '.rst')) {
+                    $this->filesystem->copy($file, $outputPath . str_replace($language->getPath(), '', $file));
                     continue;
                 }
 

--- a/lib/Docs/RST/RSTFileRepository.php
+++ b/lib/Docs/RST/RSTFileRepository.php
@@ -58,7 +58,7 @@ class RSTFileRepository
 
         $finder = $this->getFilesFinder($path);
 
-        $finder->name('*.rst');
+        $finder->name('*.*');
         $finder->notName('toc.rst');
 
         return $this->finderToArray($finder);


### PR DESCRIPTION
Now that we use `literalinclude`, source files include more than just rst files. I'd say anything with an extension goes.

This addresses an issue with guides not finding files referenced in `literalinclude` directives, because they were never copied.