### PR TITLE
Add internlink index rendering

### DIFF
--- a/lib/Docs/RST/DocumentsBuilder.php
+++ b/lib/Docs/RST/DocumentsBuilder.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Docs\RST;
 
+use Doctrine\Website\Model\ProjectVersion;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 
 interface DocumentsBuilder
 {
-    public function build(string $directory, string $targetDirectory = 'output'): void;
+    public function build(ProjectVersion $version, string $directory, string $targetDirectory = 'output'): void;
 
     /** @return DocumentNode[] */
     public function getDocuments(): array;

--- a/lib/Docs/RST/RSTBuilder.php
+++ b/lib/Docs/RST/RSTBuilder.php
@@ -42,6 +42,7 @@ class RSTBuilder
         $this->filesystem->remove($this->rstFileRepository->findFiles($outputPath));
 
         $this->builder->build(
+            $version,
             $project->getProjectVersionDocsPath($this->docsDir, $version, $language->getCode()),
             $outputPath,
         );


### PR DESCRIPTION
This adds the interlink output to projects, allowing other projects to consume this output via the url `projects/<project>/en/<version>/objects.inv.json`

In a follow up PR we will expose this and add more code make it possible to use these links in the doctrine documentation itself.

refs #619 