### PR TITLE
Update reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "CI"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,4 +6,6 @@ on: ["pull_request", "push"]
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@4.0.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@7.1.0"
+    with:
+      php-version: "8.3"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,22 +3,8 @@ name: "Static Analysis"
 on: ["push", "pull_request"]
 
 jobs:
-  code-analysis:
-
-    runs-on: "ubuntu-latest"
-
-    steps:
-    - uses: "actions/checkout@v4"
-
-    - name: "Setup PHP Action"
-      uses: "shivammathur/setup-php@v2"
-      with:
-        php-version: "8.3"
-
-    - name: "Install dependencies with Composer"
-      uses: "ramsey/composer-install@v2"
-      with:
-        composer-options: "--prefer-dist --no-progress --no-suggest"
-
-    - name: "Run PHPStan"
-      run: "./vendor/bin/phpstan analyse"
+  static-analysis:
+    name: "Static Analysis"
+    uses: "doctrine/.github/.github/workflows/phpstan.yml@7.1.0"
+    with:
+      php-version: "8.3"


### PR DESCRIPTION
It started with the phpstan workflow that can be used for the website now, since psalm was dropped, but I updated coding-standards workflow too and added a dependabot config too.