### PR TITLE
Remove code path usage from projects

### DIFF
--- a/lib/DataSources/DbPrefill/Projects.php
+++ b/lib/DataSources/DbPrefill/Projects.php
@@ -45,7 +45,6 @@ class Projects implements DbPrefill
         $integrationFor      = (string) ($projectData['integrationFor'] ?? '');
         $docsRepositoryName  = (string) ($projectData['docsRepositoryName'] ?? $repositoryName);
         $docsPath            = (string) ($projectData['docsPath'] ?? '/docs');
-        $codePath            = (string) ($projectData['codePath'] ?? '/lib');
         $description         = (string) ($projectData['description'] ?? '');
         $keywords            = $projectData['keywords'] ?? [];
 
@@ -106,7 +105,6 @@ class Projects implements DbPrefill
             $integrationFor,
             $docsRepositoryName,
             $docsPath,
-            $codePath,
             $description,
             $projectIntegrationType,
             $integration,

--- a/lib/Model/Project.php
+++ b/lib/Model/Project.php
@@ -49,8 +49,6 @@ class Project
         #[ORM\Column(type: 'string')]
         private string $docsPath,
         #[ORM\Column(type: 'string')]
-        private string $codePath,
-        #[ORM\Column(type: 'string')]
         private string $description,
         #[ORM\OneToOne(targetEntity: ProjectIntegrationType::class, fetch: 'EAGER', orphanRemoval: true)]
         #[ORM\JoinColumn(name: 'projectIntegrationType', referencedColumnName: 'id', nullable: true)]
@@ -135,11 +133,6 @@ class Project
     public function getDocsPath(): string
     {
         return $this->docsPath;
-    }
-
-    public function getCodePath(): string
-    {
-        return $this->codePath;
     }
 
     public function getDescription(): string

--- a/lib/Projects/ProjectDataReader.php
+++ b/lib/Projects/ProjectDataReader.php
@@ -87,7 +87,6 @@ class ProjectDataReader
             'name' => $repositoryName,
             'repositoryName' => $repositoryName,
             'docsPath' => $this->detectDocsPath($repositoryName),
-            'codePath' => $this->detectCodePath($repositoryName),
             'slug' => $slug,
             'versions' => [
                 [
@@ -118,11 +117,6 @@ class ProjectDataReader
     private function detectDocsPath(string $repositoryName): string|null
     {
         return $this->detectPath($repositoryName, ['/docs', '/doc', '/Resources/doc', '/source'], null);
-    }
-
-    private function detectCodePath(string $repositoryName): string|null
-    {
-        return $this->detectPath($repositoryName, ['/src', '/lib'], '/');
     }
 
     /** @param string[] $pathsToCheck */

--- a/tests/DataSources/DbPrefill/ProjectsTest.php
+++ b/tests/DataSources/DbPrefill/ProjectsTest.php
@@ -79,7 +79,6 @@ class ProjectsTest extends TestCase
         self::assertSame('doctrine-testproject', $project->getDocsSlug());
         self::assertSame('testproject', $project->getDocsRepositoryName());
         self::assertSame('/docs', $project->getDocsPath());
-        self::assertSame('/lib', $project->getCodePath());
         self::assertSame('doctrine/testproject', $project->getComposerPackageName());
         self::assertSame('testproject', $project->getRepositoryName());
         self::assertFalse($project->isIntegration());

--- a/tests/DataSources/DbPrefill/fixtures/projects.json
+++ b/tests/DataSources/DbPrefill/fixtures/projects.json
@@ -6,7 +6,6 @@
         "name": "Testproject",
         "repositoryName": "testproject",
         "docsPath": "/docs",
-        "codePath": "/lib",
         "slug": "testproject",
         "versionsGreaterThan": "1.0.1",
         "versions": [

--- a/tests/Projects/ProjectDataReaderTest.php
+++ b/tests/Projects/ProjectDataReaderTest.php
@@ -21,7 +21,6 @@ class ProjectDataReaderTest extends TestCase
             'name' => 'test-project',
             'repositoryName' => 'test-project',
             'docsPath' => '/docs',
-            'codePath' => '/src',
             'slug' => 'test-project',
             'versions' => [
                 [
@@ -48,7 +47,6 @@ class ProjectDataReaderTest extends TestCase
             'repositoryName' => 'no-project-json',
             'name' => 'no-project-json',
             'docsPath' => null,
-            'codePath' => '/',
             'slug' => 'no-project-json',
             'versions' => [
                 [

--- a/tests/Projects/ProjectTest.php
+++ b/tests/Projects/ProjectTest.php
@@ -27,7 +27,6 @@ class ProjectTest extends TestCase
             'repositoryName' => 'test-project',
             'docsRepositoryName' => 'test-project',
             'docsPath' => '/docs',
-            'codePath' => '/src',
             'description' => 'Test description.',
             'keywords' => ['keyword1', 'keyword2'],
             'versions' => new ArrayCollection([
@@ -90,11 +89,6 @@ class ProjectTest extends TestCase
     public function testGetDocsPath(): void
     {
         self::assertSame('/docs', $this->project->getDocsPath());
-    }
-
-    public function testGetCodePath(): void
-    {
-        self::assertSame('/src', $this->project->getCodePath());
     }
 
     public function testGetDescription(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,7 +42,6 @@ abstract class TestCase extends BaseTestCase
             'integrationFor' => '',
             'docsRepositoryName' => '',
             'docsPath' => '',
-            'codePath' => '',
             'description' => '',
             'projectIntegrationType' => null,
             'integration' => true,

--- a/tests/test-cache/data/projects.json
+++ b/tests/test-cache/data/projects.json
@@ -6,7 +6,6 @@
         "name": "Object Relational Mapper",
         "repositoryName": "orm",
         "docsPath": "/docs",
-        "codePath": "/lib",
         "slug": "orm",
         "versions": [
             {
@@ -390,7 +389,6 @@
         "name": "Database Abstraction Layer",
         "repositoryName": "dbal",
         "docsPath": "/docs",
-        "codePath": "/src",
         "slug": "dbal",
         "versions": [
             {
@@ -713,7 +711,6 @@
         "name": "Annotations",
         "repositoryName": "annotations",
         "docsPath": "/docs",
-        "codePath": "/lib",
         "slug": "annotations",
         "versions": [
             {


### PR DESCRIPTION
Code paths aren't used anymore in the website and only appear in the website-build itself while not used later on. This was found while working on https://github.com/doctrine/instantiator/pull/122.