### PR TITLE
Upgrade the Algolia SDK to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "8.3.*",
-        "algolia/algoliasearch-client-php": "^3.3",
+        "algolia/algoliasearch-client-php": "^4",
         "doctrine/collections": "^2",
         "doctrine/dbal": "^4.0",
         "doctrine/inflector": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,56 +4,48 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c3f3e5f57fd1ff992370c9fa748688b",
+    "content-hash": "7737597d7c6f50a3c288c50c0f47fbea",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
-            "version": "3.4.1",
+            "version": "4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algolia/algoliasearch-client-php.git",
-                "reference": "cf87b649f745479c0800299481d91dc303e23cea"
+                "reference": "ddc6ab3710c5527d0637cf991601ac7979197d94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/cf87b649f745479c0800299481d91dc303e23cea",
-                "reference": "cf87b649f745479c0800299481d91dc303e23cea",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/ddc6ab3710c5527d0637cf991601ac7979197d94",
+                "reference": "ddc6ab3710c5527d0637cf991601ac7979197d94",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.3 || ^8.0",
+                "guzzlehttp/psr7": "^2.0",
+                "php": ">=8.1",
                 "psr/http-message": "^1.1 || ^2.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "fzaninotto/faker": "^1.8",
-                "phpunit/phpunit": "^8.0 || ^9.0",
-                "symfony/yaml": "^2.0 || ^4.0"
+                "friendsofphp/php-cs-fixer": "^2.0 || ^3.5.0",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^11.0",
+                "vlucas/phpdotenv": "^5.4"
             },
             "suggest": {
                 "guzzlehttp/guzzle": "If you prefer to use Guzzle HTTP client instead of the Http Client implementation provided by the package"
             },
-            "bin": [
-                "bin/algolia-doctor"
-            ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.0": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "src/Http/Psr7/functions.php",
-                    "src/functions.php"
+                    "lib/Http/Psr7/functions.php"
                 ],
                 "psr-4": {
-                    "Algolia\\AlgoliaSearch\\": "src/"
+                    "Algolia\\AlgoliaSearch\\": "lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -63,10 +55,11 @@
             "authors": [
                 {
                     "name": "Algolia Team",
-                    "email": "contact@algolia.com"
+                    "homepage": "https://alg.li/support"
                 }
             ],
-            "description": "Algolia Search API Client for PHP",
+            "description": "API powering the features of Algolia.",
+            "homepage": "https://github.com/algolia/algoliasearch-client-php",
             "keywords": [
                 "algolia",
                 "api",
@@ -76,9 +69,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algolia/algoliasearch-client-php/issues",
-                "source": "https://github.com/algolia/algoliasearch-client-php/tree/3.4.1"
+                "source": "https://github.com/algolia/algoliasearch-client-php/tree/4.13.0"
             },
-            "time": "2023-08-28T14:34:04+00:00"
+            "time": "2025-01-22T12:32:40+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -8524,15 +8517,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "8.3.*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/services.xml
+++ b/config/services.xml
@@ -56,7 +56,7 @@
             <argument>%doctrine.website.send_grid.api_key%</argument>
         </service>
 
-        <service id="Algolia\AlgoliaSearch\SearchClient" autowire="false">
+        <service id="Algolia\AlgoliaSearch\Api\SearchClient" autowire="false">
             <factory method="create"/>
             <argument>%doctrine.website.algolia.app_id%</argument>
             <argument>%doctrine.website.algolia.admin_api_key%</argument>

--- a/lib/Docs/SearchIndexer.php
+++ b/lib/Docs/SearchIndexer.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Docs;
 
-use Algolia\AlgoliaSearch\SearchClient;
-use Algolia\AlgoliaSearch\SearchIndex;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use Doctrine\Website\Model\Project;
 use Doctrine\Website\Model\ProjectVersion;
 use Generator;
@@ -50,9 +49,7 @@ class SearchIndexer
 
     public function initSearchIndex(): void
     {
-        $index = $this->getSearchIndex();
-
-        $index->setSettings([
+        $this->client->setSettings(self::INDEX_NAME, [
             'attributesToIndex' => ['projectName', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'content'],
             'customRanking' => ['asc(rank)'],
             'ranking' => ['words', 'typo', 'attribute', 'proximity', 'custom'],
@@ -65,7 +62,7 @@ class SearchIndexer
             'removeWordsIfNoResults' => 'allOptional',
         ]);
 
-        $index->clearObjects();
+        $this->client->clearObjects(self::INDEX_NAME);
     }
 
     /** @param DocumentNode[] $documents */
@@ -82,7 +79,7 @@ class SearchIndexer
             }
         }
 
-        $this->getSearchIndex()->saveObjects($records, ['autoGenerateObjectIDIfNotExist' => true]);
+        $this->client->saveObjects(self::INDEX_NAME, $records, ['autoGenerateObjectIDIfNotExist' => true]);
     }
 
     /** @return Generator<searchRecord> */
@@ -224,10 +221,5 @@ class SearchIndexer
     private function stripContent(string $content): string
     {
         return str_replace(['"', '\''], '', $content);
-    }
-
-    private function getSearchIndex(): SearchIndex
-    {
-        return $this->client->initIndex(self::INDEX_NAME);
     }
 }

--- a/tests/Docs/SearchIndexerTest.php
+++ b/tests/Docs/SearchIndexerTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Website\Tests\Docs;
 
-use Algolia\AlgoliaSearch\SearchClient;
-use Algolia\AlgoliaSearch\SearchIndex;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 use Doctrine\Website\Application;
 use Doctrine\Website\Docs\RST\GuidesParser;
 use Doctrine\Website\Docs\SearchIndexer;
@@ -33,16 +32,9 @@ class SearchIndexerTest extends TestCase
 
     public function testInitSearchIndex(): void
     {
-        $index = $this->createMock(SearchIndex::class);
-
         $this->client->expects(self::once())
-            ->method('initIndex')
-            ->with(SearchIndexer::INDEX_NAME)
-            ->willReturn($index);
-
-        $index->expects(self::once())
             ->method('setSettings')
-            ->with([
+            ->with(SearchIndexer::INDEX_NAME, [
                 'attributesToIndex' => ['projectName', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'content'],
                 'customRanking' => ['asc(rank)'],
                 'ranking' => ['words', 'typo', 'attribute', 'proximity', 'custom'],
@@ -55,7 +47,7 @@ class SearchIndexerTest extends TestCase
                 'removeWordsIfNoResults' => 'allOptional',
             ]);
 
-        $index->expects(self::once())
+        $this->client->expects(self::once())
             ->method('clearObjects');
 
         $this->searchIndexer->initSearchIndex();
@@ -69,13 +61,6 @@ class SearchIndexerTest extends TestCase
             'slug' => 'orm',
         ]);
         $version = new ProjectVersion(['slug' => '1.0']);
-
-        $index = $this->createMock(SearchIndex::class);
-
-        $this->client->expects(self::once())
-            ->method('initIndex')
-            ->with(SearchIndexer::INDEX_NAME)
-            ->willReturn($index);
 
         $documents = $this->buildDocuments(__DIR__ . '/resources/search-indexer');
 
@@ -199,9 +184,9 @@ class SearchIndexerTest extends TestCase
             ],
         ];
 
-        $index->expects(self::once())
+        $this->client->expects(self::once())
             ->method('saveObjects')
-            ->with($expectedRecords, ['autoGenerateObjectIDIfNotExist' => true]);
+            ->with(SearchIndexer::INDEX_NAME, $expectedRecords, ['autoGenerateObjectIDIfNotExist' => true]);
 
         $this->searchIndexer->buildSearchIndexes($project, $version, $documents);
     }
@@ -214,13 +199,6 @@ class SearchIndexerTest extends TestCase
             'slug' => 'orm',
         ]);
         $version = new ProjectVersion(['slug' => '1.0']);
-
-        $index = $this->createMock(SearchIndex::class);
-
-        $this->client->expects(self::once())
-            ->method('initIndex')
-            ->with(SearchIndexer::INDEX_NAME)
-            ->willReturn($index);
 
         $documents = $this->buildDocuments(__DIR__ . '/resources/search-indexer-with-quotes');
 
@@ -266,9 +244,9 @@ class SearchIndexerTest extends TestCase
             ],
         ];
 
-        $index->expects(self::once())
+        $this->client->expects(self::once())
             ->method('saveObjects')
-            ->with($expectedRecords, ['autoGenerateObjectIDIfNotExist' => true]);
+            ->with(SearchIndexer::INDEX_NAME, $expectedRecords, ['autoGenerateObjectIDIfNotExist' => true]);
 
         $this->searchIndexer->buildSearchIndexes($project, $version, $documents);
     }


### PR DESCRIPTION
The main difference is the disappearance of the SearchIndex interface. Instead, the client's method now all have a new argument for specifying the index name to act on.