### PR TITLE
Lock dependency versions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,6 +6,7 @@ on: ["pull_request", "push"]
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@7.1.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@7.2.0"
     with:
       php-version: "8.3"
+      composer-dependency-versions: "locked"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,6 +5,7 @@ on: ["push", "pull_request"]
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/phpstan.yml@7.1.0"
+    uses: "doctrine/.github/.github/workflows/phpstan.yml@7.2.0"
     with:
       php-version: "8.3"
+      composer-dependency-versions: "locked"


### PR DESCRIPTION
Let us ensure we get the exact same results when running tools locally and in the CI.

This fixes the build.