### PR TITLE
Revert doctrine slack link 

### DIFF
--- a/source/community.html
+++ b/source/community.html
@@ -43,7 +43,7 @@ Doctrine developers on GitHub and Slack.
             The primary method for communicating with other Doctrine developers is via Slack.
         </p>
 
-        <a href="https://doctrine.slack.com" class="btn btn-primary" target="_blank"
+        <a href="https://www.doctrine-project.org/slack" class="btn btn-primary" target="_blank"
             rel="noopener noreferrer">Go to Slack</a>
     </div>
 </div>


### PR DESCRIPTION
Thanks to @jwage, the [original redirect link](https://www.doctrine-project.org/slack) to the Slack registration page was fixed with a new invite link and this time it's one that won't expire.