### PR TITLE
Introduce additional sort order for projects

### DIFF
--- a/config/data/projects.yml
+++ b/config/data/projects.yml
@@ -22,6 +22,7 @@ parameters:
         -
             repositoryName: dbal
             versionsGreaterThan: "2.99.0"
+            sortOrder: 2
 
         - repositoryName: doctrine1
         - repositoryName: event-manager
@@ -29,11 +30,14 @@ parameters:
         - repositoryName: instantiator
         - repositoryName: lexer
         - repositoryName: migrations
-        - repositoryName: mongodb-odm
+        -
+            repositoryName: mongodb-odm
+            sortOrder: 3
         - repositoryName: orientdb-odm
         -
             repositoryName: orm
             versionsGreaterThan: "2.9.99"
+            sortOrder: 1
 
         - repositoryName: persistence
         - repositoryName: phpcr-odm

--- a/lib/DataSources/DbPrefill/Projects.php
+++ b/lib/DataSources/DbPrefill/Projects.php
@@ -47,6 +47,7 @@ class Projects implements DbPrefill
         $docsPath            = (string) ($projectData['docsPath'] ?? '/docs');
         $description         = (string) ($projectData['description'] ?? '');
         $keywords            = $projectData['keywords'] ?? [];
+        $sortOrder           = $projectData['sortOrder'] ?? 999;
 
         $versions = new ArrayCollection();
         foreach ($projectData['versions'] ?? [] as $version) {
@@ -110,6 +111,7 @@ class Projects implements DbPrefill
             $integration,
             $keywords,
             $versions,
+            $sortOrder,
         );
 
         $this->entityManager->persist($project);

--- a/lib/Model/Project.php
+++ b/lib/Model/Project.php
@@ -59,6 +59,8 @@ class Project
         private array $keywords,
         #[ORM\OneToMany(targetEntity: ProjectVersion::class, fetch: 'EAGER', mappedBy: 'project', orphanRemoval: true)]
         private Collection $versions,
+        #[ORM\Column(type: 'integer')]
+        public readonly int $sortOrder,
     ) {
         foreach ($this->versions as $version) {
             $version->setProject($this);

--- a/lib/Repositories/ProjectRepository.php
+++ b/lib/Repositories/ProjectRepository.php
@@ -44,7 +44,7 @@ class ProjectRepository extends EntityRepository
         return $this->findBy([
             'active' => true,
             'integration' => false,
-        ], ['name' => 'asc']);
+        ], ['sortOrder' => 'asc', 'name' => 'asc']);
     }
 
     /** @return Project[] */
@@ -71,7 +71,7 @@ class ProjectRepository extends EntityRepository
         return $this->findBy([
             'active' => true,
             'integration' => true,
-        ], ['name' => 'asc']);
+        ], ['sortOrder' => 'asc', 'name' => 'asc']);
     }
 
     /** @return Project[] */
@@ -80,6 +80,6 @@ class ProjectRepository extends EntityRepository
         return $this->findBy([
             'integration' => true,
             'integrationFor' => $project->getSlug(),
-        ], ['name' => 'asc']);
+        ], ['sortOrder' => 'asc', 'name' => 'asc']);
     }
 }

--- a/tests/DataSources/DbPrefill/ProjectsTest.php
+++ b/tests/DataSources/DbPrefill/ProjectsTest.php
@@ -85,6 +85,7 @@ class ProjectsTest extends TestCase
         self::assertSame('', $project->getIntegrationFor());
         self::assertSame('It\'s a testproject', $project->getDescription());
         self::assertSame(['testproject', 'docblock', 'parser'], $project->getKeywords());
+        self::assertSame(42, $project->sortOrder);
         $this->assertProjectStats($project->getProjectStats());
 
         $versions = $project->getVersions();

--- a/tests/DataSources/DbPrefill/fixtures/projects.json
+++ b/tests/DataSources/DbPrefill/fixtures/projects.json
@@ -8,6 +8,7 @@
         "docsPath": "/docs",
         "slug": "testproject",
         "versionsGreaterThan": "1.0.1",
+        "sortOrder": 42,
         "versions": [
             {
                 "name": "2.0",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,6 +47,7 @@ abstract class TestCase extends BaseTestCase
             'integration' => true,
             'keywords' => [],
             'versions' => new ArrayCollection(),
+            'sortOrder' => 999,
         ];
 
         $data = array_merge($default, $data);


### PR DESCRIPTION
Projects with a higher rate of usage have higher traffic on their docs. This Pr allows to order ORM, DBAL and ODM higher in our project lists on the website making them easier to find for users of the website.