### PR TITLE
fix(typo): fqcn class

### DIFF
--- a/source/blog/2022-01-11-orm-2.11.md
+++ b/source/blog/2022-01-11-orm-2.11.md
@@ -59,7 +59,7 @@ There are two major use cases for this:
 #[Entity]
 class User
 {
-     #[ManyToOne(targetEntity: Country:class), JoinColumn(name: "country_code", referencedColumnName: "country_code")]
+     #[ManyToOne(targetEntity: Country::class), JoinColumn(name: "country_code", referencedColumnName: "country_code")]
      public $country;
 
      #[Column(type: "string", name: "country_code", insertable: false, updatable: false)]


### PR DESCRIPTION
This pull request includes a minor correction to the `source/blog/2022-01-11-orm-2.11.md` file. The change fixes a syntax error in the `ManyToOne` annotation by replacing a single colon with a double colon in the `targetEntity` parameter.