### PR TITLE
Add null check

### DIFF
--- a/lib/Git/TagBranchGuesser.php
+++ b/lib/Git/TagBranchGuesser.php
@@ -34,6 +34,10 @@ class TagBranchGuesser
 
         $tagBranchName = $this->generateTagBranchSlug($tag);
 
+        if ($tagBranchName === null) {
+            return null;
+        }
+
         $guesses = [
             $tagBranchName,
             sprintf('%s.x', $tagBranchName),


### PR DESCRIPTION
When that variable is null, there is no point in executing the code below, because there is not going to be a branch called ".x".

After this gets merged, #810 should get a green build.