### PR TITLE
Leverage config-based git hooks

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -492,17 +492,24 @@ Running checks before pushing
 
 Rather than starting many containers on a remote infrastructure to
 figure what is wrong with your code, running some of the checks locally
-before pushing is never a bad idea. You can do so by creating a
-``.git/hooks/pre-push`` file or even a ``.git/hooks/pre-commit`` file
-with the following content:
+before pushing is never a bad idea. You can do so by creating
+``pre-push`` or even ``pre-commit`` hooks. Here is an example with
+``pre-push`` hooks:
 
-.. code-block:: bash
+.. code-block:: console
 
-    #!/bin/bash
-    set -e
-    echo ''|vendor/bin/phpcs
-    vendor/bin/phpstan
-    vendor/bin/phpunit
+    $ git config hook.jobs 3
+    $ git config hook.phpcs.event pre-push
+    $ git config hook.phpcs.command "sh -c \"echo ''|vendor/bin/phpcs\""
+    $ git config hook.phpcs.parallel true
+    $ git config hook.phpstan.event pre-push
+    $ git config hook.phpstan.command "sh -c 'vendor/bin/phpstan'"
+    $ git config hook.phpstan.parallel true
+    $ git config hook.phpunit.event pre-push
+    $ git config hook.phpunit.command "sh -c 'vendor/bin/phpunit'"
+    $ git config hook.phpunit.parallel true
+
+Note that you cannot use parallelism with ``pre-commit`` hooks.
 
 Getting your PR reviewed
 ------------------------

--- a/source/contribute/website.rst
+++ b/source/contribute/website.rst
@@ -32,12 +32,13 @@ Next run ``composer install && yarn install`` to install all of the dependencies
 Coding Standards
 ----------------
 
-Copy the ``pre-commit`` hook to ``.git/hooks/pre-commit`` to ensure
-coding standards are maintained:
+Configure the ``pre-commit`` script has a hook to ensure coding
+standards are maintained:
 
 .. code-block:: console
 
-    $ cp pre-commit .git/hooks/pre-commit
+    $ git config hooks.pre-commit.event pre-commit
+    $ git config hooks.pre-commit.command pre-commit
 
 Configuration
 -------------


### PR DESCRIPTION
Since Git 2.54, there is a great new way to create hooks with pure configuration rather than a bash script.

Git 2.55 allows to run hooks in parallel for some events.